### PR TITLE
fix(dashboard): add cache protection to daily_costs() to prevent empt…

### DIFF
--- a/usage.30s.py
+++ b/usage.30s.py
@@ -1723,6 +1723,9 @@ def update_unknown():
 def daily_costs():
     """输出按天+按模型的成本 JSON(从扫描缓存读,无额外 I/O)。"""
     cache = _load_scan_cache()
+    if not cache.get("claude"):
+        compute()
+        cache = _load_scan_cache()
     days = {}
     models = {}
 


### PR DESCRIPTION
…y data panel

When /tmp/_tokei_scan_cache.json is empty or missing (e.g., after macOS restart or manual cleanup), the Dashboard panel returned 0 entries while Wrapped view continued working normally.

Added the same cache-protection logic that wrapped() already has: if the scan cache is empty, trigger compute() to rescan local logs before aggregating daily costs.

Fixes: HSU-4