### PR TITLE
feat: split Qoder CLI and QoderWork into separate tool cards

### DIFF
--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -34,6 +34,7 @@ enum Theme {
     static let gemini = Color(red: 0.62, green: 0.52, blue: 0.92)   // 薰衣草
     static let grok   = Color(red: 0.65, green: 0.68, blue: 0.75)   // 冷灰银
     static let qoder  = Color(red: 0.90, green: 0.75, blue: 0.35)   // 琥珀金
+    static let qodercli = Color(red: 0.95, green: 0.65, blue: 0.25) // 蜜橘
     static let hermes = Color(red: 0.40, green: 0.82, blue: 0.60)   // 翠绿
     static let openclaw = Color(red: 0.85, green: 0.45, blue: 0.68) // 玫红
     static let pi = Color(red: 0.74, green: 0.58, blue: 0.95)       // 柔紫

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -424,14 +424,15 @@ struct Usage: Codable {
     var codex: CodexStat
     var gemini: GeminiStat
     var grok: GrokStat
-    var qoder: QoderStat
+    var qoder: TokenUsageStat
+    var qoderwork: QoderStat
     var hermes: HermesStat
     var openclaw: OpenClawStat
     var pi: TokenUsageStat
     var opencode: TokenUsageStat
 
     enum CodingKeys: String, CodingKey {
-        case claude, codex, gemini, grok, qoder, hermes, openclaw, pi, opencode
+        case claude, codex, gemini, grok, qoder, qoderwork, hermes, openclaw, pi, opencode
     }
 
     init(from decoder: Decoder) throws {
@@ -440,7 +441,8 @@ struct Usage: Codable {
         codex = try c.decode(CodexStat.self, forKey: .codex)
         gemini = try c.decode(GeminiStat.self, forKey: .gemini)
         grok = try c.decode(GrokStat.self, forKey: .grok)
-        qoder = try c.decode(QoderStat.self, forKey: .qoder)
+        qoder = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qoder) ?? TokenUsageStat(ranges: .empty)
+        qoderwork = try c.decodeIfPresent(QoderStat.self, forKey: .qoderwork) ?? QoderStat(ranges: QoderRanges(today: QoderRange(in: 0, out: 0), yesterday: QoderRange(in: 0, out: 0), week: QoderRange(in: 0, out: 0), last_week: QoderRange(in: 0, out: 0), month: QoderRange(in: 0, out: 0), year: QoderRange(in: 0, out: 0)))
         hermes = try c.decode(HermesStat.self, forKey: .hermes)
         openclaw = try c.decode(OpenClawStat.self, forKey: .openclaw)
         pi = try c.decodeIfPresent(TokenUsageStat.self, forKey: .pi) ?? TokenUsageStat(ranges: .empty)

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -23,13 +23,14 @@ struct PanelView: View {
     @AppStorage("showGemini") private var showGemini = true
     @AppStorage("showGrok") private var showGrok = true
     @AppStorage("showQoder") private var showQoder = true
+    @AppStorage("showQoderCli") private var showQoderCli = true
     @AppStorage("showHermes") private var showHermes = true
     @AppStorage("showOpenClaw") private var showOpenClaw = true
     @AppStorage("showPi") private var showPi = true
     @AppStorage("showOpenCode") private var showOpenCode = true
 
     private var visibleCount: Int {
-        [showClaude, showCodex, showGemini, showGrok, showQoder, showHermes, showOpenClaw, showPi, showOpenCode].filter { $0 }.count
+        [showClaude, showCodex, showGemini, showGrok, showQoderCli, showQoder, showHermes, showOpenClaw, showPi, showOpenCode].filter { $0 }.count
     }
     private var useWide: Bool { visibleCount > 2 }
     private var panelWidth: CGFloat { useWide ? 640 : Theme.panelWidth }
@@ -188,7 +189,7 @@ struct PanelView: View {
     private func toolCards(for u: Usage) -> [ToolCardItem] {
         let cr = u.claude.ranges.get(sel), xr = u.codex.ranges.get(sel)
         let gr = u.gemini.ranges.get(sel), kr = u.grok.ranges.get(sel)
-        let qr = u.qoder.ranges.get(sel), hr = u.hermes.ranges.get(sel)
+        let qclir = u.qoder.ranges.get(sel), qwr = u.qoderwork.ranges.get(sel), hr = u.hermes.ranges.get(sel)
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel), or = u.opencode.ranges.get(sel)
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude, active: cr.sessions > 0,
@@ -199,8 +200,10 @@ struct PanelView: View {
                          tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
             ToolCardItem(id: "grok", name: "Grok", visible: showGrok, active: kr.sessions > 0,
                          tint: Theme.grok, content: AnyView(grokBlock(kr, model: u.grok.model))),
-            ToolCardItem(id: "qoder", name: "Qoder", visible: showQoder, active: qr.calls > 0,
-                         tint: Theme.qoder, content: AnyView(qoderBlock(u.qoder, qr))),
+            ToolCardItem(id: "qoder", name: "Qoder", visible: showQoderCli, active: qclir.sessions > 0,
+                         tint: Theme.qodercli, content: AnyView(tokenUsageBlock(title: "Qoder", qclir, tint: Theme.qodercli))),
+            ToolCardItem(id: "qoderwork", name: "QoderWork", visible: showQoder, active: qwr.calls > 0,
+                         tint: Theme.qoder, content: AnyView(qoderBlock(u.qoderwork, qwr))),
             ToolCardItem(id: "hermes", name: "Hermes", visible: showHermes, active: hr.sessions > 0,
                          tint: Theme.hermes, content: AnyView(hermesBlock(hr))),
             ToolCardItem(id: "openclaw", name: "OpenClaw", visible: showOpenClaw, active: lr.tasks > 0 || lr.in + lr.out > 0,
@@ -387,7 +390,7 @@ struct PanelView: View {
     @ViewBuilder
     func qoderBlock(_ q: QoderStat, _ r: QoderRange) -> some View {
         VStack(alignment: .leading, spacing: 11) {
-            cardHeadPlain("Qoder", tint: Theme.qoder)
+            cardHeadPlain("QoderWork", tint: Theme.qoder)
             if r.calls > 0 {
                 metricGrid({
                     var items: [Metric] = [
@@ -855,7 +858,8 @@ struct PanelView: View {
                 settingsRow("Codex", tint: Theme.codex, isOn: $showCodex)
                 settingsRow("Gemini", tint: Theme.gemini, isOn: $showGemini)
                 settingsRow("Grok", tint: Theme.grok, isOn: $showGrok)
-                settingsRow("Qoder", tint: Theme.qoder, isOn: $showQoder)
+                settingsRow("Qoder", tint: Theme.qodercli, isOn: $showQoderCli)
+                settingsRow("QoderWork", tint: Theme.qoder, isOn: $showQoder)
                 settingsRow("Hermes", tint: Theme.hermes, isOn: $showHermes)
                 settingsRow("OpenClaw", tint: Theme.openclaw, isOn: $showOpenClaw)
                 settingsRow("Pi", tint: Theme.pi, isOn: $showPi)
@@ -1363,7 +1367,7 @@ struct PanelView: View {
 
         if let data = result.stdout.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            let tools = ["claude", "codex", "gemini", "grok", "qoder", "hermes", "openclaw", "pi", "opencode"]
+            let tools = ["claude", "codex", "gemini", "grok", "qoder", "qoderwork", "hermes", "openclaw", "pi", "opencode"]
                 .filter { json[$0] != nil }
                 .joined(separator: ",")
             lines.append("json: ok tools: \(tools)")

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -85,6 +85,7 @@ final class SyncManager {
             mergeRanges(&u.gemini.ranges, peer.usage.gemini.ranges)
             mergeRanges(&u.grok.ranges, peer.usage.grok.ranges)
             mergeRanges(&u.qoder.ranges, peer.usage.qoder.ranges)
+            mergeRanges(&u.qoderwork.ranges, peer.usage.qoderwork.ranges)
             mergeRanges(&u.hermes.ranges, peer.usage.hermes.ranges)
             mergeRanges(&u.openclaw.ranges, peer.usage.openclaw.ranges)
             mergeRanges(&u.pi.ranges, peer.usage.pi.ranges)

--- a/Tokei/Sources/Tokei/WrappedView.swift
+++ b/Tokei/Sources/Tokei/WrappedView.swift
@@ -350,7 +350,7 @@ struct BadgeView: View {
 // 撒花:跨 token 里程碑时从顶部落下的彩屑。
 struct ConfettiView: View {
     @State private var fall = false
-    private let palette: [Color] = [Theme.claude, Theme.qoder, Theme.hermes,
+    private let palette: [Color] = [Theme.claude, Theme.qoder, Theme.qodercli, Theme.hermes,
                                     Theme.codex, Theme.gemini, Theme.openclaw]
     var body: some View {
         GeometryReader { geo in

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -162,11 +162,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let showX = ud.object(forKey: "showCodex") as? Bool ?? true
                 let showP = ud.object(forKey: "showPi") as? Bool ?? true
                 let showO = ud.object(forKey: "showOpenCode") as? Bool ?? true
+                let showQCli = ud.object(forKey: "showQoderCli") as? Bool ?? true
                 var total = 0
                 if showC { let r = u.claude.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
                 if showX { let r = u.codex.ranges.get(.today); total += Int(r.in + r.out + r.cached + r.reason) }
                 if showP { let r = u.pi.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
                 if showO { let r = u.opencode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                if showQCli { let r = u.qoder.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
                 if total > 0 {
                     seg(Fmt.human(total), .secondaryLabelColor)
                 } else {

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -298,6 +298,9 @@ def _empty_qoder():
                   "duration": 0, "ctx_sum": 0.0, "ctx_count": 0} for k in RANGE_KEYS}
     return {"ranges": ranges, "quota": None, "model": None}
 
+def _empty_qodercli():
+    return {"ranges": _empty_token_ranges()}
+
 
 def _empty_hermes():
     ranges = {k: {"in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0,
@@ -958,6 +961,82 @@ def scan_qoder(bounds, cache):
     return {"ranges": B, "quota": quota, "model": model}
 
 
+# ---------- Qoder CLI ----------
+# JSONL: ~/.qoder/projects/<proj>/<session>.jsonl (same format as Claude Code)
+
+def scan_qoder_cli(bounds, cache):
+    fc = cache.setdefault("qodercli", {})
+    B = _empty_token_ranges()
+
+    proj_dir = os.path.join(QODER_DIR, "projects")
+    if not os.path.isdir(proj_dir):
+        return {"ranges": B}
+
+    stale = set(fc.keys())
+
+    for f in glob.glob(os.path.join(proj_dir, "**", "*.jsonl"), recursive=True):
+        stale.discard(f)
+        try:
+            st = os.stat(f)
+        except OSError:
+            continue
+        sig = f"{st.st_mtime}:{st.st_size}"
+        entry = fc.get(f)
+        if not entry or entry.get("sig") != sig:
+            days = {}
+            seen_mids = set()
+            try:
+                with open(f, "r", encoding="utf-8", errors="ignore") as fh:
+                    for line in fh:
+                        if '"usage"' not in line:
+                            continue
+                        try:
+                            o = json.loads(line)
+                        except Exception:
+                            continue
+                        if o.get("type") != "assistant":
+                            continue
+                        msg = o.get("message") or {}
+                        u = msg.get("usage")
+                        if not u:
+                            continue
+                        mid = msg.get("id")
+                        if mid:
+                            if mid in seen_mids:
+                                continue
+                            seen_mids.add(mid)
+                        dt = parse_ts(o.get("timestamp", ""))
+                        if dt is None:
+                            continue
+                        dt = dt.astimezone()
+                        inp = u.get("input_tokens", 0) or 0
+                        out = u.get("output_tokens", 0) or 0
+                        cr = u.get("cache_read_input_tokens", 0) or 0
+                        cw = u.get("cache_creation_input_tokens", 0) or 0
+                        model = msg.get("model") or ""
+                        if inp + out + cr + cw == 0:
+                            continue
+                        dk = dt.date().isoformat()
+                        day = days.setdefault(dk, _empty_token_day())
+                        _add_token_usage(day, inp, out, cr, cw, 0, 0.0, model)
+            except OSError:
+                continue
+            fc[f] = {"sig": sig, "days": days}
+
+    for p in stale:
+        fc.pop(p, None)
+
+    for f, entry in fc.items():
+        for dk, day in entry.get("days", {}).items():
+            try:
+                d = date.fromisoformat(dk)
+            except ValueError:
+                continue
+            for k in classify_date(d, bounds):
+                _merge_token_day(B[k], day, f)
+    return {"ranges": B}
+
+
 # ---------- Hermes ----------
 # SQLite: ~/.hermes/state.db (旧布局) + ~/.hermes/profiles/*/state.db (profile 布局)
 def _hermes_db_paths():
@@ -1487,7 +1566,8 @@ def compute():
     cx = _safe_scan("codex", lambda: scan_codex(bounds, cache), _empty_codex, errors)
     gm = _safe_scan("gemini", lambda: scan_gemini(bounds), _empty_gemini, errors)
     gk = _safe_scan("grok", lambda: scan_grok(bounds), _empty_grok, errors)
-    qd = _safe_scan("qoder", lambda: scan_qoder(bounds, cache), _empty_qoder, errors)
+    qd = _safe_scan("qoderwork", lambda: scan_qoder(bounds, cache), _empty_qoder, errors)
+    qcli = _safe_scan("qodercli", lambda: scan_qoder_cli(bounds, cache), _empty_qodercli, errors)
     hm = _safe_scan("hermes", lambda: scan_hermes(bounds, cache), _empty_hermes, errors)
     oc = _safe_scan("openclaw", lambda: scan_openclaw(bounds, cache), _empty_openclaw, errors)
     pi = _safe_scan("pi", lambda: scan_pi(bounds, cache), _empty_pi, errors)
@@ -1549,7 +1629,7 @@ def compute():
     xranges = {k: codex_range(cx["ranges"][k]) for k in RANGE_KEYS}
     granges = {k: gemini_range(gm["ranges"][k]) for k in RANGE_KEYS}
     kranges = {k: grok_range(gk["ranges"][k]) for k in RANGE_KEYS}
-    qranges = {k: qoder_range(qd["ranges"][k]) for k in RANGE_KEYS}
+    qwranges = {k: qoder_range(qd["ranges"][k]) for k in RANGE_KEYS}
 
     def hermes_range(b):
         denom = b["cr"] + b["cw"] + b["in"]
@@ -1578,6 +1658,7 @@ def compute():
 
     piranges = {k: token_usage_range(pi["ranges"][k]) for k in RANGE_KEYS}
     ocranges = {k: token_usage_range(ocode["ranges"][k]) for k in RANGE_KEYS}
+    qcliranges = {k: token_usage_range(qcli["ranges"][k]) for k in RANGE_KEYS}
 
     cur = cc["cur"]
     cur_total = cur["in"] + cur["out"] + cur["cr"] + cur["cw"]
@@ -1617,7 +1698,10 @@ def compute():
             "model": gk["model"],
         },
         "qoder": {
-            "ranges": qranges,
+            "ranges": qcliranges,
+        },
+        "qoderwork": {
+            "ranges": qwranges,
             "quota": qd.get("quota"),
             "model": qd.get("model"),
         },
@@ -2049,6 +2133,13 @@ def daily_costs():
             d = days.setdefault(dk, _empty())
             d["tokens"] += day.get("in", 0) + day.get("out", 0)
 
+    for fp, entry in cache.get("qodercli", {}).items():
+        for dk, day in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            d = days.setdefault(dk, _empty())
+            d["tokens"] += token_total(day)
+
     codex_total = sum(d["codex"] for d in days.values())
     codex_in = sum(d["x_in"] for d in days.values())
     codex_out = sum(d["x_out"] for d in days.values())
@@ -2241,6 +2332,21 @@ def wrapped():
             day_tokens[dk] = day_tokens.get(dk, 0) + tok
             total_tokens += tok
             weekday[date.fromisoformat(dk).weekday()] += tok
+
+    # --- Qoder CLI (token_usage format) ---
+    for f, entry in cache.get("qodercli", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        for dk, day in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            tok = token_total(day)
+            day_tokens[dk] = day_tokens.get(dk, 0) + tok
+            total_tokens += tok
+            weekday[date.fromisoformat(dk).weekday()] += tok
+            for mn, mv in day.get("models", {}).items():
+                nm = f"{nice_model(mn)} (Qoder)"
+                model_tok[nm] = model_tok.get(nm, 0) + token_total(mv)
 
     # --- Gemini (无缓存,需重新扫描取 year 总量;仅 all/365d 包含) ---
     if period in ("all", "365d"):


### PR DESCRIPTION
## Summary

Split the single "Qoder" tool card into two independent cards:

- **Qoder** — CLI tool, reads JSONL from `~/.qoder/projects/**/*.jsonl` (same format as Claude Code). Displays token usage (in/out/cache), cache hit rate, model breakdown, session count.
- **QoderWork** — Desktop app, reads SQLite from `~/Library/Application Support/QoderWork/data/agents.db`. Displays calls, duration, context usage, quota.

## Changes

### Python data layer (`usage.30s.py`)
- New `scan_qoder_cli()` scanner following the Pi scanner pattern
- Renamed output key `"qoder"` → `"qoderwork"` for desktop data
- New `"qoder"` key for CLI data (`token_usage_range` format)
- Added Qoder CLI data to Wrapped stats

### Swift UI (`Sources/Tokei/`)
- **Model.swift**: `Usage.qoder` type changed to `TokenUsageStat` (CLI); added `Usage.qoderwork: QoderStat` (desktop)
- **Design.swift**: Added `Theme.qodercli` color (honey orange)
- **PanelView.swift**: New Qoder CLI card using `tokenUsageBlock()`; renamed existing card to "QoderWork"; separate settings toggles
- **SyncManager.swift**: Added QoderWork merge line
- **main.swift**: Added Qoder CLI tokens to status bar total
- **WrappedView.swift**: Added qodercli color to confetti palette

## Design decisions
- Zero new Swift types — reuses existing `TokenUsageStat` / `TokenUsageRange`
- Cost = 0 for Qoder CLI (model names like `lite`/`auto` have no known pricing; overridable via `pricing_overrides.json`)
- Backward compatible: both fields use `decodeIfPresent` with empty fallbacks
