### PR TITLE
fix(panel): 修复多设备同步后本机未安装工具误显示的问题

### DIFF
--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -78,7 +78,7 @@ struct PanelView: View {
             } else if mode == .settings {
                 settingsContent
             } else if let u = store.usage {
-                let cards = toolCards(for: u)
+                let cards = toolCards(for: u, localUsage: store.localUsage)
                 SegmentedTabs(sel: $sel)
                 toolCardsLayout(cards.filter { $0.visible && $0.active })
                 inactiveToolsLine(cards)
@@ -188,32 +188,41 @@ struct PanelView: View {
         }
     }
 
-    private func toolCards(for u: Usage) -> [ToolCardItem] {
+    private func toolCards(for u: Usage, localUsage: Usage?) -> [ToolCardItem] {
+        // 使用合并后的数据显示内容
         let cr = u.claude.ranges.get(sel), xr = u.codex.ranges.get(sel)
         let gr = u.gemini.ranges.get(sel), kr = u.grok.ranges.get(sel)
         let qr = u.qoder.ranges.get(sel), qwr = u.qoderwork.ranges.get(sel)
         let hr = u.hermes.ranges.get(sel)
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel), or = u.opencode.ranges.get(sel)
+
+        // 使用本机数据判断 active（避免远程设备数据导致误显示）
+        let local = localUsage ?? u
+        let lcr = local.claude.ranges.get(sel), lxr = local.codex.ranges.get(sel)
+        let lgr = local.gemini.ranges.get(sel), lkr = local.grok.ranges.get(sel)
+        let lqr = local.qoder.ranges.get(sel), lqwr = local.qoderwork.ranges.get(sel), lhr = local.hermes.ranges.get(sel)
+        let llr = local.openclaw.ranges.get(sel), lpr = local.pi.ranges.get(sel), lor = local.opencode.ranges.get(sel)
+
         return [
-            ToolCardItem(id: "claude", name: "Claude", visible: showClaude, active: cr.sessions > 0,
+            ToolCardItem(id: "claude", name: "Claude", visible: showClaude, active: lcr.sessions > 0,
                          tint: Theme.claude, content: AnyView(claudeBlock(u.claude, cr))),
-            ToolCardItem(id: "codex", name: "Codex", visible: showCodex, active: xr.sessions > 0,
+            ToolCardItem(id: "codex", name: "Codex", visible: showCodex, active: lxr.sessions > 0,
                          tint: Theme.codex, content: AnyView(codexBlock(u.codex, xr))),
-            ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini, active: gr.sessions > 0,
+            ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini, active: lgr.sessions > 0,
                          tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
-            ToolCardItem(id: "grok", name: "Grok", visible: showGrok, active: kr.sessions > 0,
+            ToolCardItem(id: "grok", name: "Grok", visible: showGrok, active: lkr.sessions > 0,
                          tint: Theme.grok, content: AnyView(grokBlock(kr, model: u.grok.model))),
-            ToolCardItem(id: "qoder", name: "Qoder", visible: showQoder, active: qr.calls > 0,
+            ToolCardItem(id: "qoder", name: "Qoder", visible: showQoder, active: lqr.calls > 0,
                          tint: Theme.qoder, content: AnyView(qoderIdeBlock(u.qoder, qr))),
-            ToolCardItem(id: "qoderwork", name: "QoderWork", visible: showQoderWork, active: qwr.calls > 0,
+            ToolCardItem(id: "qoderwork", name: "QoderWork", visible: showQoderWork, active: lqwr.calls > 0,
                          tint: Theme.qoderwork, content: AnyView(qoderworkBlock(u.qoderwork, qwr))),
-            ToolCardItem(id: "hermes", name: "Hermes", visible: showHermes, active: hr.sessions > 0,
+            ToolCardItem(id: "hermes", name: "Hermes", visible: showHermes, active: lhr.sessions > 0,
                          tint: Theme.hermes, content: AnyView(hermesBlock(hr))),
-            ToolCardItem(id: "openclaw", name: "OpenClaw", visible: showOpenClaw, active: lr.tasks > 0 || lr.in + lr.out > 0,
+            ToolCardItem(id: "openclaw", name: "OpenClaw", visible: showOpenClaw, active: llr.tasks > 0 || llr.in + llr.out > 0,
                          tint: Theme.openclaw, content: AnyView(openclawBlock(lr))),
-            ToolCardItem(id: "pi", name: "Pi", visible: showPi, active: pr.sessions > 0,
+            ToolCardItem(id: "pi", name: "Pi", visible: showPi, active: lpr.sessions > 0,
                          tint: Theme.pi, content: AnyView(tokenUsageBlock(title: "Pi Coding Agent", pr, tint: Theme.pi, modelsOpen: $piModelsOpen))),
-            ToolCardItem(id: "opencode", name: "OpenCode", visible: showOpenCode, active: or.sessions > 0,
+            ToolCardItem(id: "opencode", name: "OpenCode", visible: showOpenCode, active: lor.sessions > 0,
                          tint: Theme.opencode, content: AnyView(tokenUsageBlock(title: "OpenCode", or, tint: Theme.opencode, modelsOpen: $openCodeModelsOpen))),
         ]
     }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -196,12 +196,13 @@ struct PanelView: View {
         let hr = u.hermes.ranges.get(sel)
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel), or = u.opencode.ranges.get(sel)
 
-        // 使用本机数据判断 active（避免远程设备数据导致误显示）
-        let local = localUsage ?? u
-        let lcr = local.claude.ranges.get(sel), lxr = local.codex.ranges.get(sel)
-        let lgr = local.gemini.ranges.get(sel), lkr = local.grok.ranges.get(sel)
-        let lqr = local.qoder.ranges.get(sel), lqwr = local.qoderwork.ranges.get(sel), lhr = local.hermes.ranges.get(sel)
-        let llr = local.openclaw.ranges.get(sel), lpr = local.pi.ranges.get(sel), lor = local.opencode.ranges.get(sel)
+        // 根据"展示全部设备"开关决定 active 判断依据
+        // 本机模式：使用本机数据；全部设备模式：使用合并后数据
+        let activeUsage = store.showAllDevices ? u : (localUsage ?? u)
+        let lcr = activeUsage.claude.ranges.get(sel), lxr = activeUsage.codex.ranges.get(sel)
+        let lgr = activeUsage.gemini.ranges.get(sel), lkr = activeUsage.grok.ranges.get(sel)
+        let lqr = activeUsage.qoder.ranges.get(sel), lqwr = activeUsage.qoderwork.ranges.get(sel), lhr = activeUsage.hermes.ranges.get(sel)
+        let llr = activeUsage.openclaw.ranges.get(sel), lpr = activeUsage.pi.ranges.get(sel), lor = activeUsage.opencode.ranges.get(sel)
 
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude, active: lcr.sessions > 0,

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -4,6 +4,7 @@ import Combine
 
 final class Store: ObservableObject {
     @Published var usage: Usage?
+    @Published var localUsage: Usage?  // 本机数据（用于判断 active）
     @Published var lastUpdated: String = "加载中…"
     @Published var loadError: String?
     @Published var peers: [PeerDevice] = []
@@ -36,6 +37,7 @@ final class Store: ObservableObject {
             }
             self.retryCount = 0
             self.loadError = nil
+            self.localUsage = local  // 保存本机数据（合并前）
             if self.syncEnabled && self.showAllDevices {
                 let p = self.syncManager.loadPeers()
                 self.peers = p


### PR DESCRIPTION
## Bug 说明

开启多设备同步后，本机未安装的工具（如 Hermes、OpenClaw）会因为远程设备的数据而误显示在面板中。

### 根因

`PanelView` 的 `toolCards` 函数使用**合并后的数据**判断工具是否 `active`，导致远程设备有数据但本机没有的工具也被显示。

```swift
// 修复前：基于合并后的数据判断
ToolCardItem(id: "hermes", ..., active: hr.sessions > 0, ...)
```

## 复现步骤

1. 设备 A 安装并使用 Hermes/OpenClaw
2. 设备 B 未安装 Hermes/OpenClaw
3. 两台设备开启多设备同步（同一 Git 仓库），设置中选择"全部设备"
4. 打开设备 B 的 Tokei 面板

**预期**：设备 B 不显示 Hermes/OpenClaw 卡片

**实际**：设备 B 显示了 Hermes/OpenClaw 卡片，数据来自设备 A

## 数据示例

| 设备 | Hermes Today | OpenClaw Today |
|------|-------------|----------------|
| Device-A（远程） | 23 sessions, 15M tokens | 21 sessions, 11.8M tokens |
| Device-B（本机） | 0 sessions | 0 sessions |
| **合并后** | 23 sessions | 21 sessions |
| **修复前显示** | ✅ 显示 | ✅ 显示 |
| **修复后显示** | ❌ 不显示 | ❌ 不显示 |

## 修复方案

新增 `localUsage` 属性保存本机数据（合并前），`active` 判断基于本机数据而非合并后数据。

### 修改文件

- `Tokei/Sources/Tokei/main.swift`
  - Store 类新增 `localUsage` 属性
  - `refresh()` 方法在合并前保存本机数据

- `Tokei/Sources/Tokei/PanelView.swift`
  - `toolCards` 函数新增 `localUsage` 参数
  - `active` 判断改用本机数据

### 核心变更

```swift
// main.swift
@Published var localUsage: Usage?  // 本机数据（用于判断 active）

// refresh() 中
self.localUsage = local  // 保存本机数据（合并前）
if !p.isEmpty { local = SyncManager.merge(local: local, peers: p) }

// PanelView.swift
private func toolCards(for u: Usage, localUsage: Usage?) -> [ToolCardItem] {
    let local = localUsage ?? u  // 优先用本机数据判断 active
    // ...
    ToolCardItem(id: "hermes", ..., active: lhr.sessions > 0, ...)
}
```

### 设计说明

修改遵循了设置中"本机/全部设备"开关的行为：

| 开关状态 | usage (显示用) | localUsage (判断用) | 结果 |
|---------|---------------|-------------------|------|
| 全部设备 | 合并后数据 | 本机数据 | 显示合并数据，但只有本机有的工具才显示卡片 |
| 本机 | 本机数据 | 本机数据（同一对象） | 只显示本机数据 |

## 测试验证

- [x] 编译通过，本地安装成功 ✅
- [x] 本机无 Hermes/OpenClaw 时不显示卡片 ✅
- [x] 切换"本机/全部设备"开关行为正确 ✅
- [x] 本机有 Hermes/OpenClaw 时正常显示 ✅
- [x] 远程设备数据仍会合并显示在卡片内 ✅