### PR TITLE
fix(usage): 修正 Claude Code usage 去重口径

### DIFF
--- a/usage.30s.py
+++ b/usage.30s.py
@@ -446,12 +446,12 @@ def scan_claude(bounds, cache):
             cur_file = f
         sig = f"{mtime}:{size}"
         entry = fc.get(f)
-        if not entry or entry.get("sig") != sig:
+        if not entry or entry.get("sig") != sig or entry.get("usage_version") != 2:
             days = {}
             hours = [0] * 24
             dh = set()
             proj = None
-            seen_mids = set()
+            seen_events = set()
             try:
                 with open(f, "r", encoding="utf-8", errors="ignore") as fh:
                     for line in fh:
@@ -460,11 +460,12 @@ def scan_claude(bounds, cache):
                         u = _claude_usage(line, want_dt=True)
                         if not u:
                             continue
-                        mid = u.get("mid")
-                        if mid:
-                            if mid in seen_mids:
+                        # message.id 会在流式/工具调用过程中重复出现；顶层 uuid 才是日志事件 id。
+                        eid = u.get("eid")
+                        if eid:
+                            if eid in seen_events:
                                 continue
-                            seen_mids.add(mid)
+                            seen_events.add(eid)
                         dt = u["dt"]
                         dk = dt.date().isoformat()
                         day = days.setdefault(dk, {"in": 0, "out": 0, "cr": 0, "cw": 0,
@@ -482,7 +483,8 @@ def scan_claude(bounds, cache):
                             proj = u["cwd"]
             except OSError:
                 continue
-            fc[f] = {"sig": sig, "days": days, "hours": hours, "dh": sorted(dh), "proj": proj}
+            fc[f] = {"sig": sig, "days": days, "hours": hours, "dh": sorted(dh),
+                     "proj": proj, "usage_version": 2}
 
     for p in stale:
         fc.pop(p, None)
@@ -558,7 +560,8 @@ def _claude_usage(line, want_dt=False):
         write_cost = (w5 or 0) / 1e6 * p["write5m"] + (w1 or 0) / 1e6 * p["write1h"]
     cost = inp / 1e6 * p["in"] + out / 1e6 * p["out"] + cr / 1e6 * p["cache_read"] + write_cost
     res = {"in": inp, "out": out, "cr": cr, "cw": cw, "cost": cost,
-           "model": msg.get("model"), "cwd": o.get("cwd"), "mid": msg.get("id")}
+           "model": msg.get("model"), "cwd": o.get("cwd"), "mid": msg.get("id"),
+           "eid": o.get("uuid")}
     if want_dt:
         res["dt"] = dt
     return res


### PR DESCRIPTION
这个 PR 修了 Claude Code usage 扫描里的一个去重逻辑导致的计算结果偏少的问题。

之前扫描 Claude Code JSONL 时，会按 `message.id` 去重：

```python
if mid in seen_mids:
    continue
```

但 Claude Code 的日志里，`message.id` 不是一条 usage 事件的唯一标识。同一个 `message.id` 可能在流式响应或工具调用过程中出现多次，每条记录都有独立的顶层 `uuid`，并且这些记录的 usage 会被 Claude 控制台计入。

我这边用一份本机当天日志做了脱敏对账：

```text
日期：2026-06-29
Claude Code 日志文件：1 个
assistant usage 行数：700
顶层 uuid 数：700
message.id 数：569

修复前 APP 统计：107,014,511 tokens
原始 usage 行合计：134,712,459 tokens
少算：27,697,948 tokens
```

这里的差额主要来自同一个 `message.id` 下的多条 assistant usage 记录。按 `message.id` 去重会把后面的记录丢掉。

## 改动

- Claude Code usage 扫描改为按顶层日志事件 `uuid` 去重
- 保留无 `uuid` 记录的兼容处理，不再用 `message.id` 误去重
- 给 Claude 扫描缓存加 `usage_version = 2`，避免旧缓存继续沿用少算结果

## 验证

修复后，用同一份本机当天日志复算：

```text
APP 统计：134,712,459 tokens
原始 assistant usage 行合计：134,712,459 tokens
```

另外跑了：

```bash
python3 -m py_compile usage.30s.py
python3 usage.30s.py --json
```