### PR TITLE
fix(opencode): 支持 OpenCode 新版 SQLite 用量采集

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -16,7 +16,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `sessions` 表 |
 | OpenClaw | `~/.openclaw/tasks/runs.sqlite` | SQLite, `task_runs` 表 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
-| OpenCode | `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | JSON, `tokens` + `cost` |
+| OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | SQLite/JSON, `tokens` + `cost` |
 
 ---
 
@@ -174,7 +174,7 @@ cost = (input - cached)/1M × price_in
 
 ### Pi Coding Agent CLI / OpenCode 成本
 
-Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 直接使用消息 JSON 中的 `cost` 字段。若 Pi 成本字段缺失，则按统一价格表用 input/output/cache_read/cache_write 回退估算。
+Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 优先读取 SQLite `message.data` 中的 `cost` 字段，旧版 JSON 文件同口径。若 Pi 成本字段缺失，则按统一价格表用 input/output/cache_read/cache_write 回退估算。
 
 ### Grok / Qoder / OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/co
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + SQLite |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
-| OpenCode | `~/.opencode/sessions/*.json` |
+| OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/*/msg_*.json` |
 | Qoder | `~/.qodo-ai/sessions/*.jsonl` |
 
 ## 对比 CodexBar

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -25,6 +25,7 @@ GROK_DIR = os.path.join(HOME, ".grok", "sessions")
 QODER_DIR = os.path.join(HOME, ".qoder")
 HERMES_DB = os.path.join(HOME, ".hermes", "state.db")
 OPENCODE_DIR = os.path.join(HOME, ".local", "share", "opencode", "storage", "message")
+OPENCODE_DB = os.path.join(HOME, ".local", "share", "opencode", "opencode.db")
 OPENCLAW_DB = os.path.join(HOME, ".openclaw", "tasks", "runs.sqlite")
 OPENCLAW_AGENTS = os.path.join(HOME, ".openclaw", "agents")
 PI_AGENT_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_DIR", os.path.join(HOME, ".pi", "agent")))
@@ -1320,9 +1321,65 @@ def scan_pi(bounds, cache):
 
 
 # ---------- OpenCode ----------
-# JSON 文件: ~/.local/share/opencode/storage/message/<session>/msg_*.json
+# 新版 SQLite: ~/.local/share/opencode/opencode.db — message 表 data JSON。
+# 旧版 JSON: ~/.local/share/opencode/storage/message/<session>/msg_*.json。
 # 每条 assistant 消息有 tokens{input,output,reasoning,cache{read,write}} + cost + modelID。
+def _scan_opencode_db(bounds):
+    B = _empty_token_ranges()
+    if not os.path.isfile(OPENCODE_DB):
+        return None
+    try:
+        import sqlite3 as _sq
+        conn = _sq.connect(f"file:{OPENCODE_DB}?mode=ro", uri=True)
+        rows = conn.execute("SELECT session_id, time_created, data FROM message").fetchall()
+        conn.close()
+    except Exception:
+        return None
+
+    saw_usage = False
+    for sid, created, raw in rows:
+        try:
+            d = json.loads(raw)
+        except Exception:
+            continue
+        if d.get("role") != "assistant":
+            continue
+        tok = d.get("tokens") or {}
+        ca = tok.get("cache") or {}
+        day_data = {
+            "in": tok.get("input", 0) or 0,
+            "out": tok.get("output", 0) or 0,
+            "reason": tok.get("reasoning", 0) or 0,
+            "cr": ca.get("read", 0) or 0,
+            "cw": ca.get("write", 0) or 0,
+            "cost": d.get("cost", 0) or 0,
+            "session": sid,
+            "models": {},
+        }
+        if not token_total(day_data) and not day_data["cost"]:
+            continue
+        t = (d.get("time") or {}).get("created") or created
+        if not t:
+            continue
+        day_data["date"] = datetime.fromtimestamp(t / 1000).strftime("%Y-%m-%d")
+        model = d.get("modelID", "")
+        _add_model_usage(day_data["models"], model, day_data["in"], day_data["out"],
+                         day_data["cr"], day_data["cw"], day_data["reason"], day_data["cost"])
+        try:
+            dd = date.fromisoformat(day_data["date"])
+        except ValueError:
+            continue
+        saw_usage = True
+        for k in classify_date(dd, bounds):
+            _merge_token_day(B[k], day_data, sid)
+    return {"ranges": B} if saw_usage else None
+
+
 def scan_opencode(bounds, cache):
+    from_db = _scan_opencode_db(bounds)
+    if from_db is not None:
+        return from_db
+
     fc = cache.setdefault("opencode", {})
     B = _empty_token_ranges()
     if not os.path.isdir(OPENCODE_DIR):


### PR DESCRIPTION
## Summary

修复新版 OpenCode 用量无法统计的问题。

OpenCode 新版本已不再依赖旧的 `~/.local/share/opencode/storage/message/*/msg_*.json` 路径。Tokei 之前只扫描旧 JSON，所以在本机 OpenCode `1.17.13` 上今日数据为 0，面板不会显示 OpenCode active 卡片。

这次改为优先读取 `~/.local/share/opencode/opencode.db`，从 `message.data` 中解析 assistant 消息的 tokens / cost / modelID；如果没有 SQLite 数据，再回退旧 JSON 路径，兼容老版本。

## Background

上游 OpenCode 的版本边界大致如下：

- `v1.15.13` 仍保留 `packages/opencode/src/storage/json-migration.ts`，用于把旧 JSON storage 迁移进 SQLite。
- `v1.16.0` 开始移除旧 JSON storage migration，对 Tokei 来说这是最关键的兼容断点。
- `v1.16.0` 同时包含 `20260510033149_session_usage` 迁移，把 session 的 cost / tokens 汇总列补进 SQLite。

参考：

- https://github.com/anomalyco/opencode/blob/v1.15.13/packages/opencode/src/storage/json-migration.ts
- https://github.com/anomalyco/opencode/commit/ca2acc4f8
- https://github.com/anomalyco/opencode/blob/v1.16.0/packages/core/src/database/migration/20260510033149_session_usage.ts

## Verification

本机环境：

- OpenCode version: `1.17.13`
- DB path: `~/.local/share/opencode/opencode.db`
- 今日一条会话只存在 SQLite，旧 JSON 文件数为 `0`

脱敏后的今日会话数据：

```text
version: 1.17.13
model: internal-glm-5.2
tokens_input: 1,990,473
tokens_output: 14,363
tokens_reasoning: 505
tokens_cache_read: 0
tokens_cache_write: 0
cost: 0.0
legacy msg_*.json files: 0