### PR TITLE
fix: dedupe Codex fork token history

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -48,8 +48,9 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 - 总量 = `input_tokens + output_tokens`（即 `total_tokens`）
 
 Codex 的子代理和分叉 rollout 可能重放父任务历史。Tokei 使用
-`total_token_usage + last_token_usage` 组成快照键,在全部 rollout 文件中只保留最早出现的一次;
-子代理后续产生的新快照继续计入。
+`session_meta.forked_from_id` 找到父会话,再用 `total_token_usage + last_token_usage`
+组成快照键扣除子会话开头复制的父会话前缀。缺少 fork 元数据时,只对较长的相同前缀
+做保守去重,避免把两个独立会话里偶然相同的 token 快照误删。
 
 **Gemini CLI** — `tokens.input` 已包含缓存:
 - 输入 = `tokens.input - tokens.cached`

--- a/tests/test_codex_dedup.py
+++ b/tests/test_codex_dedup.py
@@ -36,13 +36,38 @@ class CodexDedupedDaysTests(unittest.TestCase):
         )
 
         days = USAGE._codex_deduped_days({
-            "child": {"events": [replay, child_increment]},
-            "parent": {"events": [parent]},
+            "child": {"session_id": "child", "forked_from_id": "parent",
+                      "events": [replay, child_increment]},
+            "parent": {"session_id": "parent", "events": [parent]},
         })
 
         self.assertEqual(days["parent"]["2026-07-10"]["in"], 100)
         self.assertEqual(days["child"]["2026-07-10"]["in"], 50)
         self.assertEqual(days["child"]["2026-07-10"]["out"], 3)
+
+    def test_matching_snapshots_in_independent_sessions_are_kept(self):
+        first = event(
+            "2026-07-10T00:00:00+00:00",
+            "2026-07-10",
+            (100, 80, 5, 2),
+            (100, 80, 5, 2),
+            1.0,
+        )
+        second = event(
+            "2026-07-10T01:00:00+00:00",
+            "2026-07-10",
+            (100, 80, 5, 2),
+            (100, 80, 5, 2),
+            1.0,
+        )
+
+        days = USAGE._codex_deduped_days({
+            "a": {"session_id": "a", "events": [first]},
+            "b": {"session_id": "b", "events": [second]},
+        })
+
+        self.assertEqual(days["a"]["2026-07-10"]["in"], 100)
+        self.assertEqual(days["b"]["2026-07-10"]["in"], 100)
 
     def test_events_without_cumulative_total_are_kept(self):
         first = event(
@@ -70,6 +95,21 @@ class CodexDedupedDaysTests(unittest.TestCase):
 
 
 class CodexScanDedupTests(unittest.TestCase):
+    def session_meta(self, sid, forked_from_id=None):
+        payload = {
+            "session_id": sid,
+            "id": sid,
+            "cwd": "/tmp/project",
+            "model_provider": "custom",
+        }
+        if forked_from_id:
+            payload["forked_from_id"] = forked_from_id
+        return json.dumps({
+            "timestamp": "2024-01-08T00:00:00Z",
+            "type": "session_meta",
+            "payload": payload,
+        })
+
     def token_count(self, ts, total, last):
         return json.dumps({
             "timestamp": ts,
@@ -102,11 +142,15 @@ class CodexScanDedupTests(unittest.TestCase):
             child_total = (150, 120, 8, 3)
             child_last = (50, 40, 3, 1)
             parent.write_text(
-                self.token_count("2024-01-08T00:00:00Z", inherited_total, inherited_total) + "\n",
+                "\n".join([
+                    self.session_meta("parent"),
+                    self.token_count("2024-01-08T00:00:00Z", inherited_total, inherited_total),
+                ]) + "\n",
                 encoding="utf-8",
             )
             child.write_text(
                 "\n".join([
+                    self.session_meta("child", "parent"),
                     self.token_count("2024-01-08T01:00:00Z", inherited_total, inherited_total),
                     self.token_count("2024-01-08T01:01:00Z", child_total, child_last),
                 ]) + "\n",
@@ -134,6 +178,50 @@ class CodexScanDedupTests(unittest.TestCase):
         self.assertEqual(all_usage["cached"], 120)
         self.assertEqual(all_usage["out"], 8)
         self.assertEqual(all_usage["reason"], 3)
+        self.assertEqual(len(all_usage["sessions"]), 2)
+
+    def test_scan_keeps_independent_sessions_with_same_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / "rollout-first.jsonl"
+            second = root / "rollout-second.jsonl"
+            usage = (100, 80, 5, 2)
+            first.write_text(
+                "\n".join([
+                    self.session_meta("first"),
+                    self.token_count("2024-01-08T00:00:00Z", usage, usage),
+                ]) + "\n",
+                encoding="utf-8",
+            )
+            second.write_text(
+                "\n".join([
+                    self.session_meta("second"),
+                    self.token_count("2024-01-08T01:00:00Z", usage, usage),
+                ]) + "\n",
+                encoding="utf-8",
+            )
+            day = datetime(2024, 1, 8, tzinfo=timezone.utc)
+            bounds = {
+                "today": day,
+                "yesterday": day - timedelta(days=1),
+                "week": day,
+                "last_week": day - timedelta(days=7),
+                "last_week_end": day,
+                "month": day.replace(day=1),
+                "year": day.replace(month=1, day=1),
+            }
+            old_dir = USAGE.CODEX_DIR
+            USAGE.CODEX_DIR = tmp
+            try:
+                result = USAGE.scan_codex(bounds, {"v": USAGE._SCAN_CACHE_VERSION})
+            finally:
+                USAGE.CODEX_DIR = old_dir
+
+        all_usage = result["ranges"]["all"]
+        self.assertEqual(all_usage["in"], 200)
+        self.assertEqual(all_usage["cached"], 160)
+        self.assertEqual(all_usage["out"], 10)
+        self.assertEqual(all_usage["reason"], 4)
         self.assertEqual(len(all_usage["sessions"]), 2)
 
 

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -274,7 +274,7 @@ def human(n: float) -> str:
 # ---------- 增量扫描缓存 ----------
 import tempfile as _tempfile
 _SCAN_CACHE_FILE = os.path.join(_tempfile.gettempdir(), "_tokei_scan_cache.json")
-_SCAN_CACHE_VERSION = 12
+_SCAN_CACHE_VERSION = 13
 
 
 def _load_scan_cache():
@@ -687,36 +687,94 @@ def fetch_codex_live_limits():
         return _cached_codex_live_limits(_CODEX_QUOTA_FALLBACK_TTL)
 
 
-def _codex_deduped_days(file_cache):
-    """Return per-file daily usage after removing replayed snapshots globally."""
-    owners = {}
-    for file_path, entry in file_cache.items():
-        for event_index, event in enumerate(entry.get("events", [])):
-            if not isinstance(event, list) or len(event) != 11:
-                continue
-            total_values = event[2:6]
-            if all(value is not None for value in total_values):
-                key = tuple(event[2:10])
-            else:
-                # A last_token_usage without a cumulative total cannot be matched safely.
-                key = ("unique", file_path, event_index)
-            rank = (event[0], file_path, event_index)
-            current = owners.get(key)
-            if current is None or rank < current[0]:
-                owners[key] = (rank, file_path, event)
+def _codex_event_key(event):
+    if not isinstance(event, list) or len(event) != 11:
+        return None
+    total_values = event[2:6]
+    if not all(value is not None for value in total_values):
+        return None
+    return tuple(event[2:10])
 
+
+def _codex_add_event(days, event):
+    dk = event[1]
+    li, lc, lo, lr, cost = event[6:11]
+    day = days.setdefault(dk, {"in": 0, "cached": 0, "out": 0,
+                               "reason": 0, "cost": 0.0})
+    day["in"] += li
+    day["cached"] += lc
+    day["out"] += lo
+    day["reason"] += lr
+    day["cost"] += cost
+
+
+def _codex_prefix_match_count(child_events, parent_events):
+    n = 0
+    while n < len(child_events) and n < len(parent_events):
+        child_key = _codex_event_key(child_events[n])
+        parent_key = _codex_event_key(parent_events[n])
+        if child_key is None or child_key != parent_key:
+            break
+        n += 1
+    return n
+
+
+def _codex_replayed_event_indexes(file_cache):
+    by_sid = {}
+    ordered = []
+    for file_path, entry in file_cache.items():
+        events = entry.get("events") or []
+        if events:
+            ordered.append((file_path, entry))
+        sid = entry.get("session_id")
+        if sid:
+            by_sid[sid] = (file_path, entry)
+
+    drops = {}
+    for file_path, entry in ordered:
+        parent = by_sid.get(entry.get("forked_from_id"))
+        if not parent:
+            continue
+        n = _codex_prefix_match_count(entry.get("events") or [], parent[1].get("events") or [])
+        if n:
+            drops.setdefault(file_path, set()).update(range(n))
+
+    # Some Codex replay files do not carry fork metadata. Only use this
+    # heuristic for longer matching prefixes; a one-event match can be a real
+    # independent session with the same usage numbers.
+    for file_path, entry in ordered:
+        if drops.get(file_path):
+            continue
+        child_events = entry.get("events") or []
+        if not child_events:
+            continue
+        child_first_ts = child_events[0][0]
+        best = 0
+        for parent_path, parent_entry in ordered:
+            if parent_path == file_path:
+                continue
+            parent_events = parent_entry.get("events") or []
+            if not parent_events or parent_events[0][0] >= child_first_ts:
+                continue
+            best = max(best, _codex_prefix_match_count(child_events, parent_events))
+        if best >= 2:
+            drops.setdefault(file_path, set()).update(range(best))
+    return drops
+
+
+def _codex_deduped_days(file_cache):
+    """Return per-file daily usage after removing copied rollout prefixes."""
+    drops = _codex_replayed_event_indexes(file_cache)
     days_by_file = {}
-    for _, file_path, event in owners.values():
-        dk = event[1]
-        li, lc, lo, lr, cost = event[6:11]
-        days = days_by_file.setdefault(file_path, {})
-        day = days.setdefault(dk, {"in": 0, "cached": 0, "out": 0,
-                                   "reason": 0, "cost": 0.0})
-        day["in"] += li
-        day["cached"] += lc
-        day["out"] += lo
-        day["reason"] += lr
-        day["cost"] += cost
+    for file_path, entry in file_cache.items():
+        skip = drops.get(file_path, set())
+        for event_index, event in enumerate(entry.get("events", [])):
+            if event_index in skip or _codex_event_key(event) is None:
+                if event_index in skip:
+                    continue
+                if not isinstance(event, list) or len(event) != 11:
+                    continue
+            _codex_add_event(days_by_file.setdefault(file_path, {}), event)
     return days_by_file
 
 
@@ -768,6 +826,28 @@ def _iter_codex_token_lines(path, chunk_size=64 * 1024, header_limit=4 * 1024):
         yield bytes(candidate)
 
 
+def _codex_session_meta(path, max_lines=20, max_line_bytes=2 * 1024 * 1024):
+    try:
+        with open(path, "rb", buffering=0) as fh:
+            for _ in range(max_lines):
+                line = fh.readline(max_line_bytes)
+                if not line:
+                    break
+                if b'"session_meta"' not in line:
+                    continue
+                try:
+                    o = json.loads(line.decode("utf-8", errors="ignore"))
+                except Exception:
+                    continue
+                if o.get("type") != "session_meta":
+                    continue
+                meta = o.get("payload") or {}
+                return meta.get("session_id") or meta.get("id"), meta.get("forked_from_id")
+    except OSError:
+        pass
+    return None, None
+
+
 def scan_codex(bounds, cache):
     fc = cache.setdefault("codex", {})
     B = {k: {"in": 0, "cached": 0, "out": 0, "reason": 0, "cost": 0.0, "sessions": set()}
@@ -801,6 +881,7 @@ def scan_codex(bounds, cache):
         entry = fc.get(f)
         if not entry or entry.get("sig") != sig:
             events = []
+            session_id, forked_from_id = _codex_session_meta(f)
             file_limits = None; file_limits_ts = None; file_plan = None
             file_g_limits = None; file_g_ts = None; file_g_plan = None
             file_last_total = None
@@ -855,6 +936,7 @@ def scan_codex(bounds, cache):
             except OSError:
                 continue
             fc[f] = {"sig": sig, "events": events, "days": {},
+                     "session_id": session_id, "forked_from_id": forked_from_id,
                      "limits": file_limits, "limits_ts": file_limits_ts, "plan": file_plan,
                      "g_limits": file_g_limits, "g_ts": file_g_ts, "g_plan": file_g_plan,
                      "last_total": file_last_total}


### PR DESCRIPTION
## Summary

Fixes #23.

Upstream has already added a broad Codex replay dedupe in v1.0.11/v1.0.12. After rebasing, this PR keeps that work and makes the cross-file replay detection more precise, so independent Codex sessions with coincidentally identical token snapshots are not dropped.

This PR now:

- reads `session_id` and `forked_from_id` from Codex `session_meta`;
- removes the matching copied `token_count` prefix when a forked child rollout explicitly points at its parent;
- keeps a conservative fallback for longer matching prefixes when fork metadata is absent;
- keeps identical one-off snapshots in independent sessions;
- bumps the scan cache version so Codex entries are rescanned with session metadata.

## Tests

- `python3 -m unittest discover -s tests`
- `python3 -m py_compile usage.30s.py tests/test_codex_dedup.py tests/test_codex_limits.py tests/test_workbuddy.py`
- `git diff --check`
- Real local Codex data for 2026-07-12 still dedupes the fork replay: `input_tokens + output_tokens` is about 466M after dedupe, with cached tokens remaining a subset of input.