### PR TITLE
feat: add Qwen Code CLI usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **9 款 AI 编程工具** 上的用量、成本和性能——全部基于本地日志，零网络流量。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **11 款 AI 编程工具** 上的用量、成本和性能——全部基于本地日志，零网络流量。
 
 ### 支持的工具
 
@@ -33,7 +33,9 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **9 款 AI 编程
 | **OpenClaw** | Token、成本、任务、模型 |
 | **Pi Coding Agent CLI** | Token、成本、缓存命中率、模型、项目 |
 | **OpenCode** | Token、成本、缓存命中率、模型 |
+| **Qwen Code** | Token、思考量、成本、模型 |
 | **Qoder** | Token、调用次数、配额 |
+| **QoderWork** | Token、调用次数、配额 |
 
 ## 功能一览
 
@@ -126,13 +128,15 @@ echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/co
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + SQLite |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
 | OpenCode | `~/.opencode/sessions/*.json` |
+| Qwen Code | `~/.qwen/usage_record.jsonl` |
 | Qoder | `~/.qodo-ai/sessions/*.jsonl` |
+| QoderWork | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 
 ## 对比 CodexBar
 
 | 功能 | Tokei | [CodexBar](https://github.com/steipete/CodexBar) |
 |------|:-----:|:---------:|
-| 支持工具 | 9 | 40+ |
+| 支持工具 | 11 | 40+ |
 | Token 级用量分析 | ✅ | — |
 | 成本估算（317 模型） | ✅ | 部分 |
 | 数据面板（图表 + 热力图） | ✅ | — |
@@ -233,11 +237,11 @@ echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/co
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **9 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **11 AI coding tools** in real-time — all from local log files, with zero network traffic.
 
 **Features:** Real-time monitoring (30s refresh) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local logs only) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 
-**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok CLI, Hermes, OpenClaw, Pi Coding Agent CLI, OpenCode, Qoder
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok CLI, Hermes, OpenClaw, Pi Coding Agent CLI, OpenCode, Qwen Code, Qoder, QoderWork
 
 For full documentation, visit [tokei.lanshuagent.com](https://tokei.lanshuagent.com).
 

--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -39,6 +39,7 @@ enum Theme {
     static let openclaw = Color(red: 0.85, green: 0.45, blue: 0.68) // 玫红
     static let pi = Color(red: 0.74, green: 0.58, blue: 0.95)       // 柔紫
     static let opencode = Color(red: 0.55, green: 0.75, blue: 0.90) // 天蓝灰
+    static let qwencode = Color(red: 0.48, green: 0.55, blue: 0.95) // 靛蓝
 
     static let panelWidth: CGFloat = 322
     static let cardRadius: CGFloat = 16

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -525,9 +525,10 @@ struct Usage: Codable {
     var openclaw: OpenClawStat
     var pi: TokenUsageStat
     var opencode: TokenUsageStat
+    var qwencode: TokenUsageStat
 
     enum CodingKeys: String, CodingKey {
-        case claude, codex, gemini, grok, qoder, qoderwork, hermes, openclaw, pi, opencode
+        case claude, codex, gemini, grok, qoder, qoderwork, hermes, openclaw, pi, opencode, qwencode
     }
 
     init(from decoder: Decoder) throws {
@@ -545,6 +546,7 @@ struct Usage: Codable {
         openclaw = try c.decode(OpenClawStat.self, forKey: .openclaw)
         pi = try c.decodeIfPresent(TokenUsageStat.self, forKey: .pi) ?? TokenUsageStat(ranges: .empty)
         opencode = try c.decode(TokenUsageStat.self, forKey: .opencode)
+        qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)
     }
 }
 

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -9,6 +9,7 @@ struct PanelView: View {
     @State private var geminiModelsOpen = false
     @State private var piModelsOpen = false
     @State private var openCodeModelsOpen = false
+    @State private var qwenCodeModelsOpen = false
     @State private var expandedModels: Set<String> = []
     @State private var mode: PanelMode = .cards
     @State private var trailProjects: [TrailProject]?
@@ -31,9 +32,10 @@ struct PanelView: View {
     @AppStorage("showOpenClaw") private var showOpenClaw = true
     @AppStorage("showPi") private var showPi = true
     @AppStorage("showOpenCode") private var showOpenCode = true
+    @AppStorage("showQwenCode") private var showQwenCode = true
 
     private var visibleCount: Int {
-        [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showHermes, showOpenClaw, showPi, showOpenCode].filter { $0 }.count
+        [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showHermes, showOpenClaw, showPi, showOpenCode, showQwenCode].filter { $0 }.count
     }
     private var hasMultipleDevices: Bool { store.syncEnabled && !store.peers.isEmpty }
     private var useWide: Bool { visibleCount > 2 }
@@ -211,6 +213,7 @@ struct PanelView: View {
         let qr = u.qoder.ranges.get(sel), qwr = u.qoderwork.ranges.get(sel)
         let hr = u.hermes.ranges.get(sel)
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel), or = u.opencode.ranges.get(sel)
+        let qcr = u.qwencode.ranges.get(sel)
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude, active: cr.sessions > 0,
                          tint: Theme.claude, content: AnyView(claudeBlock(u.claude, cr))),
@@ -232,6 +235,8 @@ struct PanelView: View {
                          tint: Theme.pi, content: AnyView(tokenUsageBlock(title: "Pi Coding Agent", pr, tint: Theme.pi, modelsOpen: $piModelsOpen))),
             ToolCardItem(id: "opencode", name: "OpenCode", visible: showOpenCode, active: or.sessions > 0,
                          tint: Theme.opencode, content: AnyView(tokenUsageBlock(title: "OpenCode", or, tint: Theme.opencode, modelsOpen: $openCodeModelsOpen))),
+            ToolCardItem(id: "qwencode", name: "Qwen Code", visible: showQwenCode, active: qcr.sessions > 0,
+                         tint: Theme.qwencode, content: AnyView(tokenUsageBlock(title: "Qwen Code", qcr, tint: Theme.qwencode, modelsOpen: $qwenCodeModelsOpen))),
         ]
     }
 
@@ -1175,6 +1180,7 @@ struct PanelView: View {
                 settingsRow("OpenClaw", tint: Theme.openclaw, isOn: $showOpenClaw)
                 settingsRow("Pi", tint: Theme.pi, isOn: $showPi)
                 settingsRow("OpenCode", tint: Theme.opencode, isOn: $showOpenCode)
+                settingsRow("Qwen Code", tint: Theme.qwencode, isOn: $showQwenCode)
             }
         }
         .onChange(of: showQoder) { enabled in

--- a/tokei-collector-skill.md
+++ b/tokei-collector-skill.md
@@ -39,6 +39,7 @@ curl -sL https://raw.githubusercontent.com/<user>/tokei-sync/main/install.sh | b
 - OpenClaw (`~/.openclaw/`)
 - Pi Coding Agent CLI (`~/.pi/agent/sessions/`)
 - OpenCode (`~/.local/share/opencode/`)
+- Qwen Code (`~/.qwen/`)
 
 ## 卸载
 

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -1798,7 +1798,6 @@ def scan_qwencode(bounds, cache):
     if not os.path.isfile(QWEN_CODE_USAGE):
         return {"ranges": B}
 
-    sig_key = QWEN_CODE_USAGE
     try:
         st = os.stat(QWEN_CODE_USAGE)
     except OSError:
@@ -1831,16 +1830,20 @@ def scan_qwencode(bounds, cache):
                 day_str = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d")
                 models = {}
                 total_in = total_out = total_cr = total_reason = 0
+                total_cost = 0.0
                 for model_name, mv in d.get("models", {}).items():
                     inp = mv.get("inputTokens", 0) or 0
                     out = mv.get("outputTokens", 0) or 0
                     cr = mv.get("cachedTokens", 0) or 0
                     reason = mv.get("thoughtsTokens", 0) or 0
-                    _add_model_usage(models, model_name, inp, out, cr, 0, reason, 0)
+                    p = price_for(model_name)
+                    model_cost = inp / 1e6 * p["in"] + out / 1e6 * p["out"] + cr / 1e6 * p["cache_read"]
+                    _add_model_usage(models, model_name, inp, out, cr, 0, reason, model_cost)
                     total_in += inp
                     total_out += out
                     total_cr += cr
                     total_reason += reason
+                    total_cost += model_cost
                 day_data = {
                     "date": day_str,
                     "in": total_in,
@@ -1848,8 +1851,8 @@ def scan_qwencode(bounds, cache):
                     "cr": total_cr,
                     "cw": 0,
                     "reason": total_reason,
-                    "cost": 0,
-                    "session": d.get("sessionId", ""),
+                    "cost": total_cost,
+                    "session": d.get("sessionId") or None,
                     "models": models,
                 }
                 entries.append(day_data)
@@ -2522,7 +2525,7 @@ def build_daily_costs(period="all", refresh=True):
     days = {}
     models = {}
 
-    _empty = lambda: {"claude": 0.0, "codex": 0.0, "pi": 0.0, "opencode": 0.0,
+    _empty = lambda: {"claude": 0.0, "codex": 0.0, "pi": 0.0, "opencode": 0.0, "qwencode": 0.0,
                        "c_in": 0, "c_out": 0, "c_cr": 0, "c_cw": 0,
                        "x_in": 0, "x_out": 0, "x_cached": 0, "x_reason": 0,
                        "p_in": 0, "p_out": 0, "p_cr": 0, "p_cw": 0, "p_reason": 0,
@@ -2591,6 +2594,23 @@ def build_daily_costs(period="all", refresh=True):
             for key in TOKEN_FIELDS:
                 m[key] += mv.get(key, 0)
 
+    qwencode_entries = cache.get("qwencode", {}).get("entries", [])
+    for entry in qwencode_entries:
+        dk = entry.get("date")
+        if not dk:
+            continue
+        if cutoff and dk < cutoff:
+            continue
+        d = days.setdefault(dk, _empty())
+        d["qwencode"] += entry.get("cost", 0)
+        d["tokens"] += token_total(entry)
+        for mn, mv in entry.get("models", {}).items():
+            nm = f"{nice_model(mn)} (Qwen Code)"
+            m = models.setdefault(nm, {"cost": 0.0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "tool": "qwencode"})
+            m["cost"] += mv.get("cost", 0)
+            for key in TOKEN_FIELDS:
+                m[key] += mv.get(key, 0)
+
     for fp, entry in cache.get("hermes", {}).items():
         for dk, day in entry.get("days", {}).items():
             if cutoff and dk < cutoff:
@@ -2630,7 +2650,8 @@ def build_daily_costs(period="all", refresh=True):
                                       "reason": codex_reason, "tool": "codex"}
 
     daily = [{"date": dk, "claude": round(v["claude"], 2), "codex": round(v["codex"], 2), "pi": round(v["pi"], 2),
-              "total": round(v["claude"] + v["codex"] + v["pi"] + v["opencode"], 2),
+              "qwencode": round(v["qwencode"], 2),
+              "total": round(v["claude"] + v["codex"] + v["pi"] + v["opencode"] + v["qwencode"], 2),
               "c_in": v["c_in"], "c_out": v["c_out"], "c_cr": v["c_cr"], "c_cw": v["c_cw"],
               "x_in": v["x_in"], "x_out": v["x_out"], "x_cached": v["x_cached"], "x_reason": v["x_reason"],
               "p_in": v["p_in"], "p_out": v["p_out"], "p_cr": v["p_cr"], "p_cw": v["p_cw"], "p_reason": v["p_reason"],
@@ -2782,6 +2803,22 @@ def build_wrapped(period="all", refresh=True):
             total_tokens += tok
             total_cost += day.get("cost", 0)
             weekday[date.fromisoformat(dk).weekday()] += tok
+
+    # --- Qwen Code (in + out + cr + reason) ---
+    for entry in cache.get("qwencode", {}).get("entries", []):
+        dk = entry.get("date")
+        if not dk:
+            continue
+        if cutoff and dk < cutoff:
+            continue
+        tok = token_total(entry)
+        day_tokens[dk] = day_tokens.get(dk, 0) + tok
+        total_tokens += tok
+        total_cost += entry.get("cost", 0)
+        weekday[date.fromisoformat(dk).weekday()] += tok
+        for mn, mv in entry.get("models", {}).items():
+            nm = f"{nice_model(mn)} (Qwen Code)"
+            model_tok[nm] = model_tok.get(nm, 0) + token_total(mv)
 
     # --- Pi Coding Agent (in + out + cr + cw + reason) ---
     for f, entry in cache.get("pi", {}).items():

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -32,6 +32,7 @@ OPENCLAW_DB = os.path.join(HOME, ".openclaw", "tasks", "runs.sqlite")
 OPENCLAW_AGENTS = os.path.join(HOME, ".openclaw", "agents")
 PI_AGENT_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_DIR", os.path.join(HOME, ".pi", "agent")))
 PI_SESSION_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_SESSION_DIR", os.path.join(PI_AGENT_DIR, "sessions")))
+QWEN_CODE_DIR = os.path.join(HOME, ".qwen")
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _USER_DIR = os.path.join(HOME, ".tokei")
@@ -368,6 +369,10 @@ def _empty_opencode():
 
 def _empty_pi():
     return _empty_opencode()
+
+
+def _empty_qwencode():
+    return {"ranges": _empty_token_ranges()}
 
 
 def token_total(day):
@@ -1783,6 +1788,86 @@ def scan_opencode(bounds, cache):
     return {"ranges": B}
 
 
+# ---------- Qwen Code ----------
+QWEN_CODE_USAGE = os.path.join(QWEN_CODE_DIR, "usage_record.jsonl")
+
+
+def scan_qwencode(bounds, cache):
+    fc = cache.setdefault("qwencode", {})
+    B = _empty_token_ranges()
+    if not os.path.isfile(QWEN_CODE_USAGE):
+        return {"ranges": B}
+
+    sig_key = QWEN_CODE_USAGE
+    try:
+        st = os.stat(QWEN_CODE_USAGE)
+    except OSError:
+        return {"ranges": B}
+    sig = f"{st.st_mtime}:{st.st_size}"
+    if fc.get("sig") == sig:
+        for entry in fc.get("entries", []):
+            try:
+                dd = date.fromisoformat(entry["date"])
+            except (ValueError, KeyError):
+                continue
+            for k in classify_date(dd, bounds):
+                _merge_token_day(B[k], entry, entry.get("session"))
+        return {"ranges": B}
+
+    entries = []
+    try:
+        with open(QWEN_CODE_USAGE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                except Exception:
+                    continue
+                ts = d.get("timestamp") or d.get("startTime", 0)
+                if not ts:
+                    continue
+                day_str = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d")
+                models = {}
+                total_in = total_out = total_cr = total_reason = 0
+                for model_name, mv in d.get("models", {}).items():
+                    inp = mv.get("inputTokens", 0) or 0
+                    out = mv.get("outputTokens", 0) or 0
+                    cr = mv.get("cachedTokens", 0) or 0
+                    reason = mv.get("thoughtsTokens", 0) or 0
+                    _add_model_usage(models, model_name, inp, out, cr, 0, reason, 0)
+                    total_in += inp
+                    total_out += out
+                    total_cr += cr
+                    total_reason += reason
+                day_data = {
+                    "date": day_str,
+                    "in": total_in,
+                    "out": total_out,
+                    "cr": total_cr,
+                    "cw": 0,
+                    "reason": total_reason,
+                    "cost": 0,
+                    "session": d.get("sessionId", ""),
+                    "models": models,
+                }
+                entries.append(day_data)
+    except OSError:
+        return {"ranges": B}
+
+    fc["sig"] = sig
+    fc["entries"] = entries
+    for entry in entries:
+        try:
+            dd = date.fromisoformat(entry["date"])
+        except ValueError:
+            continue
+        for k in classify_date(dd, bounds):
+            _merge_token_day(B[k], entry, entry.get("session"))
+    return {"ranges": B}
+
+
 def fmt_reset(epoch):
     try:
         return datetime.fromtimestamp(int(epoch)).astimezone().strftime("%m-%d %H:%M")
@@ -1891,6 +1976,7 @@ def compute():
     oc = _safe_scan("openclaw", lambda: scan_openclaw(bounds, cache), _empty_openclaw, errors)
     pi = _safe_scan("pi", lambda: scan_pi(bounds, cache), _empty_pi, errors)
     ocode = _safe_scan("opencode", lambda: scan_opencode(bounds, cache), _empty_opencode, errors)
+    qwc = _safe_scan("qwencode", lambda: scan_qwencode(bounds, cache), _empty_qwencode, errors)
     _save_scan_cache(cache)
 
     def claude_range(b):
@@ -1989,6 +2075,7 @@ def compute():
 
     piranges = {k: token_usage_range(pi["ranges"][k]) for k in RANGE_KEYS}
     ocranges = {k: token_usage_range(ocode["ranges"][k]) for k in RANGE_KEYS}
+    qwcranges = {k: token_usage_range(qwc["ranges"][k]) for k in RANGE_KEYS}
 
     cur = cc["cur"]
     cur_total = cur["in"] + cur["out"] + cur["cr"] + cur["cw"]
@@ -2038,6 +2125,9 @@ def compute():
         "opencode": {
             "ranges": ocranges,
         },
+        "qwencode": {
+            "ranges": qwcranges,
+        },
     }
     if errors:
         result["_errors"] = errors
@@ -2047,7 +2137,7 @@ def compute():
 
 def _recalc_costs(result):
     """用本地最新价格表重算所有模型成本,修正历史/同步数据中的价格偏差。"""
-    for tool_key in ("claude", "gemini", "pi", "opencode", "hermes", "openclaw"):
+    for tool_key in ("claude", "gemini", "pi", "opencode", "qwencode", "hermes", "openclaw"):
         tool = result.get(tool_key)
         if not tool or "ranges" not in tool:
             continue


### PR DESCRIPTION
## Summary

Add support for Qwen Code CLI token/cost monitoring by parsing `~/.qwen/usage_record.jsonl`.

### Changes

- **`usage.30s.py`**: `scan_qwencode()` reads the JSONL session summaries, aggregates tokens (input/output/cached/reasoning) per model, calculates cost inline via `price_for()`, and feeds into the existing `token_usage_range` pipeline. Also added to `build_daily_costs` (dashboard charts) and `build_wrapped` (annual Wrapped).
- **`Model.swift`**: `Usage` struct gains a `qwencode: TokenUsageStat` field — reuses the same generic type as Pi and OpenCode.
- **`PanelView.swift`**: New "Qwen Code" card using `tokenUsageBlock`, with settings toggle (`showQwenCode`).
- **`Design.swift`**: `Theme.qwencode` color (靛蓝).
- **`README.md`**: Updated tool count (9→11), added Qwen Code + QoderWork to supported tools table, data source table, and CodexBar comparison.
- **`tokei-collector-skill.md`**: Added Qwen Code to supported tools list.

## Data source

Qwen Code writes one JSONL line per session to `~/.qwen/usage_record.jsonl`. Each line contains:

```json
{
  "sessionId": "...",
  "timestamp": 1781149321719,
  "models": {
    "qwen3.7-max": {
      "requests": 3, "inputTokens": 78330, "outputTokens": 91,
      "cachedTokens": 52183, "thoughtsTokens": 46
    }
  }
}
```

Mapped to `TokenUsageRange`: `in` ← inputTokens, `out` ← outputTokens, `cr` ← cachedTokens, `reason` ← thoughtsTokens. Cache write (`cw`) is always 0 since Qwen Code does not expose it.

## Verified

Cross-checked against real `usage_record.jsonl` (584 sessions):

```
Raw today:   sessions=9, in=1020261, out=5784, cached=306669, reason=1212
Tokei today: sessions=9, in=1020261, out=5784, cached=306669, reason=1212  ✓
Daily cost:  qwencode=\$3.56, total=\$433.01  ✓
```

Closes #12