### PR TITLE
fix(sync): 提升多设备 Git 同步的并发可靠性

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,36 @@ Tokei 支持通过私有 Git 仓库在多台机器间同步用量数据。
 git clone <你的私有仓库> ~/.tokei/sync
 curl -fsSL https://dl.lanshuagent.com/tokei/usage.30s.py -o ~/.tokei/usage.30s.py
 echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/config.json
-# 每 5 分钟自动采集并同步
-(crontab -l 2>/dev/null; echo '*/5 * * * * cd ~/.tokei/sync && python3 ~/.tokei/usage.30s.py --json >/dev/null && git pull -q && git add -A && git diff --cached --quiet || git commit -qm sync && git push -q') | crontab -
+cat > ~/.tokei/tokei-sync.sh <<'SH'
+#!/bin/bash
+set -euo pipefail
+exec 9>"$HOME/.tokei/sync.lock"
+flock -n 9 || exit 0
+cd "$HOME/.tokei/sync"
+python3 "$HOME/.tokei/usage.30s.py" --json >/dev/null
+git fetch -q origin main
+device_file=$(find . -maxdepth 1 -type f -iname "$(hostname -s).json" -print -quit)
+[ -n "$device_file" ] || device_file="./$(hostname -s).json"
+for peer_file in ./*.json; do
+  [ "$peer_file" = "$device_file" ] && continue
+  git restore --staged --worktree -- "$peer_file" 2>/dev/null || true
+done
+git add -- "$device_file"
+git diff --cached --quiet || git commit -qm "chore(sync): 更新 $(hostname -s) 用量数据"
+for attempt in 1 2 3; do
+  git fetch -q origin main
+  if ! git rebase -q origin/main; then
+    git rebase --abort 2>/dev/null || true
+    exit 1
+  fi
+  git push -q origin HEAD:main && exit 0
+  sleep "$attempt"
+done
+exit 1
+SH
+chmod +x ~/.tokei/tokei-sync.sh
+# 每 5 分钟自动采集并同步，日志写入 ~/.tokei/sync.log
+(crontab -l 2>/dev/null | grep -v 'tokei-sync.sh'; echo '*/5 * * * * ~/.tokei/tokei-sync.sh >> ~/.tokei/sync.log 2>&1') | crontab -
 ```
 
 ## 数据来源

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -1839,24 +1839,38 @@ struct PanelView: View {
           git clone \(remote) ~/.tokei/sync
         fi
         curl -fsSL https://dl.lanshuagent.com/tokei/usage.30s.py -o ~/.tokei/usage.30s.py
-        cat > ~/.tokei/config.json <<'JSON'
+        cat > ~/.tokei/config.json <<JSON
         {"sync_dir":"~/.tokei/sync","device_id":"$(hostname -s)","auto_sync":true,"sync_interval":5}
         JSON
         cat > ~/.tokei/tokei-sync.sh <<'SH'
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
+        exec 9>"$HOME/.tokei/sync.lock"
+        flock -n 9 || exit 0
         cd "$HOME/.tokei/sync"
         python3 "$HOME/.tokei/usage.30s.py" --json >/dev/null
         git fetch -q origin main
         device_file=$(find . -maxdepth 1 -type f -iname "$(hostname -s).json" -print -quit)
         [ -n "$device_file" ] || device_file="./$(hostname -s).json"
+        for peer_file in ./*.json; do
+          [ "$peer_file" = "$device_file" ] && continue
+          git restore --staged --worktree -- "$peer_file" 2>/dev/null || true
+        done
         git add -- "$device_file"
-        git diff --cached --quiet || git commit -qm "sync $(hostname -s)"
-        git rebase -q origin/main
-        git push -q origin HEAD:main
+        git diff --cached --quiet || git commit -qm "chore(sync): 更新 $(hostname -s) 用量数据"
+        for attempt in 1 2 3; do
+          git fetch -q origin main
+          if ! git rebase -q origin/main; then
+            git rebase --abort 2>/dev/null || true
+            exit 1
+          fi
+          git push -q origin HEAD:main && exit 0
+          sleep "$attempt"
+        done
+        exit 1
         SH
         chmod +x ~/.tokei/tokei-sync.sh
-        (crontab -l 2>/dev/null | grep -v 'tokei-sync.sh'; echo '*/5 * * * * ~/.tokei/tokei-sync.sh') | crontab -
+        (crontab -l 2>/dev/null | grep -v 'tokei-sync.sh'; echo '*/5 * * * * ~/.tokei/tokei-sync.sh >> ~/.tokei/sync.log 2>&1') | crontab -
         """
     }
 

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -406,12 +406,28 @@ final class SyncManager {
             if [ -z "$device_file" ]; then
               device_file='./\(escapedDevice).json'
             fi
+            for peer_file in ./*.json; do
+              [ "$peer_file" = "$device_file" ] && continue
+              git restore --staged --worktree -- "$peer_file" 2>/dev/null || true
+            done
             git add -- "$device_file" || exit 1
             if ! git diff --cached --quiet; then
-              git commit -m 'tokei sync \(escapedDevice)' || exit 1
+              git commit -m 'chore(sync): 更新 \(escapedDevice) 用量数据' || exit 1
             fi
-            git rebase origin/main 2>/dev/null || exit 1
-            git push origin HEAD:main 2>/dev/null
+            attempt=1
+            while [ "$attempt" -le 3 ]; do
+              git fetch origin main 2>/dev/null || exit 1
+              if ! git rebase origin/main 2>/dev/null; then
+                git rebase --abort 2>/dev/null || true
+                exit 1
+              fi
+              if git push origin HEAD:main 2>/dev/null; then
+                exit 0
+              fi
+              sleep "$attempt"
+              attempt=$((attempt + 1))
+            done
+            exit 1
             """
             let proc = Process()
             proc.executableURL = URL(fileURLWithPath: "/bin/zsh")

--- a/tokei-collector-skill.md
+++ b/tokei-collector-skill.md
@@ -23,7 +23,7 @@ curl -sL https://raw.githubusercontent.com/<user>/tokei-sync/main/install.sh | b
 1. 克隆同步 Git 仓库到 `~/.tokei/sync/`
 2. 每 5 分钟执行 `usage.30s.py --json` 采集本机所有 AI 工具用量
 3. 写入 `~/.tokei/sync/<device-name>.json`
-4. 自动 `git pull && git add && git commit && git push`
+4. 仅提交本机 JSON，再通过 `git fetch + rebase + push` 重试同步，避免多设备并发分叉
 5. 本地 Tokei 从同一仓库读取,自动聚合所有设备数据
 
 ## 支持的工具
@@ -44,6 +44,6 @@ curl -sL https://raw.githubusercontent.com/<user>/tokei-sync/main/install.sh | b
 ## 卸载
 
 ```bash
-crontab -l | grep -v "tokei/sync.sh" | crontab -
+crontab -l | grep -v "tokei-sync.sh" | crontab -
 rm -rf ~/.tokei/
 ```


### PR DESCRIPTION
## 问题

多设备通过 Git 同步用量数据时存在几个可靠性问题：

- 旧版采集器可能重写其他设备 JSON，导致工作区存在非本机修改。
- Linux 文档中的命令在提交本机数据前执行 `git pull`，脏文件会直接阻塞同步。
- 多台设备同时推送时没有重试机制，容易产生分叉或推送失败。
- 设置页生成的 Linux 配置使用了禁止变量展开的 heredoc，设备名可能被写成字面量 `$(hostname -s)`。

## 改动

- Mac 和 Linux 同步时仅保留、提交本机 JSON。
- 推送前使用 `fetch + rebase`，并在并发推送失败时最多重试 3 次。
- rebase 冲突时自动中止，避免仓库长期停留在未完成状态。
- Linux 同步增加文件锁和日志，防止 cron 任务重叠。
- 修复 Linux 配置中的设备名展开。
- 更新 README 和 Collector Skill 的安装、同步及卸载说明。

## 验证

- `swift build`
- `python3 -m py_compile usage.30s.py`
- 隔离 HOME 后运行 Python 测试：38/38 通过
- README 中的同步脚本通过 `bash -n`
- 在 Hermes 远程主机验证最新版采集器只修改本机 JSON，同步仓库与远端差异为 0/0