### PR TITLE
feat(grok): 支持 Grok Build 真实 token 采集与展示

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -11,7 +11,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | Claude Code | `~/.claude/*/*.jsonl` | JSONL, `type=assistant` 行含 `message.usage` |
 | Codex | `~/.codex/**/rollout-*.jsonl` | JSONL, `payload.info.last_token_usage` |
 | Gemini CLI | `~/.gemini/*/chats/session-*.json` | JSON, `messages[].tokens` |
-| Grok CLI | `~/.grok/sessions/*/*/summary.json` + `updates.jsonl` | JSON, `_meta.totalTokens` |
+| Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl` + `sessions/*/*/{summary,signals}.json` | JSONL, `shell.turn.inference_done` + 会话指标 |
 | Qoder | `~/Library/Application Support/QoderWork/data/agents.db` | SQLite, `messages.metadata` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `sessions` 表 |
 | OpenClaw | `~/.openclaw/tasks/runs.sqlite` | SQLite, `task_runs` 表 |
@@ -95,7 +95,16 @@ Tokei 优先读取逐请求日志以获得进行中会话和小时分布。旧�
 按 `sessionId` 取最后一份快照,用于补齐逐请求日志出现前的历史。同一会话同时存在两种来源时,
 逐请求日志优先,避免重复累计。
 
-**Grok CLI** — 无输入/输出拆分,仅 `totalTokens`(上下文窗口累计,取最大值,非真实消耗量)。
+**Grok Build** — `unified.jsonl` 中每条 `shell.turn.inference_done` 是一次模型调用：
+- 输入 = `prompt_tokens - cached_prompt_tokens`
+- 缓存读 = `cached_prompt_tokens`
+- 输出 = `completion_tokens - reasoning_tokens`
+- 推理 = `reasoning_tokens`
+- 总量 = 输入 + 缓存读 + 输出 + 推理
+
+记录按自身 `ts` 归入日期和小时，并通过 `sid` 关联 `summary.json` 中的模型与项目路径。
+若没有真实 usage 日志，卡片会降级展示 `signals.json` / `updates.jsonl` 的上下文快照，
+但快照不会计入 Dashboard、Wrapped 或项目 token 总量。
 
 **Qoder** — `inputTokens` / `outputTokens` 目前全为 0,仅 `durationMs` 和 `contextUsageRatio` 有值。
 
@@ -107,7 +116,7 @@ Tokei 优先读取逐请求日志以获得进行中会话和小时分布。旧�
 
 两种公式,取决于 `input` 是否包含缓存:
 
-### Claude / Hermes / Pi / WorkBuddy / OpenCode / Qwen Code(input 不含缓存)
+### Claude / Grok Build / Hermes / Pi / WorkBuddy / OpenCode / Qwen Code(input 不含缓存)
 
 ```
 hit% = cache_read / (cache_read + cache_write + input) × 100
@@ -206,9 +215,10 @@ cost = non_cached_input/1M × price_in
 
 Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 直接使用消息 JSON 中的 `cost` 字段。若 Pi 成本字段缺失，则按统一价格表用 input/output/cache_read/cache_write 回退估算。
 
-### Grok / Qoder / OpenClaw
+### Grok Build / Qoder / OpenClaw
 
-不估算成本。
+不估算成本。Grok Build 的 OAuth/订阅交互日志通常没有完整成本，缺失值不视为 0 美元；
+只有 token 参与聚合和排行。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 | **Claude Code** | Token（输入/输出/缓存）、成本、配额、模型 |
 | **Codex CLI** | Token、成本、配额、会话 |
 | **Gemini CLI** | Token、思考量、成本、模型 |
-| **Grok CLI** | Token、会话、上下文 |
+| **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟 |
 | **Hermes** | Token、成本、缓存命中率、模型 |
 | **OpenClaw** | Token、成本、任务、模型 |
 | **Pi Coding Agent CLI** | Token、成本、缓存命中率、模型、项目 |
@@ -62,7 +62,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 - 随时切换，对比不同时段用量趋势
 
 ### 项目追踪
-- 按项目维度查看 Claude Code / Pi / WorkBuddy / Grok 用量
+- 按项目维度查看 Claude Code / Pi / WorkBuddy / Grok Build 用量
 - 了解每个项目消耗了多少 Token 和成本
 
 ### 多设备同步
@@ -126,7 +126,7 @@ echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/co
 | Claude Code | `~/.claude/projects/<proj>/<session>.jsonl` |
 | Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
 | Gemini CLI | `~/.gemini/gemini-cli/conversations/*.json` |
-| Grok CLI | `~/.grok/sessions/YYYY/MM/DD/*.jsonl` |
+| Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl` + `sessions/*/*/{summary,signals}.json` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + SQLite |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
@@ -255,7 +255,7 @@ Tokei is a **macOS menu bar app** that tracks usage, cost, and performance acros
 
 **Features:** Real-time monitoring (30s refresh, five menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local logs only) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 
-**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok CLI, Hermes, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, Qoder, QoderWork
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok Build, Hermes, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, Qoder, QoderWork
 
 For full documentation, visit [tokei.lanshuagent.com](https://tokei.lanshuagent.com).
 

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -29,6 +29,10 @@ struct DailyCost: Codable, Identifiable {
     var q_out: Int?
     var q_cr: Int?
     var q_reason: Int?
+    var g_in: Int?
+    var g_out: Int?
+    var g_cr: Int?
+    var g_reason: Int?
     var tokens: Int = 0
     var id: String { date }
 }
@@ -269,6 +273,18 @@ struct DashboardView: View {
                         .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
                     Text(String(format: "$%.2f", d.qwencode ?? 0))
                         .font(.system(size: 12, weight: .semibold, design: .monospaced)).foregroundStyle(Theme.tSecondary)
+                }
+                if (d.g_in ?? 0) + (d.g_out ?? 0) + (d.g_cr ?? 0) + (d.g_reason ?? 0) > 0 {
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 4) {
+                            Circle().fill(Theme.grok).frame(width: 6, height: 6)
+                            Text("Grok Build").font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.grok)
+                        }
+                        Text("\(Fmt.human((d.g_in ?? 0) + (d.g_out ?? 0) + (d.g_cr ?? 0) + (d.g_reason ?? 0))) tok")
+                            .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
+                        Text("成本未提供")
+                            .font(.system(size: 10, weight: .medium)).foregroundStyle(Theme.tTertiary)
+                    }
                 }
             }
         }
@@ -684,6 +700,10 @@ struct DashboardView: View {
                   q_out: (lhs.q_out ?? 0) + (rhs.q_out ?? 0),
                   q_cr: (lhs.q_cr ?? 0) + (rhs.q_cr ?? 0),
                   q_reason: (lhs.q_reason ?? 0) + (rhs.q_reason ?? 0),
+                  g_in: (lhs.g_in ?? 0) + (rhs.g_in ?? 0),
+                  g_out: (lhs.g_out ?? 0) + (rhs.g_out ?? 0),
+                  g_cr: (lhs.g_cr ?? 0) + (rhs.g_cr ?? 0),
+                  g_reason: (lhs.g_reason ?? 0) + (rhs.g_reason ?? 0),
                   tokens: lhs.tokens + rhs.tokens)
     }
 
@@ -786,9 +806,11 @@ struct DashboardView: View {
         }
 
         let grok = usage.grok.ranges.get(key)
-        let grokTokens = grok.ctx_used ?? grok.tokens
-        if grokTokens > 0 {
-            out.append(modelCost(name: usage.grok.model ?? "Grok CLI", cost: 0, tool: "grok", tokens: grokTokens))
+        if !grok.models.isEmpty {
+            appendTokenModels(grok.models, tool: "grok", suffix: "Grok Build", to: &out)
+        } else if grok.usage_available && grok.tokens > 0 {
+            out.append(modelCost(name: usage.grok.model ?? "Grok Build", cost: 0,
+                                 tool: "grok", tokens: grok.tokens))
         }
 
         let qoder = usage.qoder.ranges.get(key)
@@ -849,7 +871,7 @@ struct DashboardView: View {
         return claude.in + claude.out + claude.cr + claude.cw
             + codex.in + codex.cached + codex.out
             + gemini.in + gemini.cached + gemini.out + gemini.thoughts
-            + (grok.ctx_used ?? grok.tokens)
+            + (grok.usage_available ? grok.tokens : 0)
             + qoder.in + qoder.cached + qoder.out
             + hermesTotal(usage.hermes.ranges.get(key))
             + tokenUsageTotal(usage.zcode.ranges.get(key))

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -202,6 +202,16 @@ struct GeminiStat: Codable {
 
 struct GrokRange: Codable {
     var tokens: Int
+    var hit: Double
+    var `in`: Int
+    var out: Int
+    var cr: Int
+    var reason: Int
+    var cost: Double
+    var models: [TokenModelStat]
+    var usage_available: Bool
+    var usage_calls: Int
+    var usage_sessions: Int
     var sessions: Int = 0
     var turns: Int?
     var tools: Int?
@@ -213,6 +223,64 @@ struct GrokRange: Codable {
     var cancellations: Int?
     var ttft: Int?
     var response: Int?
+
+    init(tokens: Int = 0, hit: Double = 0, `in` input: Int = 0, out: Int = 0,
+         cr: Int = 0, reason: Int = 0, cost: Double = 0,
+         models: [TokenModelStat] = [], usage_available: Bool = false,
+         usage_calls: Int = 0, usage_sessions: Int = 0, sessions: Int = 0,
+         turns: Int? = nil, tools: Int? = nil, duration: Int? = nil,
+         ctx_used: Int? = nil, ctx_window: Int? = nil, ctx: Double? = nil,
+         errors: Int? = nil, cancellations: Int? = nil, ttft: Int? = nil,
+         response: Int? = nil) {
+        self.tokens = tokens
+        self.hit = hit
+        self.in = input
+        self.out = out
+        self.cr = cr
+        self.reason = reason
+        self.cost = cost
+        self.models = models
+        self.usage_available = usage_available
+        self.usage_calls = usage_calls
+        self.usage_sessions = usage_sessions
+        self.sessions = sessions
+        self.turns = turns
+        self.tools = tools
+        self.duration = duration
+        self.ctx_used = ctx_used
+        self.ctx_window = ctx_window
+        self.ctx = ctx
+        self.errors = errors
+        self.cancellations = cancellations
+        self.ttft = ttft
+        self.response = response
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        tokens = try c.decodeIfPresent(Int.self, forKey: .tokens) ?? 0
+        hit = try c.decodeIfPresent(Double.self, forKey: .hit) ?? 0
+        `in` = try c.decodeIfPresent(Int.self, forKey: .in) ?? 0
+        out = try c.decodeIfPresent(Int.self, forKey: .out) ?? 0
+        cr = try c.decodeIfPresent(Int.self, forKey: .cr) ?? 0
+        reason = try c.decodeIfPresent(Int.self, forKey: .reason) ?? 0
+        cost = try c.decodeIfPresent(Double.self, forKey: .cost) ?? 0
+        models = try c.decodeIfPresent([TokenModelStat].self, forKey: .models) ?? []
+        usage_available = try c.decodeIfPresent(Bool.self, forKey: .usage_available) ?? false
+        usage_calls = try c.decodeIfPresent(Int.self, forKey: .usage_calls) ?? 0
+        usage_sessions = try c.decodeIfPresent(Int.self, forKey: .usage_sessions) ?? 0
+        sessions = try c.decodeIfPresent(Int.self, forKey: .sessions) ?? 0
+        turns = try c.decodeIfPresent(Int.self, forKey: .turns)
+        tools = try c.decodeIfPresent(Int.self, forKey: .tools)
+        duration = try c.decodeIfPresent(Int.self, forKey: .duration)
+        ctx_used = try c.decodeIfPresent(Int.self, forKey: .ctx_used)
+        ctx_window = try c.decodeIfPresent(Int.self, forKey: .ctx_window)
+        ctx = try c.decodeIfPresent(Double.self, forKey: .ctx)
+        errors = try c.decodeIfPresent(Int.self, forKey: .errors)
+        cancellations = try c.decodeIfPresent(Int.self, forKey: .cancellations)
+        ttft = try c.decodeIfPresent(Int.self, forKey: .ttft)
+        response = try c.decodeIfPresent(Int.self, forKey: .response)
+    }
 }
 
 struct GrokRanges: Codable {

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -8,6 +8,7 @@ struct PanelView: View {
     @State private var claudeModelsOpen = false
     @State private var codexModelsOpen = false
     @State private var geminiModelsOpen = false
+    @State private var grokModelsOpen = false
     @State private var zcodeModelsOpen = false
     @State private var mimocodeModelsOpen = false
     @State private var piModelsOpen = false
@@ -231,7 +232,7 @@ struct PanelView: View {
                          tint: Theme.codex, content: AnyView(codexBlock(u.codex, xr))),
             ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini, active: gr.sessions > 0,
                          tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
-            ToolCardItem(id: "grok", name: "Grok", visible: showGrok, active: kr.sessions > 0,
+            ToolCardItem(id: "grok", name: "Grok Build", visible: showGrok, active: kr.sessions > 0,
                          tint: Theme.grok, content: AnyView(grokBlock(kr, model: u.grok.model))),
             ToolCardItem(id: "qoder", name: "Qoder", visible: showQoder, active: qr.calls > 0,
                          tint: Theme.qoder, content: AnyView(qoderIdeBlock(u.qoder, qr))),
@@ -392,14 +393,24 @@ struct PanelView: View {
     @ViewBuilder
     func grokBlock(_ r: GrokRange, model: String?) -> some View {
         VStack(alignment: .leading, spacing: 11) {
-            cardHeadPlain("Grok CLI", tint: Theme.grok)
+            cardHead("Grok Build", tint: Theme.grok, sessions: r.sessions)
             if r.sessions > 0 {
-                CostHeadline(value: Fmt.human(r.ctx_used ?? r.tokens), caption: "\(sel.label) 总量", tint: Theme.grok)
-                metricGrid({
-                    var items: [Metric] = [
+                CostHeadline(value: Fmt.human(r.tokens),
+                             caption: r.usage_available ? "\(sel.label) 真实用量" : "\(sel.label) 上下文快照",
+                             tint: Theme.grok)
+                let grokMetrics: [Metric] = {
+                    var items: [Metric] = []
+                    if r.usage_available {
+                        items.append(.init("arrow.down", "输入", Fmt.human(r.in)))
+                        items.append(.init("bolt.fill", "缓存读", Fmt.human(r.cr)))
+                        items.append(.init("arrow.up", "输出", Fmt.human(r.out)))
+                        if r.reason > 0 { items.append(.init("brain", "推理", Fmt.human(r.reason))) }
+                        items.append(.init("waveform", "调用", "\(r.usage_calls)"))
+                    }
+                    items.append(contentsOf: [
                         .init("arrow.triangle.2.circlepath", "轮次", "\(r.turns ?? 0)"),
                         .init("wrench.and.screwdriver", "工具", "\(r.tools ?? 0)"),
-                    ]
+                    ])
                     if let duration = r.duration, duration > 0 {
                         items.append(.init("clock", "耗时", Fmt.duration(duration * 1000)))
                     }
@@ -419,11 +430,17 @@ struct PanelView: View {
                         items.append(.init("xmark.circle", "取消", "\(r.cancellations ?? 0)"))
                     }
                     return items
-                }(), tint: Theme.grok)
-                if let model, !model.isEmpty {
+                }()
+                metricGrid([], hit: r.usage_available ? r.hit : 0,
+                           extra: grokMetrics, tint: Theme.grok)
+                if r.usage_available && !r.models.isEmpty {
+                    tokenModelDisclosure(r.models, open: $grokModelsOpen, tint: Theme.grok)
+                } else if let model, !model.isEmpty {
                     modelBadge(model, tint: Theme.grok)
                 }
-                Text("Grok CLI 本地日志没有保存 input/output usage,这里展示上下文与执行指标。")
+                Text(r.usage_available
+                     ? "来自 Grok Build 本地推理日志；成本未提供。"
+                     : "未找到真实 usage 日志，当前仅展示上下文与执行指标。")
                     .font(.system(size: 8.5))
                     .foregroundStyle(Theme.tTertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -686,7 +703,7 @@ struct PanelView: View {
         }
     }
 
-    // 无命中环的卡头(Grok 无缓存命中数据)。
+    // 无命中环的简化卡头。
     func cardHeadPlain(_ title: String, tint: Color) -> some View {
         HStack(spacing: 7) {
             Circle().fill(tint.gradient).frame(width: 8, height: 8)
@@ -805,6 +822,7 @@ struct PanelView: View {
                         .buttonStyle(.plain)
                         if isExpanded {
                             modelDetailRow(tokIn: m.in, tokOut: m.out, tokCR: m.cr, tokCW: m.cw,
+                                           tokReason: m.reason,
                                            pin: m.pin, pout: m.pout, hit: hit, tint: tint)
                         }
                     }
@@ -891,7 +909,7 @@ struct PanelView: View {
     }
 
     @ViewBuilder
-    func modelDetailRow(tokIn: Int, tokOut: Int, tokCR: Int, tokCW: Int,
+    func modelDetailRow(tokIn: Int, tokOut: Int, tokCR: Int, tokCW: Int, tokReason: Int = 0,
                          pin: Double, pout: Double, hit: Double = 0, tint: Color) -> some View {
         let tagFont = Font.system(size: 9, weight: .medium, design: .monospaced)
         let labelFont = Font.system(size: 8.5)
@@ -908,6 +926,9 @@ struct PanelView: View {
                 if tokCW > 0 {
                     detailTag("✎ \(Fmt.human(tokCW))", label: "缓存写", tagFont: tagFont, labelFont: labelFont, bg: bg, border: border)
                 }
+                if tokReason > 0 {
+                    detailTag("◉ \(Fmt.human(tokReason))", label: "推理", tagFont: tagFont, labelFont: labelFont, bg: bg, border: border)
+                }
                 if hit > 0 {
                     HStack(spacing: 2) {
                         Text("命中").font(labelFont).foregroundStyle(Theme.tTertiary)
@@ -917,14 +938,16 @@ struct PanelView: View {
                     .background(Capsule().fill(bg))
                     .overlay(Capsule().strokeBorder(border, lineWidth: 0.5))
                 }
-                HStack(spacing: 2) {
-                    Text("$").font(tagFont).foregroundStyle(tint)
-                    Text("\(String(format: "%.2g", pin))/\(String(format: "%.2g", pout))")
-                        .font(tagFont).foregroundStyle(tint)
+                if pin > 0 || pout > 0 {
+                    HStack(spacing: 2) {
+                        Text("$").font(tagFont).foregroundStyle(tint)
+                        Text("\(String(format: "%.2g", pin))/\(String(format: "%.2g", pout))")
+                            .font(tagFont).foregroundStyle(tint)
+                    }
+                    .padding(.horizontal, 6).padding(.vertical, 2.5)
+                    .background(Capsule().fill(tint.opacity(0.12)))
+                    .overlay(Capsule().strokeBorder(tint.opacity(0.25), lineWidth: 0.5))
                 }
-                .padding(.horizontal, 6).padding(.vertical, 2.5)
-                .background(Capsule().fill(tint.opacity(0.12)))
-                .overlay(Capsule().strokeBorder(tint.opacity(0.25), lineWidth: 0.5))
             }
         }
         .padding(.top, 5).padding(.bottom, 2)
@@ -1240,7 +1263,7 @@ struct PanelView: View {
                 settingsRow("Claude", tint: Theme.claude, isOn: $showClaude)
                 settingsRow("Codex", tint: Theme.codex, isOn: $showCodex)
                 settingsRow("Gemini", tint: Theme.gemini, isOn: $showGemini)
-                settingsRow("Grok", tint: Theme.grok, isOn: $showGrok)
+                settingsRow("Grok Build", tint: Theme.grok, isOn: $showGrok)
                 settingsRow("Qoder", tint: Theme.qoder, isOn: $showQoder)
                 settingsRow("QoderWork", tint: Theme.qoderwork, isOn: $showQoderWork)
                 settingsRow("Hermes", tint: Theme.hermes, isOn: $showHermes)

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -233,7 +233,18 @@ final class SyncManager {
             var d = dst.get(pair.dst), s = src.get(pair.src)
             let originalLatencyWeight = max(d.turns ?? 0, d.sessions)
             let sourceLatencyWeight = max(s.turns ?? 0, s.sessions)
-            d.tokens += s.tokens; d.sessions += s.sessions
+            d.in += s.in; d.out += s.out; d.cr += s.cr; d.reason += s.reason
+            d.cost += s.cost
+            d.usage_available = d.usage_available || s.usage_available
+            d.usage_calls += s.usage_calls; d.usage_sessions += s.usage_sessions
+            if d.usage_available {
+                d.tokens = d.in + d.out + d.cr + d.reason
+            } else {
+                d.tokens += s.tokens
+            }
+            d.hit = hitRate(cached: d.cr, input: d.in)
+            mergeTokenModels(&d.models, s.models)
+            d.sessions += s.sessions
             d.turns = add(d.turns, s.turns)
             d.tools = add(d.tools, s.tools)
             d.duration = add(d.duration, s.duration)

--- a/site/index.html
+++ b/site/index.html
@@ -922,8 +922,8 @@ body::after{
       </div>
       <div class="tool-card rv rv-d4" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--silver),#888)"><span style="color:#222">Gk</span></div>
-        <h3>Grok</h3>
-        <p><span class="en">Session tracking</span><span class="zh">会话追踪</span></p>
+        <h3>Grok Build</h3>
+        <p><span class="en">Tokens, cache, reasoning, sessions</span><span class="zh">Token · 缓存 · 推理 · 会话</span></p>
       </div>
       <div class="tool-card rv rv-d5" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--amber),#C49A30)">Qo</div>

--- a/tests/test_grok_usage.py
+++ b/tests/test_grok_usage.py
@@ -1,0 +1,193 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+from urllib.parse import quote
+
+from test_codex_limits import USAGE
+
+
+def write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def append_jsonl(path, records):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        for record in records:
+            file.write(json.dumps(record) + "\n")
+
+
+def usage_line(sid, timestamp, loop, prompt, cached, completion, reasoning):
+    return {
+        "ts": timestamp,
+        "msg": "shell.turn.inference_done",
+        "sid": sid,
+        "ctx": {
+            "loop_index": loop,
+            "prompt_tokens": prompt,
+            "cached_prompt_tokens": cached,
+            "completion_tokens": completion,
+            "reasoning_tokens": reasoning,
+        },
+    }
+
+
+class GrokUsageTests(unittest.TestCase):
+    def setUp(self):
+        self.old_home = USAGE.GROK_HOME
+        self.old_dir = USAGE.GROK_DIR
+        self.old_log = USAGE.GROK_LOG
+        self.old_cache = USAGE._SCAN_CACHE_FILE
+
+    def tearDown(self):
+        USAGE.GROK_HOME = self.old_home
+        USAGE.GROK_DIR = self.old_dir
+        USAGE.GROK_LOG = self.old_log
+        USAGE._SCAN_CACHE_FILE = self.old_cache
+
+    def configure(self, root):
+        USAGE.GROK_HOME = str(root)
+        USAGE.GROK_DIR = str(root / "sessions")
+        USAGE.GROK_LOG = str(root / "logs" / "unified.jsonl")
+        USAGE._SCAN_CACHE_FILE = str(root / "scan-cache.json")
+
+    def create_session(self, root, sid, project, timestamp, with_signals=True):
+        session = root / "sessions" / quote(project, safe="") / sid
+        session.mkdir(parents=True)
+        write_json(session / "summary.json", {
+            "info": {"id": sid},
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "current_model_id": "grok-4.5",
+        })
+        if with_signals:
+            write_json(session / "signals.json", {
+                "turnCount": 3,
+                "toolCallCount": 2,
+                "sessionDurationSeconds": 60,
+                "contextTokensUsed": 1000,
+                "contextWindowTokens": 10000,
+                "errorCount": 0,
+                "toolFailureCount": 0,
+                "cancellationCount": 0,
+                "latencySampleCount": 2,
+                "avgTimeToFirstTokenMs": 500,
+                "avgResponseTimeMs": 1500,
+            })
+        append_jsonl(session / "events.jsonl", [
+            {"type": "turn_started"},
+            {"type": "turn_ended", "outcome": "completed"},
+            {"type": "turn_ended", "outcome": "cancelled"},
+            {"type": "turn_ended", "outcome": "error"},
+        ])
+        return session
+
+    def test_real_usage_is_split_deduplicated_and_cached(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".grok"
+            self.configure(root)
+            now = datetime.now().astimezone().replace(microsecond=0).isoformat()
+            sid = "019f-test-session"
+            self.create_session(root, sid, "/tmp/grok-project", now)
+            log = root / "logs" / "unified.jsonl"
+            first = usage_line(sid, now, 1, 1000, 800, 100, 30)
+            second = usage_line(sid, now, 2, 500, 100, 50, 10)
+            append_jsonl(log, [first, first, second])
+
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            result = USAGE.scan_grok(USAGE.range_bounds(), cache)
+            with mock.patch.object(
+                USAGE, "_grok_usage_record",
+                side_effect=AssertionError("unchanged Grok log was reparsed"),
+            ):
+                cached = USAGE.scan_grok(USAGE.range_bounds(), cache)
+
+            later = (datetime.now().astimezone() + timedelta(seconds=1)).replace(microsecond=0).isoformat()
+            append_jsonl(log, [usage_line(sid, later, 3, 200, 150, 20, 5)])
+            appended = USAGE.scan_grok(USAGE.range_bounds(), cache)
+
+        usage = result["ranges"]["all"]
+        self.assertEqual(usage["in"], 600)
+        self.assertEqual(usage["cr"], 900)
+        self.assertEqual(usage["out"], 110)
+        self.assertEqual(usage["reason"], 40)
+        self.assertEqual(usage["usage_calls"], 2)
+        self.assertEqual(usage["usage_sessions"], {sid})
+        self.assertEqual(usage["sessions"], {sid})
+        self.assertEqual(usage["errors"], 1)
+        self.assertEqual(usage["cancellations"], 1)
+        self.assertEqual(cached["ranges"]["all"]["usage_calls"], 2)
+        self.assertEqual(appended["ranges"]["all"]["usage_calls"], 3)
+        self.assertEqual(len(cache["grok_usage"]["entries"]), 3)
+        self.assertEqual(usage["models"]["grok-4.5"]["in"], 600)
+
+    def test_daily_wrapped_and_projects_use_real_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".grok"
+            self.configure(root)
+            now = datetime.now().astimezone().replace(microsecond=0)
+            timestamp = now.isoformat()
+            day = now.date().isoformat()
+            sid = "019f-project-session"
+            project = "/tmp/grok-build-project"
+            self.create_session(root, sid, project, timestamp, with_signals=False)
+            entry = USAGE._grok_usage_record(usage_line(sid, timestamp, 1, 1000, 800, 100, 30))
+            cache = {
+                "v": USAGE._SCAN_CACHE_VERSION,
+                "grok_usage": {"entries": [entry]},
+            }
+            Path(USAGE._SCAN_CACHE_FILE).write_text(json.dumps(cache), encoding="utf-8")
+
+            daily = USAGE.build_daily_costs("all", refresh=False)
+            wrapped = USAGE.build_wrapped("all", refresh=False)
+            output = io.StringIO()
+            with mock.patch.object(USAGE, "compute"), contextlib.redirect_stdout(output):
+                USAGE.projects()
+            projects = json.loads(output.getvalue())
+
+        self.assertEqual(daily["daily"][0]["date"], day)
+        self.assertEqual(daily["daily"][0]["g_in"], 200)
+        self.assertEqual(daily["daily"][0]["g_cr"], 800)
+        self.assertEqual(daily["daily"][0]["g_out"], 70)
+        self.assertEqual(daily["daily"][0]["g_reason"], 30)
+        self.assertEqual(daily["daily"][0]["tokens"], 1100)
+        self.assertEqual(daily["models"][0]["tool"], "grok")
+        self.assertEqual(wrapped["total_tokens"], 1100)
+        self.assertEqual(wrapped["hours"][now.hour], 1100)
+        project_row = next(row for row in projects if row["path"] == project)
+        self.assertEqual(project_row["sessions"], 1)
+        self.assertEqual(project_row["tokens"], 1100)
+        self.assertEqual(project_row["top_model"], "Grok 4.5 (Grok Build)")
+
+    def test_usage_is_classified_by_inference_timestamp_not_session_update(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".grok"
+            self.configure(root)
+            now = datetime.now().astimezone().replace(microsecond=0)
+            yesterday = now - timedelta(days=1)
+            sid = "019f-cross-day-session"
+            self.create_session(root, sid, "/tmp/cross-day", now.isoformat(), with_signals=False)
+            append_jsonl(root / "logs" / "unified.jsonl", [
+                usage_line(sid, yesterday.isoformat(), 1, 2000, 1000, 200, 50),
+                usage_line(sid, now.isoformat(), 2, 1000, 800, 100, 30),
+            ])
+
+            result = USAGE.scan_grok(USAGE.range_bounds(), {"v": USAGE._SCAN_CACHE_VERSION})
+
+        today = result["ranges"]["today"]
+        previous = result["ranges"]["yesterday"]
+        self.assertEqual(today["in"] + today["cr"] + today["out"] + today["reason"], 1100)
+        self.assertEqual(previous["in"] + previous["cr"] + previous["out"] + previous["reason"], 2200)
+        self.assertEqual(today["usage_sessions"], {sid})
+        self.assertEqual(previous["usage_sessions"], {sid})
+        self.assertEqual(today["sessions"], {sid})
+        self.assertEqual(previous["sessions"], {sid})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -77,7 +77,10 @@ GEMINI_DIR = os.path.join(HOME, ".gemini", "tmp")
 GEMINI_DIRS = _path_candidates(
     "TOKEI_GEMINI_DIR", GEMINI_DIR,
     os.path.join(HOME, ".gemini", "gemini-cli", "conversations"))
-GROK_DIR = os.path.join(HOME, ".grok", "sessions")
+GROK_HOME = os.path.abspath(os.path.expanduser(
+    os.environ.get("GROK_HOME", os.path.join(HOME, ".grok"))))
+GROK_DIR = os.path.join(GROK_HOME, "sessions")
+GROK_LOG = os.path.join(GROK_HOME, "logs", "unified.jsonl")
 WORKBUDDY_DIR = os.path.join(HOME, ".workbuddy", "projects")
 QODER_IDE_DB = os.path.join(HOME, "Library", "Application Support", "Qoder",
                             "SharedClientCache", "cache", "db", "local.db")
@@ -404,7 +407,7 @@ def human(n: float) -> str:
 # ---------- 增量扫描缓存 ----------
 import tempfile as _tempfile
 _SCAN_CACHE_FILE = os.path.join(_tempfile.gettempdir(), "_tokei_scan_cache.json")
-_SCAN_CACHE_VERSION = 16
+_SCAN_CACHE_VERSION = 17
 
 
 def _load_scan_cache():
@@ -462,7 +465,9 @@ def _empty_gemini():
 
 
 def _empty_grok():
-    ranges = {k: {"tokens": 0, "sessions": set(), "turns": 0, "tools": 0,
+    ranges = {k: {"tokens": 0, "in": 0, "out": 0, "cr": 0, "reason": 0,
+                  "cost": 0.0, "models": {}, "usage_sessions": set(), "usage_calls": 0,
+                  "sessions": set(), "turns": 0, "tools": 0,
                   "duration": 0, "ctx_used": 0, "ctx_window": 0, "errors": 0,
                   "cancellations": 0, "ttft_sum": 0, "response_sum": 0, "latency_count": 0}
               for k in RANGE_KEYS}
@@ -583,10 +588,10 @@ def _merge_token_day(bucket, day, session=None):
                          mv.get("cr", 0), mv.get("cw", 0), mv.get("reason", 0), mv.get("cost", 0))
 
 
-def _format_token_models(models):
+def _format_token_models(models, include_prices=True):
     result = []
     for n, v in sorted(models.items(), key=lambda kv: -kv[1].get("cost", 0)):
-        price_id = _pricing_id(n)
+        price_id = _pricing_id(n) if include_prices else None
         p = _raw_price(price_id) if price_id else {
             "in": 0.0, "out": 0.0, "cache_read": 0.0, "cache_write": 0.0}
         result.append({"name": nice_model(n), "in": v.get("in", 0), "out": v.get("out", 0),
@@ -1597,32 +1602,144 @@ def scan_gemini(bounds, cache):
     return {"ranges": B}
 
 
-# ---------- Grok CLI ----------
+# ---------- Grok Build ----------
 # 日志:~/.grok/sessions/<cwd>/<uuid>/{summary.json,signals.json,events.jsonl,updates.jsonl}
-# 当前 Grok CLI 本地日志未落 prompt_tokens/completion_tokens usage;官方 API 响应有 usage。
-# 这里展示 Grok 本地可验证的上下文、轮次、工具、耗时和延迟,不估真实消耗成本。
-def scan_grok(bounds):
-    B = {k: {"tokens": 0, "sessions": set(), "turns": 0, "tools": 0,
-             "duration": 0, "ctx_used": 0, "ctx_window": 0, "errors": 0,
-             "cancellations": 0, "ttft_sum": 0, "response_sum": 0, "latency_count": 0}
-         for k in RANGE_KEYS}
+# Grok Build TUI 会把每次推理的真实 token 记入 logs/unified.jsonl；会话目录提供模型、
+# 项目、上下文和运行指标。OAuth/订阅路径通常不落完整成本，因此只统计 token，不估价。
+def _grok_log_signature(path):
+    try:
+        st = os.stat(path)
+        return {"dev": st.st_dev, "ino": st.st_ino, "size": st.st_size,
+                "mtime_ns": st.st_mtime_ns}
+    except OSError:
+        return None
+
+
+def _grok_usage_record(obj):
+    if obj.get("msg") != "shell.turn.inference_done":
+        return None
+    ctx = obj.get("ctx") or {}
+    if not isinstance(ctx, dict):
+        return None
+    sid = str(obj.get("sid") or "")
+    ts = str(obj.get("ts") or "")
+    dt = parse_ts(ts)
+    if not sid or dt is None:
+        return None
+    try:
+        prompt = max(int(ctx.get("prompt_tokens") or 0), 0)
+        cached = max(int(ctx.get("cached_prompt_tokens") or 0), 0)
+        completion = max(int(ctx.get("completion_tokens") or 0), 0)
+        reasoning = max(int(ctx.get("reasoning_tokens") or 0), 0)
+    except (TypeError, ValueError):
+        return None
+    cached = min(cached, prompt)
+    reasoning = min(reasoning, completion)
+    try:
+        loop_index = int(ctx.get("loop_index") or 0)
+    except (TypeError, ValueError):
+        loop_index = 0
+    record_id = f"{sid}:{ts}:{loop_index}:{prompt}:{cached}:{completion}:{reasoning}"
+    return {"id": record_id, "ts": ts, "sid": sid, "loop": loop_index,
+            "in": prompt - cached, "cr": cached,
+            "out": completion - reasoning, "reason": reasoning}
+
+
+def _load_grok_usage_entries(cache=None):
+    signature = _grok_log_signature(GROK_LOG)
+    if signature is None:
+        if cache is not None and cache.pop("grok_usage", None) is not None:
+            cache["_dirty"] = True
+        return []
+
+    old = cache.get("grok_usage", {}) if cache is not None else {}
+    same_file = old.get("dev") == signature["dev"] and old.get("ino") == signature["ino"]
+    old_offset = int(old.get("offset", 0) or 0)
+    can_append = same_file and signature["size"] >= old_offset
+    if (can_append and old.get("size") == signature["size"]
+            and old.get("mtime_ns") == signature["mtime_ns"]):
+        return old.get("entries", [])
+
+    entries = list(old.get("entries", [])) if can_append else []
+    offset = old_offset if can_append else 0
+    seen = {entry.get("id") for entry in entries if entry.get("id")}
+    try:
+        with open(GROK_LOG, "rb") as fh:
+            fh.seek(offset)
+            while True:
+                line_start = fh.tell()
+                raw = fh.readline()
+                if not raw:
+                    break
+                if not raw.endswith(b"\n"):
+                    offset = line_start
+                    break
+                offset = fh.tell()
+                try:
+                    obj = json.loads(raw.decode("utf-8", errors="ignore"))
+                except Exception:
+                    continue
+                record = _grok_usage_record(obj)
+                if record and record["id"] not in seen:
+                    entries.append(record)
+                    seen.add(record["id"])
+    except OSError:
+        return entries
+
+    if cache is not None:
+        updated = {**signature, "offset": offset, "entries": entries}
+        if updated != old:
+            cache["grok_usage"] = updated
+            cache["_dirty"] = True
+    return entries
+
+
+def _grok_session_metadata():
+    sessions = {}
     latest_mtime = -1.0
     latest_model = None
     if not os.path.isdir(GROK_DIR):
-        return {"ranges": B, "model": None}
+        return sessions, latest_model
     for sm in glob.glob(os.path.join(GROK_DIR, "*", "*", "summary.json")):
         try:
-            mtime = os.path.getmtime(sm)
-        except OSError:
-            continue
-        try:
             with open(sm, "r", encoding="utf-8", errors="ignore") as fh:
-                s = json.load(fh)
+                summary = json.load(fh)
+            sid = str((summary.get("info") or {}).get("id") or os.path.basename(os.path.dirname(sm)))
+            group_dir = os.path.dirname(os.path.dirname(sm))
+            cwd_encoded = os.path.basename(group_dir)
+            from urllib.parse import unquote
+            project = unquote(cwd_encoded)
+            cwd_file = os.path.join(group_dir, ".cwd")
+            if os.path.isfile(cwd_file):
+                try:
+                    with open(cwd_file, "r", encoding="utf-8", errors="ignore") as fh:
+                        project = fh.read().strip() or project
+                except OSError:
+                    pass
+            model = summary.get("current_model_id")
+            sessions[sid] = {"summary": summary, "path": sm,
+                             "project": project if project.startswith("/") else "",
+                             "model": model}
+            mtime = os.path.getmtime(sm)
+            if mtime > latest_mtime:
+                latest_mtime = mtime
+                latest_model = model
         except Exception:
             continue
-        if mtime > latest_mtime:
-            latest_mtime = mtime
-            latest_model = s.get("current_model_id")
+    return sessions, latest_model
+
+
+def scan_grok(bounds, cache=None):
+    B = {k: {"tokens": 0, "in": 0, "out": 0, "cr": 0, "reason": 0,
+             "cost": 0.0, "models": {}, "usage_sessions": set(), "usage_calls": 0,
+             "sessions": set(), "turns": 0, "tools": 0,
+             "duration": 0, "ctx_used": 0, "ctx_window": 0, "errors": 0,
+             "cancellations": 0, "ttft_sum": 0, "response_sum": 0, "latency_count": 0}
+         for k in RANGE_KEYS}
+    sessions, latest_model = _grok_session_metadata()
+    for sid, meta in sessions.items():
+        sm = meta["path"]
+        s = meta["summary"]
         dt = parse_ts(s.get("updated_at") or s.get("created_at") or "")
         if dt is None:
             continue
@@ -1654,7 +1771,8 @@ def scan_grok(bounds):
         except OSError:
             pass
 
-        event_turns = event_tools = event_duration = event_errors = event_cancellations = 0
+        event_turns = event_tools = event_duration = 0
+        event_tool_errors = event_turn_errors = event_cancellations = 0
         ej = os.path.join(os.path.dirname(sm), "events.jsonl")
         try:
             with open(ej, "r", encoding="utf-8", errors="ignore") as fh:
@@ -1670,9 +1788,12 @@ def scan_grok(bounds):
                         event_tools += 1
                         event_duration += int(e.get("duration_ms") or 0)
                         if e.get("outcome") not in (None, "success"):
-                            event_errors += 1
-                    elif typ == "turn_ended" and e.get("outcome") not in (None, "completed"):
-                        event_cancellations += 1
+                            event_tool_errors += 1
+                    elif typ == "turn_ended":
+                        if e.get("outcome") == "cancelled":
+                            event_cancellations += 1
+                        elif e.get("outcome") == "error":
+                            event_turn_errors += 1
         except OSError:
             pass
 
@@ -1681,17 +1802,15 @@ def scan_grok(bounds):
         duration = int(sig.get("sessionDurationSeconds") or 0)
         ctx_used = int(sig.get("contextTokensUsed") or mx or 0)
         ctx_window = int(sig.get("contextWindowTokens") or 0)
-        errors = int(sig.get("errorCount") or 0) + int(sig.get("toolFailureCount") or event_errors or 0)
-        cancellations = int(sig.get("cancellationCount") or event_cancellations or 0)
+        signal_errors = int(sig.get("errorCount") or 0) + int(sig.get("toolFailureCount") or 0)
+        errors = max(signal_errors, event_turn_errors, event_tool_errors)
+        cancellations = max(int(sig.get("cancellationCount") or 0), event_cancellations)
         latency_count = int(sig.get("latencySampleCount") or turns or 0)
         ttft_sum = int(sig.get("avgTimeToFirstTokenMs") or 0) * latency_count
         response_sum = int(sig.get("avgResponseTimeMs") or 0) * latency_count
-        token_proxy = ctx_used or mx
 
-        sid = (s.get("info") or {}).get("id") or sm
         for k in ks:
             b = B[k]
-            b["tokens"] += token_proxy
             b["sessions"].add(sid)
             b["turns"] += turns
             b["tools"] += tools
@@ -1703,6 +1822,28 @@ def scan_grok(bounds):
             b["ttft_sum"] += ttft_sum
             b["response_sum"] += response_sum
             b["latency_count"] += latency_count
+
+    for entry in _load_grok_usage_entries(cache):
+        dt = parse_ts(entry.get("ts") or "")
+        if dt is None:
+            continue
+        ks = classify(dt.astimezone(), bounds)
+        if not ks:
+            continue
+        sid = entry.get("sid") or ""
+        model = (sessions.get(sid) or {}).get("model") or latest_model or "grok"
+        for k in ks:
+            b = B[k]
+            b["in"] += entry.get("in", 0)
+            b["out"] += entry.get("out", 0)
+            b["cr"] += entry.get("cr", 0)
+            b["reason"] += entry.get("reason", 0)
+            b["usage_calls"] += 1
+            if sid:
+                b["usage_sessions"].add(sid)
+                b["sessions"].add(sid)
+            _add_model_usage(b["models"], model, entry.get("in", 0), entry.get("out", 0),
+                             entry.get("cr", 0), 0, entry.get("reason", 0), 0.0)
     return {"ranges": B, "model": latest_model}
 
 
@@ -3372,7 +3513,7 @@ def compute():
     cc = _safe_scan("claude", lambda: scan_claude(bounds, cache), _empty_claude, errors)
     cx = _safe_scan("codex", lambda: scan_codex(bounds, cache), _empty_codex, errors)
     gm = _safe_scan("gemini", lambda: scan_gemini(bounds, cache), _empty_gemini, errors)
-    gk = _safe_scan("grok", lambda: scan_grok(bounds), _empty_grok, errors)
+    gk = _safe_scan("grok", lambda: scan_grok(bounds, cache), _empty_grok, errors)
     qd = _safe_scan("qoderwork", lambda: scan_qoder(bounds, cache), _empty_qoder, errors)
     qi = _safe_scan("qoder_ide", lambda: scan_qoder_ide(bounds, cache), _empty_qoder_ide, errors)
     hm = _safe_scan("hermes", lambda: scan_hermes(bounds, cache), _empty_hermes, errors)
@@ -3421,7 +3562,20 @@ def compute():
         latency_count = b.get("latency_count", 0)
         ctx_window = b.get("ctx_window", 0)
         ctx_pct = (b.get("ctx_used", 0) / ctx_window * 100) if ctx_window else 0.0
-        return {"tokens": b.get("tokens", 0), "sessions": len(b.get("sessions", [])),
+        usage_total = sum(b.get(key, 0) for key in ("in", "out", "cr", "reason"))
+        usage_available = b.get("usage_calls", 0) > 0
+        input_total = b.get("in", 0) + b.get("cr", 0)
+        hit = (b.get("cr", 0) / input_total * 100) if input_total else 0.0
+        return {"tokens": usage_total if usage_available else b.get("ctx_used", 0),
+                "hit": hit,
+                "in": b.get("in", 0), "out": b.get("out", 0),
+                "cr": b.get("cr", 0), "reason": b.get("reason", 0),
+                "cost": b.get("cost", 0),
+                "models": _format_token_models(b.get("models", {}), include_prices=False),
+                "usage_available": usage_available,
+                "usage_calls": b.get("usage_calls", 0),
+                "usage_sessions": len(b.get("usage_sessions", [])),
+                "sessions": len(b.get("sessions", [])),
                 "turns": b.get("turns", 0), "tools": b.get("tools", 0),
                 "duration": b.get("duration", 0), "ctx_used": b.get("ctx_used", 0),
                 "ctx_window": ctx_window, "ctx": ctx_pct,
@@ -3719,15 +3873,22 @@ def main():
     print(f"今日 ≈成本  ${gt['cost']:.2f} {F}")
     print(f"  (按 API 价估,非订阅实付) | font=Menlo size=11")
     print("---")
-    # Grok 块(降级:仅上下文 token,不估成本)
+    # Grok Build 块：优先真实 token，旧日志降级为上下文快照。
     gk = d["grok"]
     kt = gk["ranges"]["today"]
-    print(f"Grok CLI {HEAD}")
+    print(f"Grok Build {HEAD}")
     print(f"今日 会话   {kt['sessions']:>6} {F}")
-    print(f"上下文 token {human(kt['tokens']):>6} {F}")
+    if kt.get("usage_available"):
+        print(f"今日 输入   {human(kt['in']):>6} {F}")
+        print(f"今日 缓存   {human(kt['cr']):>6} {F}")
+        print(f"今日 输出   {human(kt['out']):>6} {F}")
+        if kt.get("reason"):
+            print(f"今日 推理   {human(kt['reason']):>6} {F}")
+    else:
+        print(f"上下文快照 {human(kt['ctx_used']):>6} {F}")
     if gk.get("model"):
         print(f"model: {gk['model']} {F}")
-    print(f"  (仅上下文 token,非消耗量;成本 —) | font=Menlo size=11")
+    print(f"  (成本未提供) | font=Menlo size=11")
     print("---")
     # Pi 块
     pt = d["pi"]["ranges"]["today"]
@@ -4015,6 +4176,7 @@ def build_daily_costs(period="all", refresh=True):
                        "p_in": 0, "p_out": 0, "p_cr": 0, "p_cw": 0, "p_reason": 0,
                        "w_in": 0, "w_out": 0, "w_cr": 0, "w_cw": 0,
                        "q_in": 0, "q_out": 0, "q_cr": 0, "q_reason": 0,
+                       "g_in": 0, "g_out": 0, "g_cr": 0, "g_reason": 0,
                        "tokens": 0, "sessions": 0}
 
     for fp, entry in cache.get("claude", {}).items():
@@ -4133,6 +4295,26 @@ def build_daily_costs(period="all", refresh=True):
             for key in TOKEN_FIELDS:
                 m[key] += mv.get(key, 0)
 
+    grok_sessions, grok_latest_model = _grok_session_metadata()
+    for entry in cache.get("grok_usage", {}).get("entries", []):
+        dt = parse_ts(entry.get("ts") or "")
+        if dt is None:
+            continue
+        local_dt = dt.astimezone()
+        dk = local_dt.date().isoformat()
+        if cutoff and dk < cutoff:
+            continue
+        d = days.setdefault(dk, _empty())
+        d["g_in"] += entry.get("in", 0); d["g_out"] += entry.get("out", 0)
+        d["g_cr"] += entry.get("cr", 0); d["g_reason"] += entry.get("reason", 0)
+        d["tokens"] += token_total(entry)
+        model_name = (grok_sessions.get(entry.get("sid")) or {}).get("model") or grok_latest_model or "grok"
+        nm = f"{nice_model(model_name)} (Grok Build)"
+        m = models.setdefault(nm, {"cost": 0.0, "in": 0, "out": 0, "cr": 0,
+                                   "cw": 0, "reason": 0, "tool": "grok"})
+        for key in TOKEN_FIELDS:
+            m[key] += entry.get(key, 0)
+
     for fp, entry in cache.get("hermes", {}).items():
         for dk, day in entry.get("days", {}).items():
             if cutoff and dk < cutoff:
@@ -4182,6 +4364,7 @@ def build_daily_costs(period="all", refresh=True):
               "p_in": v["p_in"], "p_out": v["p_out"], "p_cr": v["p_cr"], "p_cw": v["p_cw"], "p_reason": v["p_reason"],
               "w_in": v["w_in"], "w_out": v["w_out"], "w_cr": v["w_cr"], "w_cw": v["w_cw"],
               "q_in": v["q_in"], "q_out": v["q_out"], "q_cr": v["q_cr"], "q_reason": v["q_reason"],
+              "g_in": v["g_in"], "g_out": v["g_out"], "g_cr": v["g_cr"], "g_reason": v["g_reason"],
               "tokens": v["tokens"]}
              for dk, v in sorted(days.items())]
 
@@ -4446,6 +4629,33 @@ def build_wrapped(period="all", refresh=True):
             nm = f"{nice_model(model_name)} (Qoder)"
             model_tok[nm] = model_tok.get(nm, 0) + tok
 
+    # --- Grok Build（unified 日志中的真实 token）---
+    grok_sessions, grok_latest_model = _grok_session_metadata()
+    for entry in cache.get("grok_usage", {}).get("entries", []):
+        dt = parse_ts(entry.get("ts") or "")
+        if dt is None:
+            continue
+        local_dt = dt.astimezone()
+        dk = local_dt.date().isoformat()
+        if cutoff and dk < cutoff:
+            continue
+        tok = token_total(entry)
+        day_tokens[dk] = day_tokens.get(dk, 0) + tok
+        total_tokens += tok
+        weekday[local_dt.weekday()] += tok
+        hours[local_dt.hour] += tok
+        all_day_hours.add(f"{dk}:{local_dt.hour}")
+        meta = grok_sessions.get(entry.get("sid")) or {}
+        project_path = meta.get("project") or ""
+        project = os.path.basename(project_path.rstrip("/")) or "?"
+        if project != "?":
+            pt = proj_tok.setdefault(project, [0, 0.0])
+            pt[0] += tok
+            day_projs.setdefault(dk, set()).add(project)
+        model_name = meta.get("model") or grok_latest_model or "grok"
+        display_name = f"{nice_model(model_name)} (Grok Build)"
+        model_tok[display_name] = model_tok.get(display_name, 0) + tok
+
     # --- Gemini (无缓存,需重新扫描取 year 总量;仅 all/365d 包含) ---
     if period in ("all", "365d"):
         try:
@@ -4455,15 +4665,6 @@ def build_wrapped(period="all", refresh=True):
             gm_tok = yr.get("in", 0) + yr.get("out", 0) + yr.get("cached", 0) + yr.get("thoughts", 0)
             total_tokens += gm_tok
             total_cost += yr.get("cost", 0)
-        except Exception:
-            pass
-
-    # --- Grok (无缓存,需重新扫描取 year 总量;仅 all/365d 包含) ---
-    if period in ("all", "365d"):
-        try:
-            gk = scan_grok(bounds if period == "all" else range_bounds())
-            gk_tok = gk["ranges"].get("year", {}).get("tokens", 0)
-            total_tokens += gk_tok
         except Exception:
             pass
 
@@ -4658,29 +4859,38 @@ def projects():
     for proj_path, session_ids in workbuddy_sessions.items():
         proj_map[proj_path]["sessions"] += len(session_ids)
 
-    # Grok sessions (cwd encoded in directory name)
-    from urllib.parse import unquote
-    for sm in glob.glob(os.path.join(GROK_DIR, "*", "*", "summary.json")):
-        parts = sm.split(os.sep)
-        try:
-            cwd_encoded = parts[-3]
-            grok_path = unquote(cwd_encoded)
-            if not grok_path.startswith("/"):
-                continue
-            with open(sm, "r", encoding="utf-8", errors="ignore") as fh:
-                s = json.load(fh)
-            dt = parse_ts(s.get("updated_at") or s.get("created_at") or "")
-            if dt is None:
-                continue
+    # Grok Build sessions + unified 日志真实 token
+    grok_sessions, grok_latest_model = _grok_session_metadata()
+    for meta in grok_sessions.values():
+        grok_path = meta.get("project") or ""
+        if not grok_path:
+            continue
+        summary = meta.get("summary") or {}
+        dt = parse_ts(summary.get("updated_at") or summary.get("created_at") or "")
+        p = proj_map.setdefault(grok_path, {"sessions": 0, "tokens": 0, "cost": 0.0,
+                                             "last_active": "", "model_tok": {}, "tools": set()})
+        p["sessions"] += 1
+        p["tools"].add("grok")
+        if dt is not None:
             dk = dt.astimezone().date().isoformat()
-            p = proj_map.setdefault(grok_path, {"sessions": 0, "tokens": 0, "cost": 0.0,
-                                                 "last_active": "", "model_tok": {}, "tools": set()})
-            p["sessions"] += 1
-            p["tools"].add("grok")
             if dk > p["last_active"]:
                 p["last_active"] = dk
-        except Exception:
+    for usage_entry in cache.get("grok_usage", {}).get("entries", []):
+        meta = grok_sessions.get(usage_entry.get("sid")) or {}
+        grok_path = meta.get("project") or ""
+        if not grok_path:
             continue
+        p = proj_map[grok_path]
+        tok = token_total(usage_entry)
+        p["tokens"] += tok
+        model_name = meta.get("model") or grok_latest_model or "grok"
+        display_name = f"{nice_model(model_name)} (Grok Build)"
+        p["model_tok"][display_name] = p["model_tok"].get(display_name, 0) + tok
+        dt = parse_ts(usage_entry.get("ts") or "")
+        if dt is not None:
+            dk = dt.astimezone().date().isoformat()
+            if dk > p["last_active"]:
+                p["last_active"] = dk
 
     # 检测本地 LISTEN 端口,匹配项目 cwd
     port_map = _detect_local_servers(set(proj_map.keys()))


### PR DESCRIPTION
## 改动说明

旧实现将 Grok 上下文快照视为实际 token 消耗，导致 Dashboard、Wrapped 和项目统计的数据失真。本次改为解析 Grok Build `unified.jsonl` 中的逐次推理记录。

- 采集输入、缓存读取、输出和推理 token
- 通过 `sid` 关联模型及项目路径
- 支持跨日归档、增量读取和日志去重
- 卡片展示真实用量、缓存命中、调用、模型及运行指标
- Dashboard、Wrapped 和项目统计接入真实 Grok token
- 兼容旧版同步 JSON、`GROK_HOME` 和无 usage 数据回退
- 缺少可靠价格数据时保持成本未知，不进行估算

## 验证

- Python 测试：41/41 通过
- `python3 -m py_compile usage.30s.py` 通过
- `swift build` 通过
- 本机 Grok 0.2.99 日志验证：共采集 3,127,475 token、43 次调用
