### PR TITLE
fix(ui): 优化设置页与菜单栏紧凑布局

### DIFF
--- a/Tokei/Sources/Tokei/MenuBarStyle.swift
+++ b/Tokei/Sources/Tokei/MenuBarStyle.swift
@@ -350,6 +350,9 @@ enum MenuBarTitleRenderer {
     private static func appendArtwork(_ image: NSImage, to title: NSMutableAttributedString) {
         let attachment = NSTextAttachment()
         attachment.image = image
+        // NSTextAttachment 默认贴着文本基线，图标会比数字视觉中心偏高；按字体中心下移对齐。
+        let y = round((valueFont.ascender + valueFont.descender - image.size.height) / 2)
+        attachment.bounds = NSRect(x: 0, y: y, width: image.size.width, height: image.size.height)
         title.append(NSAttributedString(attachment: attachment))
     }
 

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -48,6 +48,7 @@ struct PanelView: View {
     private var hasMultipleDevices: Bool { store.syncEnabled && !store.peers.isEmpty }
     private var useWide: Bool { visibleCount > 2 }
     private var panelWidth: CGFloat { useWide ? 640 : Theme.panelWidth }
+    private let settingsPanelWidth: CGFloat = 660
 
     private var maxPanelHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 900) - 40
@@ -63,7 +64,7 @@ struct PanelView: View {
     }
 
     var body: some View {
-        let w = mode == .settings ? max(panelWidth, 560) : (mode == .cards ? panelWidth : max(panelWidth, 420))
+        let w = mode == .settings ? settingsPanelWidth : (mode == .cards ? panelWidth : max(panelWidth, 420))
         if scrollable {
             ScrollView(.vertical, showsIndicators: false) { panelContent }
                 .frame(width: w)
@@ -1895,19 +1896,22 @@ struct PanelView: View {
     }
 
     func settingsRow(_ name: String, tint: Color, isOn: Binding<Bool>) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             Circle().fill(tint.gradient).frame(width: 6, height: 6)
                 .shadow(color: tint.opacity(0.4), radius: 2)
             Text(name)
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(Theme.tPrimary)
-            Spacer()
+                .lineLimit(1)
+                .minimumScaleFactor(0.9)
+                .layoutPriority(1)
+            Spacer(minLength: 4)
             Toggle("", isOn: isOn)
                 .toggleStyle(.switch)
                 .controlSize(.mini)
                 .labelsHidden()
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, 8)
         .padding(.vertical, 7)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -199,6 +199,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             : (presentation.title.length == 0 ? .imageOnly : .imageLeading)
         b.attributedTitle = presentation.title
         b.contentTintColor = nil
+        fitStatusItemWidth(b)
         var summaryParts = metrics.map { metric in
             let name: String
             switch metric.kind {
@@ -218,6 +219,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let accessibility = summary.isEmpty ? "Tokei" : "Tokei · \(summary)"
         b.toolTip = accessibility
         b.setAccessibilityLabel(accessibility)
+    }
+
+    private func fitStatusItemWidth(_ button: NSStatusBarButton) {
+        button.invalidateIntrinsicContentSize()
+        let compactWidth = ceil(button.intrinsicContentSize.width) + 4
+        statusItem.length = max(NSStatusBar.system.thickness, compactWidth)
     }
 
     func autoFetchPricing() {


### PR DESCRIPTION
## 问题

- 设置页双列工具开关空间不足，导致较长的工具名称换行
- 菜单栏状态项保留了过多水平边距，挤占其他图标空间
- 菜单栏刻度图标按文本附件默认基线布局，视觉中心偏高、下方留白不均

## 修复

- 设置页使用稳定的独立宽度
- 收紧工具开关的间距并保持名称单行
- 根据菜单栏图标和标题的实际宽度动态收紧状态项
- 保留 4pt 安全边距和系统最小点击宽度
- 根据菜单栏数字字体指标校正内联图标基线，使图标与数字垂直居中

## 验证

- `swift build` 通过
- `swift build -c release` 通过
- 隔离环境 Python 测试 38/38 通过
- `git diff --check` 通过
- 确认全部 14 个工具开关正常显示
- “图标 + 66”状态项宽度由 56pt 降至 44pt
- 11pt 刻度图标按字体中心下移 1pt
