### PR TITLE
fix: 修复 OpenClaw 任务统计及面板交互异常

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -14,7 +14,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | Grok CLI | `~/.grok/sessions/*/*/summary.json` + `updates.jsonl` | JSON, `_meta.totalTokens` |
 | Qoder | `~/Library/Application Support/QoderWork/data/agents.db` | SQLite, `messages.metadata` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `sessions` 表 |
-| OpenClaw | `~/.openclaw/tasks/runs.sqlite` | SQLite, `task_runs` 表 |
+| OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` | JSONL 用量 + SQLite 任务 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
 | OpenCode | `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | JSON, `tokens` + `cost` |
@@ -99,7 +99,9 @@ Tokei 优先读取逐请求日志以获得进行中会话和小时分布。旧�
 
 **Qoder** — `inputTokens` / `outputTokens` 目前全为 0,仅 `durationMs` 和 `contextUsageRatio` 有值。
 
-**OpenClaw** — 无 token 数据,仅统计 tasks / completed / failed 计数。
+**OpenClaw** — Session JSONL 的 `message.usage` 提供输入、输出、缓存读写和成本；
+`state/openclaw.sqlite` 的 `task_runs` 提供任务状态。旧版
+`~/.openclaw/tasks/runs.sqlite` 仍作为兼容回退。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ echo '{"sync_dir":"~/.tokei/sync","device_id":"'$(hostname -s)'"}' > ~/.tokei/co
 | Gemini CLI | `~/.gemini/gemini-cli/conversations/*.json` |
 | Grok CLI | `~/.grok/sessions/YYYY/MM/DD/*.jsonl` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
-| OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + SQLite |
+| OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` |
 | OpenCode | `~/.opencode/sessions/*.json` |

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -65,12 +65,21 @@ struct PanelView: View {
     var body: some View {
         let w = mode == .settings ? max(panelWidth, 560) : (mode == .cards ? panelWidth : max(panelWidth, 420))
         if scrollable {
-            ScrollView(.vertical, showsIndicators: false) { panelContent }
-                .frame(width: w)
-                .frame(maxHeight: maxPanelHeight)
-                .background(Theme.bg)
-                .background(VisualEffect())
-                .environment(\.colorScheme, .dark)
+            if mode == .projects {
+                projectPanelContent
+                    .frame(width: w)
+                    .frame(height: min(maxPanelHeight, 720))
+                    .background(Theme.bg)
+                    .background(VisualEffect())
+                    .environment(\.colorScheme, .dark)
+            } else {
+                ScrollView(.vertical, showsIndicators: false) { panelContent }
+                    .frame(width: w)
+                    .frame(maxHeight: maxPanelHeight)
+                    .background(Theme.bg)
+                    .background(VisualEffect())
+                    .environment(\.colorScheme, .dark)
+            }
         } else {
             panelContent
                 .frame(width: w, alignment: .top)
@@ -78,6 +87,18 @@ struct PanelView: View {
                 .background(VisualEffect())
                 .environment(\.colorScheme, .dark)
         }
+    }
+
+    private var projectPanelContent: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            header
+            ScrollView(.vertical, showsIndicators: true) {
+                ProjectTrailView(cached: $trailProjects)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            footer
+        }
+        .padding(Theme.outerPad)
     }
 
     private var panelContent: some View {
@@ -262,13 +283,20 @@ struct PanelView: View {
             EqualHeightGrid() {
                 ForEach(cards) { item in
                     Card(tint: item.tint) { item.content }
+                        .id(cardContentIdentity(for: item))
                 }
             }
         } else {
             ForEach(cards) { item in
                 Card(tint: item.tint) { item.content }
+                    .id(cardContentIdentity(for: item))
             }
         }
+    }
+
+    // AnyView 在固定工具 ID 下可能复用上一时间范围的子树；范围或设备口径变化时强制刷新。
+    private func cardContentIdentity(for item: ToolCardItem) -> String {
+        "\(item.id):\(sel.rawValue):\(store.syncEnabled):\(store.showAllDevices)"
     }
 
     // MARK: - Claude 卡片
@@ -540,7 +568,7 @@ struct PanelView: View {
     func openclawBlock(_ r: OpenClawRange) -> some View {
         VStack(alignment: .leading, spacing: 11) {
             cardHead("OpenClaw", tint: Theme.openclaw, sessions: r.sessions)
-            if r.in + r.out > 0 {
+            if r.in + r.out + r.cr + r.cw > 0 {
                 CostHeadline(value: Fmt.human(r.in + r.out + r.cr + r.cw), caption: "\(sel.label) 总量", tint: Theme.openclaw)
                 metricGrid([.init("dollarsign.circle", "≈成本", String(format: "$%.2f", r.cost))],
                     hit: r.hit, extra: {

--- a/Tokei/Sources/Tokei/ProjectTrailView.swift
+++ b/Tokei/Sources/Tokei/ProjectTrailView.swift
@@ -176,25 +176,30 @@ struct ProjectTrailView: View {
                     }
                 }
                 if let ports = p.ports, !ports.isEmpty {
-                    HStack(spacing: 5) {
-                        ForEach(ports, id: \.self) { port in
-                            Button {
-                                if let url = URL(string: "http://localhost:\(port)") {
-                                    NSWorkspace.shared.open(url)
+                    ScrollView(.horizontal, showsIndicators: ports.count > 4) {
+                        HStack(spacing: 5) {
+                            ForEach(ports, id: \.self) { port in
+                                Button {
+                                    if let url = URL(string: "http://localhost:\(port)") {
+                                        NSWorkspace.shared.open(url)
+                                    }
+                                } label: {
+                                    HStack(spacing: 3) {
+                                        Circle().fill(.green).frame(width: 5, height: 5)
+                                        Text("localhost:\(port)")
+                                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                            .foregroundStyle(Theme.hermes)
+                                            .lineLimit(1)
+                                    }
+                                    .fixedSize(horizontal: true, vertical: false)
+                                    .padding(.horizontal, 6).padding(.vertical, 2)
+                                    .background(Capsule().fill(Theme.hermes.opacity(0.12)))
                                 }
-                            } label: {
-                                HStack(spacing: 3) {
-                                    Circle().fill(.green).frame(width: 5, height: 5)
-                                    Text("localhost:\(port)")
-                                        .font(.system(size: 9, weight: .medium, design: .monospaced))
-                                        .foregroundStyle(Theme.hermes)
-                                }
-                                .padding(.horizontal, 6).padding(.vertical, 2)
-                                .background(Capsule().fill(Theme.hermes.opacity(0.12)))
+                                .buttonStyle(.plain)
                             }
-                            .buttonStyle(.plain)
                         }
                     }
+                    .frame(height: 22)
                 }
             }
             Spacer(minLength: 4)

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -86,6 +86,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let store = Store()
     var statusItem: NSStatusItem!
     var popover = NSPopover()
+    lazy var statusMenu: NSMenu = {
+        let menu = NSMenu()
+        let quitItem = NSMenuItem(title: "退出", action: #selector(quitApp), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+        return menu
+    }()
     var timer: Timer?
     var globalMouseMonitor: Any?
 
@@ -96,8 +103,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ note: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let b = statusItem.button {
-            b.action = #selector(togglePopover)
+            b.action = #selector(handleStatusItemClick(_:))
             b.target = self
+            b.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
         updateStatusTitle()
 
@@ -231,6 +239,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             proc.waitUntilExit()
             DispatchQueue.main.async { self?.store.refresh() }
         }
+    }
+
+    @objc func handleStatusItemClick(_ sender: NSStatusBarButton) {
+        if NSApp.currentEvent?.type == .rightMouseUp,
+           let event = NSApp.currentEvent {
+            if popover.isShown { popover.performClose(nil) }
+            NSMenu.popUpContextMenu(statusMenu, with: event, for: sender)
+            return
+        }
+        togglePopover()
+    }
+
+    @objc func quitApp() {
+        NSApp.terminate(nil)
     }
 
     @objc func togglePopover() {

--- a/tests/test_openclaw_tasks.py
+++ b/tests/test_openclaw_tasks.py
@@ -1,0 +1,81 @@
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+from test_codex_limits import USAGE
+
+
+class OpenClawTaskTests(unittest.TestCase):
+    def create_database(self, path, created_ms, statuses):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(path)
+        connection.execute("""
+            CREATE TABLE task_runs (
+                run_id TEXT PRIMARY KEY, status TEXT, created_at INTEGER
+            )
+        """)
+        connection.executemany(
+            "INSERT INTO task_runs VALUES (?, ?, ?)",
+            [(f"run-{index}", status, created_ms)
+             for index, status in enumerate(statuses)],
+        )
+        connection.commit()
+        connection.close()
+
+    def scan(self, state_db, legacy_db, agents_dir):
+        old_state = USAGE.OPENCLAW_STATE_DB
+        old_legacy = USAGE.OPENCLAW_DB
+        old_agents = USAGE.OPENCLAW_AGENTS
+        USAGE.OPENCLAW_STATE_DB = str(state_db)
+        USAGE.OPENCLAW_DB = str(legacy_db)
+        USAGE.OPENCLAW_AGENTS = str(agents_dir)
+        try:
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            result = USAGE.scan_openclaw(USAGE.range_bounds(), cache)
+            return result, cache
+        finally:
+            USAGE.OPENCLAW_STATE_DB = old_state
+            USAGE.OPENCLAW_DB = old_legacy
+            USAGE.OPENCLAW_AGENTS = old_agents
+
+    def test_prefers_new_database_and_accepts_new_statuses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_db = root / "state" / "openclaw.sqlite"
+            legacy_db = root / "tasks" / "runs.sqlite"
+            created_ms = int(datetime.now().astimezone().timestamp() * 1000)
+            self.create_database(
+                state_db, created_ms,
+                ["succeeded", "success", "completed", "failed", "error"],
+            )
+            self.create_database(legacy_db, created_ms, ["completed"])
+
+            result, cache = self.scan(state_db, legacy_db, root / "agents")
+
+        today = result["ranges"]["today"]
+        self.assertEqual(cache["openclaw"]["_db"]["path"], str(state_db))
+        self.assertEqual(today["tasks"], 5)
+        self.assertEqual(today["completed"], 3)
+        self.assertEqual(today["failed"], 2)
+
+    def test_falls_back_to_legacy_database(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_db = root / "state" / "openclaw.sqlite"
+            legacy_db = root / "tasks" / "runs.sqlite"
+            created_ms = int(datetime.now().astimezone().timestamp() * 1000)
+            self.create_database(legacy_db, created_ms, ["completed", "failed"])
+
+            result, cache = self.scan(state_db, legacy_db, root / "agents")
+
+        today = result["ranges"]["today"]
+        self.assertEqual(cache["openclaw"]["_db"]["path"], str(legacy_db))
+        self.assertEqual(today["tasks"], 2)
+        self.assertEqual(today["completed"], 1)
+        self.assertEqual(today["failed"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -105,6 +105,7 @@ ZCODE_DB = os.path.abspath(os.path.expanduser(os.environ.get(
 MIMOCODE_DB = os.path.abspath(os.path.expanduser(os.environ.get("TOKEI_MIMOCODE_DB", ""))) \
     if os.environ.get("TOKEI_MIMOCODE_DB") else ""
 OPENCLAW_DB = os.path.join(HOME, ".openclaw", "tasks", "runs.sqlite")
+OPENCLAW_STATE_DB = os.path.join(HOME, ".openclaw", "state", "openclaw.sqlite")
 OPENCLAW_AGENTS = os.path.join(HOME, ".openclaw", "agents")
 PI_AGENT_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_DIR", os.path.join(HOME, ".pi", "agent")))
 PI_SESSION_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_SESSION_DIR", os.path.join(PI_AGENT_DIR, "sessions")))
@@ -404,7 +405,7 @@ def human(n: float) -> str:
 # ---------- 增量扫描缓存 ----------
 import tempfile as _tempfile
 _SCAN_CACHE_FILE = os.path.join(_tempfile.gettempdir(), "_tokei_scan_cache.json")
-_SCAN_CACHE_VERSION = 16
+_SCAN_CACHE_VERSION = 17
 
 
 def _load_scan_cache():
@@ -2122,8 +2123,52 @@ def scan_hermes(bounds, cache):
 
 
 # ---------- OpenClaw ----------
-# SQLite: ~/.openclaw/tasks/runs.sqlite — 任务计数
+# SQLite: ~/.openclaw/state/openclaw.sqlite（新版）或 ~/.openclaw/tasks/runs.sqlite（旧版）
 # Session JSONL: ~/.openclaw/agents/*/sessions/*.jsonl — token 用量
+def _openclaw_db_paths():
+    return [path for path in _path_candidates(
+        "TOKEI_OPENCLAW_DB", OPENCLAW_STATE_DB, OPENCLAW_DB) if os.path.isfile(path)]
+
+
+def _openclaw_task_db_path(_sq):
+    for path in _openclaw_db_paths():
+        conn = None
+        try:
+            conn = _sq.connect(f"file:{path}?mode=ro", uri=True)
+            found = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_runs'"
+            ).fetchone()
+            if found:
+                return path
+        except Exception:
+            continue
+        finally:
+            if conn is not None:
+                conn.close()
+    return None
+
+
+def _scan_openclaw_db(db_path, _sq):
+    conn = _sq.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        task_days = {}
+        for row in conn.execute("""
+            SELECT date(created_at/1000,'unixepoch','localtime') as day,
+                   COUNT(*) as total,
+                   SUM(CASE WHEN status IN ('completed','succeeded','success') THEN 1 ELSE 0 END),
+                   SUM(CASE WHEN status IN ('failed','error') THEN 1 ELSE 0 END)
+            FROM task_runs WHERE created_at > 0
+            GROUP BY day
+        """):
+            dk, total, completed, failed = row
+            if dk:
+                task_days[dk] = {"tasks": int(total or 0), "completed": int(completed or 0),
+                                 "failed": int(failed or 0)}
+        return task_days
+    finally:
+        conn.close()
+
+
 def scan_openclaw(bounds, cache):
     import sqlite3 as _sq
     fc = cache.setdefault("openclaw", {})
@@ -2152,43 +2197,23 @@ def scan_openclaw(bounds, cache):
              "cost": 0.0, "sessions": set(), "models": {}} for k in RANGE_KEYS}
 
     # --- Part 1: SQLite task counts ---
-    if os.path.isfile(OPENCLAW_DB):
-        try:
-            sig = f"{os.path.getmtime(OPENCLAW_DB)}:{os.path.getsize(OPENCLAW_DB)}"
-        except OSError:
-            sig = None
-        if sig:
-            entry = fc.get("_db")
-            if not entry or entry.get("sig") != sig:
-                task_days = {}
-                try:
-                    conn = _sq.connect(f"file:{OPENCLAW_DB}?mode=ro", uri=True)
-                    for row in conn.execute("""
-                        SELECT date(created_at/1000,'unixepoch','localtime') as day,
-                               COUNT(*) as total,
-                               SUM(CASE WHEN status='completed' THEN 1 ELSE 0 END),
-                               SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END)
-                        FROM task_runs WHERE created_at > 0
-                        GROUP BY day
-                    """):
-                        dk, total, completed, failed = row
-                        if dk:
-                            task_days[dk] = {"tasks": int(total or 0), "completed": int(completed or 0),
-                                             "failed": int(failed or 0)}
-                    conn.close()
-                except Exception:
-                    pass
-                fc["_db"] = {"sig": sig, "days": task_days}
-                changed = True
-            for dk, day in fc.get("_db", {}).get("days", {}).items():
-                try:
-                    d = date.fromisoformat(dk)
-                except ValueError:
-                    continue
-                for k in _day_keys(d):
-                    b = B[k]
-                    b["tasks"] += day["tasks"]; b["completed"] += day["completed"]
-                    b["failed"] += day["failed"]
+    db_path = _openclaw_task_db_path(_sq)
+    if db_path:
+        sig = _sqlite_signature(db_path)
+        entry = fc.get("_db")
+        if not entry or entry.get("path") != db_path or entry.get("sig") != sig:
+            task_days = _scan_openclaw_db(db_path, _sq)
+            fc["_db"] = {"path": db_path, "sig": sig, "days": task_days}
+            changed = True
+        for dk, day in fc.get("_db", {}).get("days", {}).items():
+            try:
+                d = date.fromisoformat(dk)
+            except ValueError:
+                continue
+            for k in _day_keys(d):
+                b = B[k]
+                b["tasks"] += day["tasks"]; b["completed"] += day["completed"]
+                b["failed"] += day["failed"]
     elif "_db" in fc:
         fc.pop("_db", None)
         changed = True


### PR DESCRIPTION
## 问题

- OpenClaw 新版任务数据库迁移到 `~/.openclaw/state/openclaw.sqlite`，成功状态变为 `succeeded`，现有采集无法正确统计任务。
- 切换时间范围时，工具卡片可能复用旧的 `AnyView` 内容，出现标签与数据范围不一致。
- 项目端口使用无边界横向布局，大量端口会把标签压缩成竖条并撑开整个面板，底部操作无法访问。
- 菜单栏图标仅支持左键打开面板，面板异常时缺少直接退出入口。

## 修复

- 优先读取 OpenClaw 新版状态数据库，保留旧数据库回退。
- 兼容新版任务状态，并将 SQLite WAL/SHM 纳入缓存签名。
- 时间范围、同步状态或设备口径变化时重新创建工具卡片。
- 项目足迹限制面板高度，固定头部和底部，仅滚动项目列表。
- 端口标签保持单行并支持横向滚动，避免大量端口撑开布局。
- 菜单栏图标支持右键菜单，提供「退出」功能。
- OpenClaw 仅有缓存 token 时也正常展示用量。
- 补充数据库兼容测试和数据来源文档。

## 验证

- `env HOME=/tmp/tokei-openclaw-test-home python3 -m unittest discover -s tests`
- `python3 -m py_compile usage.30s.py`
- `git diff --check`
- `cd Tokei && swift build`
- `cd Tokei && ./package.sh`
