### PR TITLE
feat(grok): 展示 Grok 周额度与重置，并支持菜单栏额度来源选择

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -244,6 +244,32 @@ Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 直接使用消
 
 兼容 Codex 新旧返回结构:旧结构通常是 primary=5h、secondary=周;新结构可能只有 primary=周。
 
+### Grok Build(credits)
+
+默认**只读本地日志**，不访问网络：
+
+- 来源：`${GROK_HOME:-~/.grok}/logs/unified.jsonl` 中
+  `billing: fetched credits config`
+- `pct` — 当前周期已用百分比（`creditUsagePercent`）
+- `reset` — 周期结束/重置时间
+- `plan` — 套餐名（日志里的 `subscriptionTier`，如 SuperGrok）
+- `window` — `week` / `month`（由 `currentPeriod.type` 推断）
+- `source` — `log` / `live` / `cache`
+
+可选实时接口（**默认关闭**，需用户显式开启）：
+
+- 配置：`~/.tokei/config.json` 中 `grok_live_quota_enabled: true`
+- 或环境变量：`TOKEI_GROK_LIVE_QUOTA=1`（`0` 强制关闭）
+- 接口：`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
+- 鉴权：`~/.grok/auth.json` 中的 Bearer token
+- 额外字段：`products[]`（如 GrokBuild / Api 分产品已用百分比）
+
+策略：
+
+1. 始终优先解析本地日志
+2. 仅当用户开启实时查询时，才请求账单接口覆盖为最新值
+3. 失败时回退到本地日志或短缓存，不报错
+
 ### Qoder(credit)
 
 从 QoderWork 日志 `main.log` 中提取 `userQuota`:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 | **Claude Code** | Token（输入/输出/缓存）、成本、配额、模型 |
 | **Codex CLI** | Token、成本、配额、会话 |
 | **Gemini CLI** | Token、思考量、成本、模型 |
-| **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟 |
+| **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟、配额（本地日志；可选实时） |
 | **Hermes** | Token、成本、缓存命中率、模型 |
 | **OpenClaw** | Token、成本、任务、模型 |
 | **Pi Coding Agent CLI** | Token、成本、缓存命中率、模型、项目 |
@@ -153,7 +153,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | Claude Code | `~/.claude/projects/<proj>/<session>.jsonl` |
 | Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
 | Gemini CLI | `~/.gemini/gemini-cli/conversations/*.json` |
-| Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl` + `sessions/*/*/{summary,signals}.json` |
+| Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl`（含真实 token + billing 额度）+ `sessions/*/*/{summary,signals}.json`；可选实时账单接口（设置里默认关闭） |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |

--- a/Tokei/Sources/Tokei/MenuBarStyle.swift
+++ b/Tokei/Sources/Tokei/MenuBarStyle.swift
@@ -55,6 +55,47 @@ enum MenuBarDensity: String, CaseIterable, Identifiable {
     }
 }
 
+/// 菜单栏额度来源（与面板「显示卡片」独立；只控制状态栏显示哪些剩余额度）。
+enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
+    case claude
+    case codex
+    case grok
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        case .grok: return "Grok"
+        }
+    }
+
+    var defaultsKey: String {
+        switch self {
+        case .claude: return "menuBarQuotaClaude"
+        case .codex: return "menuBarQuotaCodex"
+        case .grok: return "menuBarQuotaGrok"
+        }
+    }
+
+    /// Claude/Codex 默认开，与历史行为一致；Grok 额度是新增来源，默认关，避免抢占状态栏。
+    var defaultEnabled: Bool {
+        switch self {
+        case .claude, .codex: return true
+        case .grok: return false
+        }
+    }
+
+    var isEnabled: Bool {
+        let ud = UserDefaults.standard
+        if ud.object(forKey: defaultsKey) == nil { return defaultEnabled }
+        return ud.bool(forKey: defaultsKey)
+    }
+
+    static func isEnabled(_ source: MenuBarQuotaSource) -> Bool { source.isEnabled }
+}
+
 enum MenuBarMetricKind {
     case claude
     case codex

--- a/Tokei/Sources/Tokei/MenuBarStyle.swift
+++ b/Tokei/Sources/Tokei/MenuBarStyle.swift
@@ -58,6 +58,7 @@ enum MenuBarDensity: String, CaseIterable, Identifiable {
 enum MenuBarMetricKind {
     case claude
     case codex
+    case grok
     case total
 }
 
@@ -591,6 +592,7 @@ enum MenuBarTitleRenderer {
         switch kind {
         case .claude: return AppDelegate.claudeColor
         case .codex: return AppDelegate.codexColor
+        case .grok: return AppDelegate.grokColor
         case .total: return .secondaryLabelColor
         }
     }
@@ -714,6 +716,7 @@ struct MenuBarStylePreview: View {
         switch kind {
         case .claude: return AppDelegate.claudeColor
         case .codex: return AppDelegate.codexColor
+        case .grok: return AppDelegate.grokColor
         case .total: return .secondaryLabelColor
         }
     }
@@ -722,6 +725,7 @@ struct MenuBarStylePreview: View {
         switch kind {
         case .claude: return Theme.claude
         case .codex: return Theme.codex
+        case .grok: return Theme.grok
         case .total: return Theme.tSecondary
         }
     }

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -280,9 +280,43 @@ struct GrokRanges: Codable {
     }
 }
 
+struct GrokProductUsage: Codable, Identifiable {
+    var name: String
+    var pct: Double?
+    var id: String { name }
+}
+
 struct GrokStat: Codable {
     var ranges: GrokRanges
     var model: String?
+    /// 本周期已用百分比（0–100）。
+    var pct: Double?
+    /// 周期重置时间（unix epoch 秒）。
+    var reset: Int?
+    /// 套餐名，如 SuperGrok。
+    var plan: String?
+    /// 分产品已用百分比（GrokBuild / Api 等）。
+    var products: [GrokProductUsage] = []
+    /// week / month。
+    var window: String?
+    /// log / live / cache。
+    var source: String?
+    var q_updated: Int?
+    var stale: Bool?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        ranges = try c.decode(GrokRanges.self, forKey: .ranges)
+        model = try c.decodeIfPresent(String.self, forKey: .model)
+        pct = try c.decodeIfPresent(Double.self, forKey: .pct)
+        reset = try c.decodeIfPresent(Int.self, forKey: .reset)
+        plan = try c.decodeIfPresent(String.self, forKey: .plan)
+        products = try c.decodeIfPresent([GrokProductUsage].self, forKey: .products) ?? []
+        window = try c.decodeIfPresent(String.self, forKey: .window)
+        source = try c.decodeIfPresent(String.self, forKey: .source)
+        q_updated = try c.decodeIfPresent(Int.self, forKey: .q_updated)
+        stale = try c.decodeIfPresent(Bool.self, forKey: .stale)
+    }
 }
 
 struct QoderRange: Codable {

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -1344,7 +1344,7 @@ struct PanelView: View {
                 }
             }
 
-            Text("只影响状态栏剩余额度，与「显示卡片」无关。双额度会按勾选显示；单额度在勾选项里取剩余最少的一项。")
+            Text("只影响状态栏剩余额度，与「显示卡片」无关。双额度按勾选显示；单额度在勾选项中取剩余最少。全部关闭时状态栏只留图标，不再显示用量数字。")
                 .font(.system(size: 8.5))
                 .foregroundStyle(Theme.tTertiary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -1336,9 +1336,8 @@ struct PanelView: View {
             }
 
             settingsStackedValue("额度来源") {
-                LazyVGrid(columns: [GridItem(.flexible(), spacing: 6),
-                                    GridItem(.flexible(), spacing: 6),
-                                    GridItem(.flexible(), spacing: 6)], spacing: 6) {
+                LazyVGrid(columns: [GridItem(.flexible(), spacing: 7),
+                                    GridItem(.flexible(), spacing: 7)], spacing: 7) {
                     settingsRow("Claude", tint: Theme.claude, isOn: $menuBarQuotaClaude)
                     settingsRow("Codex", tint: Theme.codex, isOn: $menuBarQuotaCodex)
                     settingsRow("Grok", tint: Theme.grok, isOn: $menuBarQuotaGrok)

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -44,6 +44,10 @@ struct PanelView: View {
     @AppStorage("showQwenCode") private var showQwenCode = true
     /// 默认关闭：Grok 额度只读本地日志；开启后才用登录凭据请求实时账单接口。
     @AppStorage("grokLiveQuotaEnabled") private var grokLiveQuotaEnabled = false
+    /// 菜单栏额度来源（与显示卡片独立）。Grok 默认关，避免新额度源抢占状态栏。
+    @AppStorage(MenuBarQuotaSource.claude.defaultsKey) private var menuBarQuotaClaude = true
+    @AppStorage(MenuBarQuotaSource.codex.defaultsKey) private var menuBarQuotaCodex = true
+    @AppStorage(MenuBarQuotaSource.grok.defaultsKey) private var menuBarQuotaGrok = false
 
     private var visibleCount: Int {
         [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showHermes, showZcode, showMimoCode,
@@ -1331,6 +1335,21 @@ struct PanelView: View {
                 .frame(width: settingsMenuPickerWidth)
             }
 
+            settingsStackedValue("额度来源") {
+                LazyVGrid(columns: [GridItem(.flexible(), spacing: 6),
+                                    GridItem(.flexible(), spacing: 6),
+                                    GridItem(.flexible(), spacing: 6)], spacing: 6) {
+                    settingsRow("Claude", tint: Theme.claude, isOn: $menuBarQuotaClaude)
+                    settingsRow("Codex", tint: Theme.codex, isOn: $menuBarQuotaCodex)
+                    settingsRow("Grok", tint: Theme.grok, isOn: $menuBarQuotaGrok)
+                }
+            }
+
+            Text("只影响状态栏剩余额度，与「显示卡片」无关。双额度会按勾选显示；单额度在勾选项里取剩余最少的一项。")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
             HStack {
                 Spacer()
                 MenuBarStylePreview(
@@ -1344,6 +1363,15 @@ struct PanelView: View {
             (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
         }
         .onChange(of: menuBarDensity) { _ in
+            (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
+        }
+        .onChange(of: menuBarQuotaClaude) { _ in
+            (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
+        }
+        .onChange(of: menuBarQuotaCodex) { _ in
+            (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
+        }
+        .onChange(of: menuBarQuotaGrok) { _ in
             (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
         }
     }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -501,8 +501,12 @@ struct PanelView: View {
                 quotaRow(title: title, pct: 100 - pct, reset: g.reset, tint: Theme.grok)
                 ForEach(g.products.filter { $0.pct != nil }) { product in
                     if let used = product.pct {
-                        grokProductShareRow(name: Self.grokProductLabel(product.name),
-                                            usedPct: used, tint: Theme.grok)
+                        grokProductShareRow(
+                            name: Self.grokProductLabel(product.name),
+                            usedPct: used,
+                            tint: Theme.grok,
+                            help: Self.grokProductHelp(product.name)
+                        )
                     }
                 }
                 if let plan = g.plan, !plan.isEmpty {
@@ -550,26 +554,44 @@ struct PanelView: View {
     /// 账单 product 字段 → 更可读的名称。
     static func grokProductLabel(_ raw: String) -> String {
         switch raw.lowercased() {
-        case "grokbuild": return "Grok Build"
-        case "api": return "API"
-        case "grokchat": return "Grok Chat"
+        case "grokbuild": return "Grok Build（本机 CLI）"
+        case "api": return "开放 API（api.x.ai）"
+        case "grokchat": return "Grok 网页聊天"
         default: return raw
         }
     }
 
+    /// 分产品占用说明（悬停 / 辅助读屏）。
+    static func grokProductHelp(_ raw: String) -> String {
+        switch raw.lowercased() {
+        case "grokbuild":
+            return "Grok Build / 本机 CLI 编程消耗，占用本周统一额度池的比例。"
+        case "api":
+            return "通过 xAI 开放 API（api.x.ai / Console 密钥）调用模型的消耗，与 CLI 共用同一周额度池。"
+        case "grokchat":
+            return "grok.com 网页聊天消耗，与 CLI / 开放 API 共用同一周额度池。"
+        default:
+            return "该产品在本周统一额度池中的占用比例（与周剩余共用同一重置时间）。"
+        }
+    }
+
     /// 分产品占用：显示该产品在统一周额度里占了多少，不展示独立重置时间。
-    func grokProductShareRow(name: String, usedPct: Double, tint: Color) -> some View {
+    func grokProductShareRow(name: String, usedPct: Double, tint: Color, help: String) -> some View {
         VStack(spacing: 4) {
             HStack {
-                Text(name).font(.system(size: 11)).foregroundStyle(Theme.tSecondary)
-                Spacer()
+                Text(name)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.tSecondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+                Spacer(minLength: 6)
                 Text(String(format: "占用 %.0f%%", usedPct))
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
                     .foregroundStyle(Theme.tPrimary)
             }
             MiniBar(value: max(0, min(100, 100 - usedPct)), tint: tint.opacity(0.75))
         }
-        .help("\(name) 在本周统一额度池中的占用比例（与周剩余共用同一重置时间）")
+        .help(help)
     }
 
     // MARK: - Qoder IDE 卡片

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -497,11 +497,12 @@ struct PanelView: View {
             if let pct = g.pct, g.stale != true {
                 if r.sessions > 0 || r.usage_calls > 0 { thinDivider }
                 let title = (g.window == "month") ? "月剩余" : "周剩余"
+                // 总剩余：同一周额度池。分产品 usagePercent 是该产品在池内的占用占比，不是独立额度剩余。
                 quotaRow(title: title, pct: 100 - pct, reset: g.reset, tint: Theme.grok)
                 ForEach(g.products.filter { $0.pct != nil }) { product in
-                    if let p = product.pct {
-                        quotaRow(title: product.name, pct: 100 - p, reset: nil,
-                                 tint: Theme.grok.opacity(0.85))
+                    if let used = product.pct {
+                        grokProductShareRow(name: Self.grokProductLabel(product.name),
+                                            usedPct: used, tint: Theme.grok)
                     }
                 }
                 if let plan = g.plan, !plan.isEmpty {
@@ -542,8 +543,33 @@ struct PanelView: View {
         }
         .foregroundStyle(Theme.tTertiary)
         .help(stat.source == "live"
-              ? "已开启 Grok 实时额度查询"
+              ? "已开启 Grok 实时额度查询。Grok Build / API 等为同一周额度池内的占用拆分，共享上方重置时间。"
               : "默认只读 ~/.grok 本地日志，不访问网络")
+    }
+
+    /// 账单 product 字段 → 更可读的名称。
+    static func grokProductLabel(_ raw: String) -> String {
+        switch raw.lowercased() {
+        case "grokbuild": return "Grok Build"
+        case "api": return "API"
+        case "grokchat": return "Grok Chat"
+        default: return raw
+        }
+    }
+
+    /// 分产品占用：显示该产品在统一周额度里占了多少，不展示独立重置时间。
+    func grokProductShareRow(name: String, usedPct: Double, tint: Color) -> some View {
+        VStack(spacing: 4) {
+            HStack {
+                Text(name).font(.system(size: 11)).foregroundStyle(Theme.tSecondary)
+                Spacer()
+                Text(String(format: "占用 %.0f%%", usedPct))
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(Theme.tPrimary)
+            }
+            MiniBar(value: max(0, min(100, 100 - usedPct)), tint: tint.opacity(0.75))
+        }
+        .help("\(name) 在本周统一额度池中的占用比例（与周剩余共用同一重置时间）")
     }
 
     // MARK: - Qoder IDE 卡片
@@ -1119,9 +1145,12 @@ struct PanelView: View {
                 Text(String(format: "%.0f%%", pct))
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
                     .foregroundStyle(pct <= 15 ? AnyShapeStyle(.red) : AnyShapeStyle(Theme.tPrimary))
-                Text("· \(Fmt.reset(reset))")
-                    .font(.system(size: 9.5, design: .monospaced))
-                    .foregroundStyle(Theme.tTertiary)
+                // 无重置时间时不显示「· ?」，避免分产品行误导。
+                if reset != nil {
+                    Text("· \(Fmt.reset(reset))")
+                        .font(.system(size: 9.5, design: .monospaced))
+                        .foregroundStyle(Theme.tTertiary)
+                }
             }
             MiniBar(value: pct, tint: pct <= 15 ? .red : tint)
         }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -42,6 +42,8 @@ struct PanelView: View {
     @AppStorage("showWorkBuddy") private var showWorkBuddy = true
     @AppStorage("showOpenCode") private var showOpenCode = true
     @AppStorage("showQwenCode") private var showQwenCode = true
+    /// 默认关闭：Grok 额度只读本地日志；开启后才用登录凭据请求实时账单接口。
+    @AppStorage("grokLiveQuotaEnabled") private var grokLiveQuotaEnabled = false
 
     private var visibleCount: Int {
         [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showHermes, showZcode, showMimoCode,
@@ -265,8 +267,8 @@ struct PanelView: View {
             ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini, active: gr.sessions > 0,
                          tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
             ToolCardItem(id: "grok", name: "Grok", visible: showGrok,
-                         active: kr.sessions > 0 || kr.usage_calls > 0,
-                         tint: Theme.grok, content: AnyView(grokBlock(kr, model: u.grok.model))),
+                         active: kr.sessions > 0 || kr.usage_calls > 0 || u.grok.pct != nil,
+                         tint: Theme.grok, content: AnyView(grokBlock(u.grok, kr))),
             ToolCardItem(id: "qoder", name: "Qoder", visible: showQoder, active: qr.calls > 0,
                          tint: Theme.qoder, content: AnyView(qoderIdeBlock(u.qoder, qr))),
             ToolCardItem(id: "qoderwork", name: "QoderWork", visible: showQoderWork, active: qwr.calls > 0,
@@ -432,7 +434,7 @@ struct PanelView: View {
 
     // MARK: - Grok 卡片
     @ViewBuilder
-    func grokBlock(_ r: GrokRange, model: String?) -> some View {
+    func grokBlock(_ g: GrokStat, _ r: GrokRange) -> some View {
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Grok", tint: Theme.grok, sessions: r.sessions)
             if r.sessions > 0 || r.usage_calls > 0 {
@@ -476,7 +478,7 @@ struct PanelView: View {
                            extra: grokMetrics, tint: Theme.grok)
                 if r.usage_available && !r.models.isEmpty {
                     tokenModelDisclosure(r.models, open: $grokModelsOpen, tint: Theme.grok)
-                } else if let model, !model.isEmpty {
+                } else if let model = g.model, !model.isEmpty {
                     modelBadge(model, tint: Theme.grok)
                 }
                 Text(r.usage_available
@@ -485,10 +487,59 @@ struct PanelView: View {
                     .font(.system(size: 8.5))
                     .foregroundStyle(Theme.tTertiary)
                     .fixedSize(horizontal: false, vertical: true)
-            } else {
+            } else if g.pct == nil {
                 emptyHint
             }
+            if let pct = g.pct, g.stale != true {
+                if r.sessions > 0 || r.usage_calls > 0 { thinDivider }
+                let title = (g.window == "month") ? "月剩余" : "周剩余"
+                quotaRow(title: title, pct: 100 - pct, reset: g.reset, tint: Theme.grok)
+                ForEach(g.products.filter { $0.pct != nil }) { product in
+                    if let p = product.pct {
+                        quotaRow(title: product.name, pct: 100 - p, reset: nil,
+                                 tint: Theme.grok.opacity(0.85))
+                    }
+                }
+                if let plan = g.plan, !plan.isEmpty {
+                    HStack {
+                        Text("plan").font(.system(size: 11)).foregroundStyle(Theme.tTertiary)
+                        Spacer()
+                        Text(plan)
+                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Theme.tSecondary)
+                            .padding(.horizontal, 7).padding(.vertical, 2)
+                            .background(Capsule().fill(Theme.grok.opacity(0.16)))
+                    }
+                }
+                grokQuotaStatus(g)
+            } else if g.stale == true {
+                if r.sessions > 0 || r.usage_calls > 0 { thinDivider }
+                Text("额度周期已结束，等待 Grok 写入新日志")
+                    .font(.system(size: 9.5, design: .monospaced))
+                    .foregroundStyle(Color.orange.opacity(0.88))
+            }
         }
+    }
+
+    func grokQuotaStatus(_ stat: GrokStat) -> some View {
+        let sourceLabel: String
+        switch stat.source {
+        case "live": sourceLabel = "实时接口"
+        case "cache": sourceLabel = "本地缓存"
+        default: sourceLabel = "本地日志"
+        }
+        let updated = stat.q_updated.map { Fmt.reset($0) } ?? "更新时间未知"
+        return HStack(spacing: 5) {
+            Image(systemName: "clock")
+                .font(.system(size: 9))
+            Text("额度来源 \(sourceLabel) · \(updated)")
+                .font(.system(size: 9.5, design: .monospaced))
+            Spacer()
+        }
+        .foregroundStyle(Theme.tTertiary)
+        .help(stat.source == "live"
+              ? "已开启 Grok 实时额度查询"
+              : "默认只读 ~/.grok 本地日志，不访问网络")
     }
 
     // MARK: - Qoder IDE 卡片
@@ -1207,6 +1258,7 @@ struct PanelView: View {
 
                 VStack(alignment: .leading, spacing: 11) {
                     settingsMenuBarSection
+                    settingsPrivacySection
                     settingsSystemSection
                     settingsReminderSection
                     settingsSyncSection
@@ -1350,8 +1402,26 @@ struct PanelView: View {
         }
     }
 
+    var settingsPrivacySection: some View {
+        settingsSection("lock.shield", "隐私与额度") {
+            settingsToggleRow("Grok 实时额度查询", isOn: $grokLiveQuotaEnabled)
+            Text("默认只读本机 Grok 日志中的额度快照，不访问网络。开启后才会用本地登录凭据请求 Grok 账单接口，以便拿到最新剩余额度。")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .onChange(of: grokLiveQuotaEnabled) { enabled in
+            Self.setGrokLiveQuotaEnabled(enabled)
+            store.refresh()
+        }
+    }
+
     private static func setQoderIdeEnabled(_ enabled: Bool) {
         SyncManager.setQoderIdeEnabled(enabled)
+    }
+
+    private static func setGrokLiveQuotaEnabled(_ enabled: Bool) {
+        SyncManager.setGrokLiveQuotaEnabled(enabled)
     }
 
     /// 启动时把 UI 开关(showQoderIde)的当前值落盘到 config.json。
@@ -1360,6 +1430,12 @@ struct PanelView: View {
     static func syncQoderIdeConfigOnLaunch() {
         let enabled = UserDefaults.standard.object(forKey: "showQoderIde") as? Bool ?? true
         setQoderIdeEnabled(enabled)
+    }
+
+    /// 启动时同步 Grok 实时额度开关（默认关）。
+    static func syncGrokLiveQuotaConfigOnLaunch() {
+        let enabled = UserDefaults.standard.object(forKey: "grokLiveQuotaEnabled") as? Bool ?? false
+        setGrokLiveQuotaEnabled(enabled)
     }
 
     var settingsPricingSection: some View {

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -220,6 +220,24 @@ final class SyncManager {
         } ?? false
     }
 
+    /// Grok 实时额度：默认关闭，只写 config 字段，不改动同步相关配置。
+    @discardableResult
+    static func setGrokLiveQuotaEnabled(_ enabled: Bool) -> Bool {
+        withConfigLock {
+            var dictionary: [String: Any] = [:]
+            if FileManager.default.fileExists(atPath: configPath.path) {
+                let data = try Data(contentsOf: configPath)
+                guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                dictionary = object
+            }
+            dictionary["grok_live_quota_enabled"] = enabled
+            try writeConfigDictionary(dictionary)
+            return true
+        } ?? false
+    }
+
     // MARK: - Read peers
 
     func loadPeers() -> PeerLoadReport {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -243,20 +243,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         if let u = store.usage {
             let ud = UserDefaults.standard
-            if ud.object(forKey: "showClaude") as? Bool ?? true,
+            // 菜单栏额度来源与「显示卡片」独立：卡片可开，但状态栏只显示用户勾选的来源。
+            if MenuBarQuotaSource.claude.isEnabled,
+               ud.object(forKey: "showClaude") as? Bool ?? true,
                u.claude.q5_stale != true,
                let q5 = u.claude.q5 {
                 let remaining = 100 - q5
                 metrics.append(.init(kind: .claude, value: String(format: "%.0f", remaining),
                                      remaining: remaining))
             }
-            if ud.object(forKey: "showCodex") as? Bool ?? true,
+            if MenuBarQuotaSource.codex.isEnabled,
+               ud.object(forKey: "showCodex") as? Bool ?? true,
                let quota = u.codex.p5 ?? u.codex.pw {
                 let remaining = 100 - quota
                 metrics.append(.init(kind: .codex, value: String(format: "%.0f", remaining),
                                      remaining: remaining))
             }
-            if ud.object(forKey: "showGrok") as? Bool ?? true,
+            if MenuBarQuotaSource.grok.isEnabled,
+               ud.object(forKey: "showGrok") as? Bool ?? true,
                u.grok.stale != true,
                let pct = u.grok.pct {
                 let remaining = 100 - pct

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -268,29 +268,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                      remaining: remaining))
             }
             if metrics.isEmpty {
-                let showC = ud.object(forKey: "showClaude") as? Bool ?? true
-                let showX = ud.object(forKey: "showCodex") as? Bool ?? true
-                let showP = ud.object(forKey: "showPi") as? Bool ?? true
-                let showW = ud.object(forKey: "showWorkBuddy") as? Bool ?? true
-                let showO = ud.object(forKey: "showOpenCode") as? Bool ?? true
-                let showQC = ud.object(forKey: "showQwenCode") as? Bool ?? true
-                let showQ = ud.object(forKey: "showQoderIde") as? Bool ?? false
-                let showZ = ud.object(forKey: "showZcode") as? Bool ?? true
-                let showM = ud.object(forKey: "showMimoCode") as? Bool ?? true
-                var total = 0
-                if showC { let r = u.claude.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
-                if showX { let r = u.codex.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
-                if showP { let r = u.pi.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
-                if showW { let r = u.workbuddy.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
-                if showO { let r = u.opencode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
-                if showQC { let r = u.qwencode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.reason) }
-                if showQ { let r = u.qoder.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
-                if showZ { let r = u.zcode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
-                if showM { let r = u.mimocode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
-                if total > 0 {
-                    metrics.append(.init(kind: .total, value: Fmt.human(total)))
-                } else {
+                // 用户把额度来源全部关掉时：只保留图标，不再回退显示今日 token 总量。
+                let anyQuotaSourceOn = MenuBarQuotaSource.allCases.contains { $0.isEnabled }
+                if !anyQuotaSourceOn {
                     fallbackIcon = true
+                } else {
+                    let showC = ud.object(forKey: "showClaude") as? Bool ?? true
+                    let showX = ud.object(forKey: "showCodex") as? Bool ?? true
+                    let showP = ud.object(forKey: "showPi") as? Bool ?? true
+                    let showW = ud.object(forKey: "showWorkBuddy") as? Bool ?? true
+                    let showO = ud.object(forKey: "showOpenCode") as? Bool ?? true
+                    let showQC = ud.object(forKey: "showQwenCode") as? Bool ?? true
+                    let showQ = ud.object(forKey: "showQoderIde") as? Bool ?? false
+                    let showZ = ud.object(forKey: "showZcode") as? Bool ?? true
+                    let showM = ud.object(forKey: "showMimoCode") as? Bool ?? true
+                    var total = 0
+                    if showC { let r = u.claude.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
+                    if showX { let r = u.codex.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
+                    if showP { let r = u.pi.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                    if showW { let r = u.workbuddy.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
+                    if showO { let r = u.opencode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                    if showQC { let r = u.qwencode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.reason) }
+                    if showQ { let r = u.qoder.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
+                    if showZ { let r = u.zcode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                    if showM { let r = u.mimocode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                    if total > 0 {
+                        metrics.append(.init(kind: .total, value: Fmt.human(total)))
+                    } else {
+                        fallbackIcon = true
+                    }
                 }
             }
         } else {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -175,9 +175,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var timer: Timer?
     var globalMouseMonitor: Any?
 
-    // 菜单栏额度颜色(与面板 Theme.claude/codex 一致)。
+    // 菜单栏额度颜色(与面板 Theme.claude/codex/grok 一致)。
     static let claudeColor = NSColor(red: 0.92, green: 0.52, blue: 0.40, alpha: 1)
     static let codexColor  = NSColor(red: 0.42, green: 0.68, blue: 0.98, alpha: 1)
+    static let grokColor   = NSColor(red: 0.65, green: 0.68, blue: 0.75, alpha: 1)
 
     func applicationDidFinishLaunching(_ note: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -194,9 +195,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior = .applicationDefined
         popover.animates = true
 
-        // 启动时先把 Qoder IDE 开关状态落盘到 config.json,
-        // 确保随后的 refresh() 触发的 Python 扫描能读到正确的 qoder_ide_enabled。
+        // 启动时先把 Qoder IDE / Grok 实时额度开关落盘到 config.json,
+        // 确保随后的 refresh() 触发的 Python 扫描能读到正确配置。
         PanelView.syncQoderIdeConfigOnLaunch()
+        PanelView.syncGrokLiveQuotaConfigOnLaunch()
         if var syncConfig = store.syncManager.config {
             let interval = SyncManager.normalizedSyncInterval(syncConfig.sync_interval)
             if syncConfig.sync_interval != interval {
@@ -254,6 +256,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 metrics.append(.init(kind: .codex, value: String(format: "%.0f", remaining),
                                      remaining: remaining))
             }
+            if ud.object(forKey: "showGrok") as? Bool ?? true,
+               u.grok.stale != true,
+               let pct = u.grok.pct {
+                let remaining = 100 - pct
+                metrics.append(.init(kind: .grok, value: String(format: "%.0f", remaining),
+                                     remaining: remaining))
+            }
             if metrics.isEmpty {
                 let showC = ud.object(forKey: "showClaude") as? Bool ?? true
                 let showX = ud.object(forKey: "showCodex") as? Bool ?? true
@@ -303,6 +312,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             switch metric.kind {
             case .claude: name = "Claude"
             case .codex: name = "Codex"
+            case .grok: name = "Grok"
             case .total: name = "今日"
             }
             if metric.remaining != nil {

--- a/tests/test_grok_quota.py
+++ b/tests/test_grok_quota.py
@@ -1,0 +1,208 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from .test_codex_limits import USAGE
+except ImportError:
+    from test_codex_limits import USAGE
+
+
+def write_jsonl(path, records):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record) + "\n")
+
+
+class GrokQuotaTests(unittest.TestCase):
+    def setUp(self):
+        self.old_home = USAGE.GROK_HOME
+        self.old_log = USAGE.GROK_LOG
+        self.old_auth = USAGE.GROK_AUTH
+        self.old_cache = USAGE.GROK_QUOTA_CACHE
+        self.old_user = USAGE._USER_DIR
+
+    def tearDown(self):
+        USAGE.GROK_HOME = self.old_home
+        USAGE.GROK_LOG = self.old_log
+        USAGE.GROK_AUTH = self.old_auth
+        USAGE.GROK_QUOTA_CACHE = self.old_cache
+        USAGE._USER_DIR = self.old_user
+
+    def configure(self, root):
+        USAGE.GROK_HOME = str(root / ".grok")
+        USAGE.GROK_LOG = str(root / ".grok" / "logs" / "unified.jsonl")
+        USAGE.GROK_AUTH = str(root / ".grok" / "auth.json")
+        USAGE.GROK_QUOTA_CACHE = str(root / ".tokei" / "grok_quota_cache.json")
+        USAGE._USER_DIR = str(root / ".tokei")
+        Path(USAGE._USER_DIR).mkdir(parents=True, exist_ok=True)
+
+    def billing_line(self, pct, start, end, plan="SuperGrok", products=None, ts=None):
+        config = {
+            "creditUsagePercent": pct,
+            "currentPeriod": {
+                "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                "start": start,
+                "end": end,
+            },
+            "billingPeriodStart": start,
+            "billingPeriodEnd": end,
+        }
+        if products is not None:
+            config["productUsage"] = products
+        return {
+            "ts": ts or start,
+            "msg": "billing: fetched credits config",
+            "ctx": {"config": config, "subscriptionTier": plan},
+        }
+
+    def test_local_log_is_preferred_and_live_disabled_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            write_jsonl(Path(USAGE.GROK_LOG), [
+                self.billing_line(
+                    44.0,
+                    "2026-07-14T08:24:06+00:00",
+                    "2026-07-21T08:24:06+00:00",
+                    ts="2026-07-19T02:00:00+00:00",
+                ),
+            ])
+            with mock.patch.object(USAGE, "fetch_grok_live_quota") as live:
+                quota = USAGE.scan_grok_quota()
+                live.assert_not_called()
+
+        self.assertEqual(quota["pct"], 44.0)
+        self.assertEqual(quota["plan"], "SuperGrok")
+        self.assertEqual(quota["source"], "log")
+        self.assertEqual(quota["window"], "week")
+        self.assertFalse(quota["stale"])
+        self.assertIsNotNone(quota["reset"])
+
+    def test_live_api_only_when_config_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            write_jsonl(Path(USAGE.GROK_LOG), [
+                self.billing_line(
+                    10.0,
+                    "2026-07-14T08:24:06+00:00",
+                    "2026-07-21T08:24:06+00:00",
+                    ts="2026-07-19T01:00:00+00:00",
+                ),
+            ])
+            live_payload = {
+                "pct": 55.0,
+                "reset": 1784622246,
+                "plan": "SuperGrok",
+                "products": [{"name": "GrokBuild", "pct": 50.0}],
+                "window": "week",
+                "source": "live",
+                "updated": 1784430000,
+                "stale": False,
+            }
+            with mock.patch.object(USAGE, "fetch_grok_live_quota", return_value=live_payload):
+                quota = USAGE.scan_grok_quota()
+
+        self.assertEqual(quota["pct"], 55.0)
+        self.assertEqual(quota["source"], "live")
+        self.assertEqual(quota["products"][0]["name"], "GrokBuild")
+
+    def test_env_zero_forces_offline_even_if_config_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            write_jsonl(Path(USAGE.GROK_LOG), [
+                self.billing_line(
+                    12.0,
+                    "2026-07-14T08:24:06+00:00",
+                    "2026-07-21T08:24:06+00:00",
+                    ts="2026-07-19T01:00:00+00:00",
+                ),
+            ])
+            with mock.patch.dict(USAGE.os.environ, {"TOKEI_GROK_LIVE_QUOTA": "0"}), \
+                 mock.patch.object(USAGE, "fetch_grok_live_quota") as live:
+                self.assertFalse(USAGE._grok_live_quota_enabled())
+                quota = USAGE.scan_grok_quota()
+                live.assert_not_called()
+
+        self.assertEqual(quota["source"], "log")
+        self.assertEqual(quota["pct"], 12.0)
+
+    def test_normalize_marks_expired_period_stale(self):
+        # 2020-01-01 的 epoch 约 1577836800；用更大 now 判定已过期。
+        quota = USAGE._normalize_grok_billing(
+            {
+                "creditUsagePercent": 80.0,
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "end": "2020-01-01T00:00:00+00:00",
+                },
+                "productUsage": [{"product": "GrokBuild", "usagePercent": 70.0}],
+            },
+            plan="SuperGrok",
+            source="log",
+            updated=1_700_000_000,
+            now_epoch=1_700_000_000,
+        )
+        self.assertTrue(quota["stale"])
+        self.assertEqual(quota["pct"], 0.0)
+        self.assertIsNone(quota["reset"])
+        self.assertEqual(quota["products"][0]["pct"], 0.0)
+
+    def test_live_fetch_uses_auth_and_writes_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            Path(USAGE.GROK_AUTH).parent.mkdir(parents=True, exist_ok=True)
+            Path(USAGE.GROK_AUTH).write_text(json.dumps({
+                "https://auth.x.ai::id": {"key": "test-token", "auth_mode": "oidc"},
+            }), encoding="utf-8")
+
+            class FakeResponse:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    return False
+
+                def read(self):
+                    return json.dumps({
+                        "config": {
+                            "creditUsagePercent": 33.0,
+                            "currentPeriod": {
+                                "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                                "start": "2026-07-14T08:24:06+00:00",
+                                "end": "2026-07-21T08:24:06+00:00",
+                            },
+                            "productUsage": [
+                                {"product": "GrokBuild", "usagePercent": 30.0},
+                                {"product": "Api", "usagePercent": 3.0},
+                            ],
+                        }
+                    }).encode("utf-8")
+
+            with mock.patch("urllib.request.urlopen", return_value=FakeResponse()) as opener:
+                quota = USAGE.fetch_grok_live_quota()
+
+            self.assertEqual(opener.call_count, 1)
+            req = opener.call_args[0][0]
+            self.assertEqual(req.full_url, USAGE._GROK_LIVE_BILLING_URL)
+            self.assertEqual(req.get_header("Authorization"), "Bearer test-token")
+            self.assertEqual(quota["pct"], 33.0)
+            self.assertEqual(quota["source"], "live")
+            cached = json.loads(Path(USAGE.GROK_QUOTA_CACHE).read_text(encoding="utf-8"))
+            self.assertEqual(cached["quota"]["pct"], 33.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grok_quota.py
+++ b/tests/test_grok_quota.py
@@ -157,41 +157,52 @@ class GrokQuotaTests(unittest.TestCase):
         self.assertIsNone(quota["reset"])
         self.assertEqual(quota["products"][0]["pct"], 0.0)
 
+    def _write_auth(self, token="test-token"):
+        Path(USAGE.GROK_AUTH).parent.mkdir(parents=True, exist_ok=True)
+        Path(USAGE.GROK_AUTH).write_text(json.dumps({
+            "https://auth.x.ai::id": {"key": token, "auth_mode": "oidc"},
+        }), encoding="utf-8")
+
+    def _fake_billing_response(self, body):
+        payload = json.dumps(body).encode("utf-8")
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self, *args, **kwargs):
+                return payload
+
+        return FakeResponse()
+
     def test_live_fetch_uses_auth_and_writes_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             self.configure(root)
             (root / ".tokei" / "config.json").write_text(
                 json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
-            Path(USAGE.GROK_AUTH).parent.mkdir(parents=True, exist_ok=True)
-            Path(USAGE.GROK_AUTH).write_text(json.dumps({
-                "https://auth.x.ai::id": {"key": "test-token", "auth_mode": "oidc"},
-            }), encoding="utf-8")
+            self._write_auth()
 
-            class FakeResponse:
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    return False
-
-                def read(self):
-                    return json.dumps({
-                        "config": {
-                            "creditUsagePercent": 33.0,
-                            "currentPeriod": {
-                                "type": "USAGE_PERIOD_TYPE_WEEKLY",
-                                "start": "2026-07-14T08:24:06+00:00",
-                                "end": "2026-07-21T08:24:06+00:00",
-                            },
-                            "productUsage": [
-                                {"product": "GrokBuild", "usagePercent": 30.0},
-                                {"product": "Api", "usagePercent": 3.0},
-                            ],
-                        }
-                    }).encode("utf-8")
-
-            with mock.patch("urllib.request.urlopen", return_value=FakeResponse()) as opener:
+            body = {
+                "config": {
+                    "creditUsagePercent": 33.0,
+                    "currentPeriod": {
+                        "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                        "start": "2026-07-14T08:24:06+00:00",
+                        "end": "2026-07-21T08:24:06+00:00",
+                    },
+                    "productUsage": [
+                        {"product": "GrokBuild", "usagePercent": 30.0},
+                        {"product": "Api", "usagePercent": 3.0},
+                        {"product": "GrokChat"},
+                    ],
+                }
+            }
+            with mock.patch("urllib.request.urlopen",
+                            return_value=self._fake_billing_response(body)) as opener:
                 quota = USAGE.fetch_grok_live_quota()
 
             self.assertEqual(opener.call_count, 1)
@@ -200,8 +211,173 @@ class GrokQuotaTests(unittest.TestCase):
             self.assertEqual(req.get_header("Authorization"), "Bearer test-token")
             self.assertEqual(quota["pct"], 33.0)
             self.assertEqual(quota["source"], "live")
+            self.assertEqual(quota["window"], "week")
+            self.assertIsNotNone(quota["reset"])
+            # GrokChat 无 usagePercent 时 pct 为 None，UI 会过滤；解析仍保留条目。
+            self.assertEqual(
+                [(p["name"], p["pct"]) for p in quota["products"]],
+                [("GrokBuild", 30.0), ("Api", 3.0), ("GrokChat", None)],
+            )
             cached = json.loads(Path(USAGE.GROK_QUOTA_CACHE).read_text(encoding="utf-8"))
             self.assertEqual(cached["quota"]["pct"], 33.0)
+            self.assertEqual(cached["source"], "live")
+
+    def test_live_api_parses_real_shape_product_usage(self):
+        """对齐真实接口：creditUsagePercent + productUsage 占用拆分。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            self._write_auth()
+            body = {
+                "config": {
+                    "currentPeriod": {
+                        "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                        "start": "2026-07-14T08:24:06.864825+00:00",
+                        "end": "2026-07-21T08:24:06.864825+00:00",
+                    },
+                    "creditUsagePercent": 54.0,
+                    "productUsage": [
+                        {"product": "GrokBuild", "usagePercent": 52.0},
+                        {"product": "Api", "usagePercent": 2.0},
+                        {"product": "GrokChat"},
+                    ],
+                    "isUnifiedBillingUser": True,
+                    "billingPeriodStart": "2026-07-14T08:24:06.864825+00:00",
+                    "billingPeriodEnd": "2026-07-21T08:24:06.864825+00:00",
+                }
+            }
+            with mock.patch("urllib.request.urlopen",
+                            return_value=self._fake_billing_response(body)):
+                quota = USAGE.fetch_grok_live_quota()
+
+        self.assertEqual(quota["pct"], 54.0)
+        self.assertEqual(quota["source"], "live")
+        self.assertEqual(quota["products"][0]["name"], "GrokBuild")
+        self.assertEqual(quota["products"][0]["pct"], 52.0)
+        self.assertEqual(quota["products"][1]["name"], "Api")
+        self.assertEqual(quota["products"][1]["pct"], 2.0)
+        # 分产品是占用占比，总和应接近总已用（允许接口四舍五入）
+        used = sum(p["pct"] for p in quota["products"] if p["pct"] is not None)
+        self.assertAlmostEqual(used, 54.0, places=5)
+
+    def test_live_api_failure_falls_back_to_local_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            self._write_auth()
+            write_jsonl(Path(USAGE.GROK_LOG), [
+                self.billing_line(
+                    41.0,
+                    "2026-07-14T08:24:06+00:00",
+                    "2026-07-21T08:24:06+00:00",
+                    ts="2026-07-19T03:00:00+00:00",
+                ),
+            ])
+            with mock.patch("urllib.request.urlopen", side_effect=OSError("network down")):
+                quota = USAGE.scan_grok_quota()
+
+        self.assertEqual(quota["pct"], 41.0)
+        self.assertEqual(quota["source"], "log")
+        self.assertEqual(quota["plan"], "SuperGrok")
+
+    def test_live_api_skipped_without_auth_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            # 无 auth.json
+            write_jsonl(Path(USAGE.GROK_LOG), [
+                self.billing_line(
+                    22.0,
+                    "2026-07-14T08:24:06+00:00",
+                    "2026-07-21T08:24:06+00:00",
+                    ts="2026-07-19T03:00:00+00:00",
+                ),
+            ])
+            with mock.patch("urllib.request.urlopen") as opener:
+                quota = USAGE.scan_grok_quota()
+                opener.assert_not_called()
+
+        self.assertEqual(quota["source"], "log")
+        self.assertEqual(quota["pct"], 22.0)
+
+    def test_compute_surfaces_live_quota_fields(self):
+        """compute() 输出的 grok 块应带上 pct/reset/products/source。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            (root / ".tokei" / "config.json").write_text(
+                json.dumps({"grok_live_quota_enabled": True}), encoding="utf-8")
+            self._write_auth()
+            write_jsonl(Path(USAGE.GROK_LOG), [])
+            live = {
+                "pct": 12.5,
+                "reset": 1_784_622_246,
+                "plan": "SuperGrok",
+                "products": [
+                    {"name": "GrokBuild", "pct": 10.0},
+                    {"name": "Api", "pct": 2.5},
+                ],
+                "window": "week",
+                "source": "live",
+                "updated": 1_784_400_000,
+                "stale": False,
+            }
+            empty_ranges = {
+                k: {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0,
+                    "cost": 0.0, "models": {}, "usage_sessions": set(), "usage_calls": 0,
+                    "sessions": set(), "turns": 0, "tools": 0, "duration": 0,
+                    "ctx_used": 0, "ctx_window": 0, "errors": 0, "cancellations": 0,
+                    "ttft_sum": 0, "response_sum": 0, "latency_count": 0}
+                for k in USAGE.RANGE_KEYS
+            }
+            with mock.patch.object(USAGE, "scan_grok",
+                                   return_value={"ranges": empty_ranges, "model": "grok-4.5",
+                                                 "days": {}}), \
+                 mock.patch.object(USAGE, "scan_grok_quota", return_value=live), \
+                 mock.patch.object(USAGE, "scan_claude",
+                                   return_value=USAGE._empty_claude()), \
+                 mock.patch.object(USAGE, "scan_codex",
+                                   return_value=USAGE._empty_codex()), \
+                 mock.patch.object(USAGE, "scan_gemini",
+                                   return_value=USAGE._empty_gemini()), \
+                 mock.patch.object(USAGE, "scan_qoder",
+                                   return_value=USAGE._empty_qoder()), \
+                 mock.patch.object(USAGE, "scan_qoder_ide",
+                                   return_value=USAGE._empty_qoder_ide()), \
+                 mock.patch.object(USAGE, "scan_hermes",
+                                   return_value=USAGE._empty_hermes()), \
+                 mock.patch.object(USAGE, "scan_zcode",
+                                   return_value=USAGE._empty_zcode()), \
+                 mock.patch.object(USAGE, "scan_mimocode",
+                                   return_value=USAGE._empty_mimocode()), \
+                 mock.patch.object(USAGE, "scan_openclaw",
+                                   return_value=USAGE._empty_openclaw()), \
+                 mock.patch.object(USAGE, "scan_pi",
+                                   return_value=USAGE._empty_pi()), \
+                 mock.patch.object(USAGE, "scan_workbuddy",
+                                   return_value=USAGE._empty_workbuddy()), \
+                 mock.patch.object(USAGE, "scan_opencode",
+                                   return_value=USAGE._empty_opencode()), \
+                 mock.patch.object(USAGE, "scan_qwencode",
+                                   return_value=USAGE._empty_qwencode()), \
+                 mock.patch.object(USAGE, "scan_claude_plan", return_value={}):
+                result = USAGE.compute()
+
+        grok = result["grok"]
+        self.assertEqual(grok["pct"], 12.5)
+        self.assertEqual(grok["reset"], 1_784_622_246)
+        self.assertEqual(grok["plan"], "SuperGrok")
+        self.assertEqual(grok["source"], "live")
+        self.assertEqual(grok["window"], "week")
+        self.assertEqual(grok["products"][1]["name"], "Api")
+        self.assertEqual(grok["products"][1]["pct"], 2.5)
+        self.assertEqual(grok["model"], "grok-4.5")
 
 
 if __name__ == "__main__":

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -6,6 +6,8 @@
 # <swiftbar.runInBash>false</swiftbar.runInBash>
 #
 # 数据主要读自本地会话日志,不改动任何 CLI；Codex 额度会短缓存查询官方 live usage。
+# Grok 额度默认只读本地 unified.jsonl billing 日志；实时账单接口需显式开启
+# (config grok_live_quota_enabled 或 TOKEI_GROK_LIVE_QUOTA=1)。
 # 仅 --update-prices 显式联网更新价格表:
 #   Claude Code: ~/.claude/projects/<proj>/<session>.jsonl  (assistant 行 message.usage,增量)
 #   Codex:       ~/.codex/{sessions,archived_sessions}/**/rollout-*.jsonl (token_count 事件,含额度)
@@ -82,6 +84,7 @@ GROK_HOME = os.path.abspath(os.path.expanduser(
     os.environ.get("GROK_HOME", os.path.join(HOME, ".grok"))))
 GROK_DIR = os.path.join(GROK_HOME, "sessions")
 GROK_LOG = os.path.join(GROK_HOME, "logs", "unified.jsonl")
+GROK_AUTH = os.path.join(GROK_HOME, "auth.json")
 WORKBUDDY_DIR = os.path.join(HOME, ".workbuddy", "projects")
 QODER_IDE_DB = os.path.join(HOME, "Library", "Application Support", "Qoder",
                             "SharedClientCache", "cache", "db", "local.db")
@@ -139,6 +142,7 @@ PRICING_FILE = _writable_path("pricing.json")
 OVERRIDES_FILE = _writable_path("pricing_overrides.json")
 CODEX_QUOTA_CACHE = _writable_path("codex_quota_cache.json")
 CLAUDE_QUOTA_CACHE = _writable_path("claude_quota_cache.json")
+GROK_QUOTA_CACHE = _writable_path("grok_quota_cache.json")
 
 # 每 1M token 美元单价。基准价来自 OpenRouter,外置在 pricing.json(由 --update-prices 同步);
 # pricing_overrides.json 做本地修正(write1h / 别名 / 缺漏),一键更新不覆盖它。
@@ -2011,6 +2015,254 @@ def _grok_usage_days(records, sessions, latest_model):
                 project_day["sessions"].add(sid)
             project_day["models"][model] = project_day["models"].get(model, 0) + amount
     return days
+
+
+# ---------- Grok 额度 (默认只读本地日志;实时 API 需显式开启) ----------
+# 本地: ~/.grok/logs/unified.jsonl 中 `billing: fetched credits config`
+# 可选: GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
+# 开关: ~/.tokei/config.json 的 grok_live_quota_enabled, 或 TOKEI_GROK_LIVE_QUOTA=1
+_GROK_QUOTA_TTL = 30
+_GROK_QUOTA_FALLBACK_TTL = 300
+_GROK_QUOTA_LOG_SCAN_BYTES = 2 * 1024 * 1024
+_GROK_BILLING_MSG = "billing: fetched credits config"
+_GROK_LIVE_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+
+
+def _tokei_config():
+    cfg = _load_json(os.path.join(_USER_DIR, "config.json"), {})
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _grok_live_quota_enabled():
+    """实时额度默认关闭;仅用户显式开启或环境变量强制时才联网。"""
+    env = os.environ.get("TOKEI_GROK_LIVE_QUOTA")
+    if env == "0":
+        return False
+    if env == "1":
+        return True
+    return bool(_tokei_config().get("grok_live_quota_enabled"))
+
+
+def _grok_auth_token():
+    auth = _load_json(GROK_AUTH, {})
+    if not isinstance(auth, dict):
+        return None
+    for entry in auth.values():
+        if not isinstance(entry, dict):
+            continue
+        token = entry.get("key") or entry.get("access_token")
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    return None
+
+
+def _normalize_grok_billing(config, *, plan=None, source=None, updated=None,
+                            now_epoch=None):
+    if not isinstance(config, dict):
+        return None
+    pct_raw = config.get("creditUsagePercent")
+    if pct_raw is None:
+        return None
+    try:
+        pct = float(pct_raw)
+    except (TypeError, ValueError):
+        return None
+    period = config.get("currentPeriod") if isinstance(config.get("currentPeriod"), dict) else {}
+    end = period.get("end") or config.get("billingPeriodEnd")
+    reset = _iso_to_epoch(end) if end else None
+    products = []
+    for item in config.get("productUsage") or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("product") or item.get("name")
+        if not name:
+            continue
+        usage_pct = item.get("usagePercent")
+        try:
+            products.append({
+                "name": str(name),
+                "pct": float(usage_pct) if usage_pct is not None else None,
+            })
+        except (TypeError, ValueError):
+            products.append({"name": str(name), "pct": None})
+    now = int(now_epoch if now_epoch is not None else datetime.now().timestamp())
+    stale = bool(reset is not None and reset <= now)
+    if stale:
+        # 周期已过重置点,本地快照不再代表当前额度。
+        pct = 0.0
+        for item in products:
+            if item.get("pct") is not None:
+                item["pct"] = 0.0
+    period_type = period.get("type") or ""
+    if "WEEKLY" in str(period_type).upper():
+        window = "week"
+    elif "MONTH" in str(period_type).upper():
+        window = "month"
+    else:
+        window = "week"
+    plan_name = plan
+    if not plan_name:
+        plan_name = config.get("subscriptionTier") or config.get("plan")
+    return {
+        "pct": pct,
+        "reset": None if stale else reset,
+        "plan": plan_name,
+        "products": products,
+        "window": window,
+        "source": source,
+        "updated": int(updated) if updated is not None else now,
+        "stale": stale,
+    }
+
+
+def _scan_grok_billing_from_log(path=None, max_bytes=_GROK_QUOTA_LOG_SCAN_BYTES):
+    """从 unified.jsonl 尾部读取最近一次 billing: fetched credits config。"""
+    log_path = path or GROK_LOG
+    try:
+        size = os.path.getsize(log_path)
+    except OSError:
+        return None
+    if size <= 0:
+        return None
+    start = max(0, size - max_bytes)
+    latest = None
+    latest_ts = None
+    try:
+        with open(log_path, "rb") as fh:
+            fh.seek(start)
+            if start:
+                fh.readline()  # 丢掉半行
+            for raw in fh:
+                if _GROK_BILLING_MSG.encode("utf-8") not in raw:
+                    continue
+                try:
+                    obj = json.loads(raw.decode("utf-8", errors="ignore"))
+                except Exception:
+                    continue
+                if obj.get("msg") != _GROK_BILLING_MSG:
+                    continue
+                ctx = obj.get("ctx") or {}
+                if not isinstance(ctx, dict):
+                    continue
+                config = ctx.get("config")
+                if not isinstance(config, dict):
+                    continue
+                ts = obj.get("ts")
+                if latest_ts is None or (isinstance(ts, str) and ts >= latest_ts):
+                    latest_ts = ts if isinstance(ts, str) else latest_ts
+                    latest = {
+                        "config": config,
+                        "plan": ctx.get("subscriptionTier") or ctx.get("plan"),
+                        "ts": ts,
+                    }
+    except OSError:
+        return None
+    if not latest:
+        return None
+    updated = _iso_to_epoch(latest.get("ts"))
+    return _normalize_grok_billing(
+        latest["config"], plan=latest.get("plan"), source="log", updated=updated)
+
+
+def _cached_grok_quota(max_age):
+    cached = _load_json(GROK_QUOTA_CACHE, {})
+    if not isinstance(cached, dict):
+        return None
+    quota = cached.get("quota")
+    fetched_at = cached.get("fetched_at")
+    if not isinstance(quota, dict) or fetched_at is None:
+        return None
+    try:
+        age = datetime.now().timestamp() - float(fetched_at)
+    except (TypeError, ValueError):
+        return None
+    if age > max_age:
+        return None
+    out = dict(quota)
+    out.setdefault("source", cached.get("source") or out.get("source") or "cache")
+    return out
+
+
+def _save_grok_quota_cache(quota):
+    if not isinstance(quota, dict) or quota.get("pct") is None:
+        return
+    try:
+        os.makedirs(os.path.dirname(GROK_QUOTA_CACHE) or _USER_DIR, exist_ok=True)
+        _atomic_write_json(GROK_QUOTA_CACHE, {
+            "fetched_at": datetime.now().timestamp(),
+            "source": quota.get("source"),
+            "quota": quota,
+        })
+        try:
+            os.chmod(GROK_QUOTA_CACHE, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        pass
+
+
+def fetch_grok_live_quota():
+    """仅在用户开启时请求 Grok billing API;失败回退到短缓存。"""
+    if not _grok_live_quota_enabled():
+        return None
+    cached = _cached_grok_quota(_GROK_QUOTA_TTL)
+    if cached and cached.get("source") == "live":
+        return cached
+    token = _grok_auth_token()
+    if not token:
+        return _cached_grok_quota(_GROK_QUOTA_FALLBACK_TTL)
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            _GROK_LIVE_BILLING_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "User-Agent": "Tokei",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=3) as res:
+            data = json.load(res)
+        config = data.get("config") if isinstance(data, dict) else None
+        plan = None
+        if isinstance(data, dict):
+            plan = data.get("subscriptionTier") or data.get("plan")
+        quota = _normalize_grok_billing(config, plan=plan, source="live")
+        if not quota:
+            return _cached_grok_quota(_GROK_QUOTA_FALLBACK_TTL)
+        _save_grok_quota_cache(quota)
+        return quota
+    except Exception:
+        return _cached_grok_quota(_GROK_QUOTA_FALLBACK_TTL)
+
+
+def scan_grok_quota():
+    """默认优先本地日志;仅显式开启时才走实时 API。"""
+    log_quota = _scan_grok_billing_from_log()
+    if log_quota and not log_quota.get("stale"):
+        _save_grok_quota_cache(log_quota)
+
+    if _grok_live_quota_enabled():
+        live = fetch_grok_live_quota()
+        if live and live.get("pct") is not None:
+            return live
+
+    if log_quota and log_quota.get("pct") is not None:
+        return log_quota
+
+    cached = _cached_grok_quota(_GROK_QUOTA_FALLBACK_TTL * 12)  # 本地缓存放宽到约 1 小时
+    if cached and cached.get("pct") is not None:
+        out = dict(cached)
+        out["source"] = "cache"
+        # 过期周期仍标 stale
+        reset = out.get("reset")
+        now = int(datetime.now().timestamp())
+        if reset is not None and int(reset) <= now:
+            out["stale"] = True
+            out["pct"] = 0.0
+            out["reset"] = None
+        return out
+    return {}
 
 
 def scan_grok(bounds, cache=None):
@@ -4082,6 +4334,7 @@ def compute():
     r5, rw = quota["r5"], quota["rw"]
 
     plan = _safe_scan("claude_plan", scan_claude_plan, lambda: {}, errors) or {}
+    grok_quota = _safe_scan("grok_quota", scan_grok_quota, lambda: {}, errors) or {}
 
     result = {
         "claude": {
@@ -4103,6 +4356,14 @@ def compute():
         "grok": {
             "ranges": kranges,
             "model": gk["model"],
+            "pct": grok_quota.get("pct"),
+            "reset": grok_quota.get("reset"),
+            "plan": grok_quota.get("plan"),
+            "products": grok_quota.get("products") or [],
+            "window": grok_quota.get("window"),
+            "source": grok_quota.get("source"),
+            "q_updated": grok_quota.get("updated"),
+            "stale": grok_quota.get("stale"),
         },
         "qoderwork": {
             "ranges": qwranges,
@@ -4362,6 +4623,11 @@ def main():
     kt = gk["ranges"]["today"]
     print(f"Grok Build {HEAD}")
     print(f"今日 会话   {kt['sessions']:>6} {F}")
+    if gk.get("pct") is not None and not gk.get("stale"):
+        remaining = 100 - float(gk["pct"])
+        print(f"周剩余   {remaining:5.1f}%  reset {fmt_reset(gk.get('reset'))} {F}")
+        if gk.get("plan"):
+            print(f"plan: {gk['plan']} {F}")
     if kt.get("usage_available"):
         print(f"今日 输入   {human(kt['in']):>6} {F}")
         print(f"今日 缓存   {human(kt['cr']):>6} {F}")


### PR DESCRIPTION
## Summary

为 Grok Build 增加与 Claude / Codex 同风格的**周额度展示**（已用/剩余百分比、重置时间、套餐名），并补齐菜单栏额度来源的可控性。

### Grok 额度
- 在 Grok 卡片底部显示周剩余进度条、重置时间、套餐（如 SuperGrok）
- **默认只读本地日志**：解析 `~/.grok/logs/unified.jsonl` 中的 `billing: fetched credits config`，不访问网络
- **可选实时账单查询**（默认关闭）：设置 → 隐私与额度 →「Grok 实时额度查询」
  - 开启后使用 `~/.grok/auth.json` 请求 `cli-chat-proxy.grok.com/v1/billing?format=credits`
  - 可用环境变量 `TOKEI_GROK_LIVE_QUOTA=0/1` 强制关/开
- 实时结果可展示统一额度池内的分产品占用：
  - **Grok Build（本机 CLI）**
  - **开放 API（api.x.ai）**
  - （若有）Grok 网页聊天
- 分产品展示为「占用 %」（同一周额度池的拆分），**不是**独立剩余额度；重置时间只在「周剩余」主行显示
- 失败时回退本地日志或短缓存，不影响主流程

### 菜单栏
- 设置 → 菜单栏 → **额度来源**：独立勾选 Claude / Codex / Grok（与「显示卡片」无关，两列布局）
- 默认：Claude、Codex 开；**Grok 关**（避免新额度源默认占满状态栏）
- 双额度：按勾选显示；单额度：在勾选项中取剩余最少
- **全部关闭时**：状态栏只保留图标，不再回退显示今日 token 总量灰字

## Privacy

| 模式 | 行为 |
|------|------|
| 默认 | 只读 `~/.grok` 本地日志 / 短缓存 |
| 设置开启实时额度 | 用本机 OIDC token 请求 Grok 账单接口 |
| `TOKEI_GROK_LIVE_QUOTA=0` | 强制不联网 |

## Test plan

- [x] `python3 -m unittest tests.test_grok_quota tests.test_grok_usage tests.test_codex_limits`
- [x] 新增/扩展 `tests/test_grok_quota.py`：本地日志、开关、真实 API 响应形状（GrokBuild/Api）、无 token、API 失败回退、`compute()` 透出字段
- [x] `swift build` / `bash package.sh`
- [x] 本机离线读出 SuperGrok 周额度（`source=log`）
- [x] 本机开启实时额度：周剩余 + 分产品占用（CLI / 开放 API），重置时间正常，无「· ?」
- [x] 设置里开关额度来源，状态栏即时变化
- [x] 额度来源全关 → 仅图标、无数字

## Notes

- 采集逻辑与文档见 `CALCULATION.md` / `README.md`
- 不改多设备同步的额度合并策略（额度仍为本机账号状态）