### PR TITLE
fix(hermes): 补齐 0.19 迁移后的历史与辅助用量

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -13,7 +13,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | Gemini CLI | `~/.gemini/*/chats/session-*.json` | JSON, `messages[].tokens` |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl` + `sessions/*/*/{summary,signals}.json` | JSONL, `shell.turn.inference_done` + 会话指标 |
 | Qoder | `~/Library/Application Support/QoderWork/data/agents.db` | SQLite, `messages.metadata` |
-| Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `sessions` 表 |
+| Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `session_model_usage*` 用量表，回退 `sessions` 表 |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` | JSONL 用量 + SQLite 任务 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
@@ -68,6 +68,11 @@ token 快照误删。
 - 缓存读 = `cache_read_tokens`
 - 缓存写 = `cache_write_tokens`
 - 推理 = `reasoning_tokens`
+
+优先合并 `session_model_usage` 与升级中断时保留的 `session_model_usage_v21`，按会话、模型、
+计费端点和任务维度去重；主循环明细不存在时才回退 `sessions` 汇总。这样既包含 0.19 新增的
+审批、标题生成等辅助调用，也保留已删除会话留下的历史用量；会话数仍以 `sessions` 中
+可见的会话为准，避免把内部清理记录重复算作对话。
 
 **OpenCode** — 字段独立:
 - 输入 = `tokens.input`
@@ -211,7 +216,8 @@ cost = non_cached_input/1M × price_in
 
 ### Hermes 成本
 
-直接使用数据库中的 `actual_cost_usd`,回退到 `estimated_cost_usd`。
+优先使用数据库中的 `actual_cost_usd`,回退到 `estimated_cost_usd`；两者都为 0 时按统一
+价格表估算，避免 Hermes 自定义供应商未写入账单金额时把成本显示为 0。
 
 ### Pi Coding Agent CLI / OpenCode 成本
 

--- a/tests/test_cost_recalculation.py
+++ b/tests/test_cost_recalculation.py
@@ -45,6 +45,31 @@ class CostRecalculationTests(unittest.TestCase):
             self.assertEqual(model["cost"], 42.0, tool)
             self.assertEqual(result[tool]["ranges"]["today"]["cost"], 42.0, tool)
 
+    def test_hermes_missing_cost_uses_pricing_fallback(self):
+        name = "Deepseek V4 Flash"
+        model = {
+            "name": name,
+            "in": 100,
+            "out": 20,
+            "cr": 30,
+            "cw": 4,
+            "reason": 5,
+            "cost": 0.0,
+        }
+        result = {"hermes": {"ranges": {"today": {"models": [model], "cost": 0.0}}}}
+
+        USAGE._recalc_costs(result)
+
+        price = USAGE._raw_price(USAGE._pricing_id(name))
+        expected = (
+            100 * price["in"]
+            + 25 * price["out"]
+            + 30 * price["cache_read"]
+            + 4 * price["cache_write"]
+        ) / 1_000_000
+        self.assertAlmostEqual(model["cost"], expected, places=6)
+        self.assertAlmostEqual(result["hermes"]["ranges"]["today"]["cost"], expected, places=6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hermes_usage.py
+++ b/tests/test_hermes_usage.py
@@ -1,0 +1,184 @@
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+from test_codex_limits import USAGE
+
+
+SESSION_SCHEMA = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    model TEXT,
+    started_at REAL,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL
+)
+"""
+
+USAGE_SCHEMA = """
+CREATE TABLE {table} (
+    session_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    billing_provider TEXT NOT NULL DEFAULT '',
+    billing_base_url TEXT NOT NULL DEFAULT '',
+    billing_mode TEXT NOT NULL DEFAULT '',
+    task TEXT DEFAULT '',
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd REAL NOT NULL DEFAULT 0,
+    actual_cost_usd REAL,
+    first_seen REAL,
+    last_seen REAL
+)
+"""
+
+
+class HermesUsageTests(unittest.TestCase):
+    def setUp(self):
+        self.timestamp = datetime.now().astimezone().timestamp()
+
+    def scan(self, db_path):
+        cache = {"v": USAGE._SCAN_CACHE_VERSION}
+        with mock.patch.object(USAGE, "_hermes_db_paths", return_value=[str(db_path)]):
+            return USAGE.scan_hermes(USAGE.range_bounds(), cache)["ranges"]
+
+    def test_sessions_only_database_keeps_legacy_behavior(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "state.db"
+            connection = sqlite3.connect(db_path)
+            connection.execute(SESSION_SCHEMA)
+            connection.execute(
+                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("legacy", "legacy-model", self.timestamp, 100, 20, 30, 4, 5, 1.25, None),
+            )
+            connection.commit()
+            connection.close()
+
+            ranges = self.scan(db_path)
+
+        self.assertEqual(ranges["today"]["in"], 100)
+        self.assertEqual(ranges["today"]["out"], 20)
+        self.assertEqual(ranges["today"]["cr"], 30)
+        self.assertEqual(ranges["today"]["reason"], 5)
+        self.assertEqual(ranges["today"]["sessions"], 1)
+        self.assertEqual(ranges["today"]["cost"], 1.25)
+
+    def test_v22_usage_includes_auxiliary_tasks_without_double_counting_main(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "state.db"
+            connection = sqlite3.connect(db_path)
+            connection.execute(SESSION_SCHEMA)
+            connection.execute(USAGE_SCHEMA.format(table="session_model_usage"))
+            connection.execute(
+                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("active", "main-model", self.timestamp, 100, 20, 0, 0, 3, 1.25, None),
+            )
+            connection.executemany(
+                """INSERT INTO session_model_usage
+                   (session_id, model, task, input_tokens, output_tokens, reasoning_tokens,
+                    first_seen, last_seen)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    ("active", "main-model", "", 100, 20, 3, self.timestamp, self.timestamp),
+                    ("active", "helper-model", "approval", 12, 4, 0, self.timestamp, self.timestamp),
+                    ("active", "helper-model", "title_generation", 8, 1, 0, self.timestamp, self.timestamp),
+                ],
+            )
+            connection.commit()
+            connection.close()
+
+            ranges = self.scan(db_path)
+
+        self.assertEqual(ranges["today"]["in"], 120)
+        self.assertEqual(ranges["today"]["out"], 25)
+        self.assertEqual(ranges["today"]["reason"], 3)
+        self.assertEqual(ranges["today"]["sessions"], 1)
+        self.assertEqual(ranges["today"]["cost"], 1.25)
+        self.assertEqual(ranges["today"]["models"]["main-model"]["in"], 100)
+        self.assertEqual(ranges["today"]["models"]["helper-model"]["in"], 20)
+
+    def test_partial_v22_migration_merges_legacy_orphans_and_current_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "state.db"
+            connection = sqlite3.connect(db_path)
+            connection.execute(SESSION_SCHEMA)
+            connection.execute(USAGE_SCHEMA.format(table="session_model_usage_v21"))
+            connection.execute(USAGE_SCHEMA.format(table="session_model_usage"))
+            connection.executemany(
+                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    ("legacy-valid", "legacy", self.timestamp, 100, 10, 0, 0, 0, 0, None),
+                    ("current", "current", self.timestamp, 200, 20, 0, 0, 0, 0, None),
+                ],
+            )
+            connection.executemany(
+                """INSERT INTO session_model_usage_v21
+                   (session_id, model, task, input_tokens, output_tokens, first_seen, last_seen)
+                   VALUES (?, ?, '', ?, ?, ?, ?)""",
+                [
+                    ("legacy-valid", "legacy", 100, 10, self.timestamp, self.timestamp),
+                    ("deleted-history", "old-model", 300, 30, self.timestamp, self.timestamp),
+                ],
+            )
+            connection.executemany(
+                """INSERT INTO session_model_usage
+                   (session_id, model, task, input_tokens, output_tokens, first_seen, last_seen)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    ("current", "current", "", 200, 20, self.timestamp, self.timestamp),
+                    ("current", "helper", "approval", 10, 2, self.timestamp, self.timestamp),
+                ],
+            )
+            connection.commit()
+            connection.close()
+
+            ranges = self.scan(db_path)
+
+        self.assertEqual(ranges["today"]["in"], 610)
+        self.assertEqual(ranges["today"]["out"], 62)
+        self.assertEqual(ranges["today"]["sessions"], 2)
+
+    def test_duplicate_legacy_and_current_rows_use_larger_cumulative_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "state.db"
+            connection = sqlite3.connect(db_path)
+            connection.execute(SESSION_SCHEMA)
+            connection.execute(USAGE_SCHEMA.format(table="session_model_usage_v21"))
+            connection.execute(USAGE_SCHEMA.format(table="session_model_usage"))
+            connection.execute(
+                "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("same", "model", self.timestamp, 120, 12, 0, 0, 0, 0, None),
+            )
+            for table, inp, out in (
+                ("session_model_usage_v21", 100, 10),
+                ("session_model_usage", 120, 12),
+            ):
+                connection.execute(
+                    f"""INSERT INTO {table}
+                        (session_id, model, task, input_tokens, output_tokens, first_seen, last_seen)
+                        VALUES (?, ?, '', ?, ?, ?, ?)""",
+                    ("same", "model", inp, out, self.timestamp, self.timestamp),
+                )
+            connection.commit()
+            connection.close()
+
+            ranges = self.scan(db_path)
+
+        self.assertEqual(ranges["today"]["in"], 120)
+        self.assertEqual(ranges["today"]["out"], 12)
+        self.assertEqual(ranges["today"]["sessions"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -410,7 +410,7 @@ def human(n: float) -> str:
 # ---------- 增量扫描缓存 ----------
 import tempfile as _tempfile
 _SCAN_CACHE_FILE = os.path.join(_tempfile.gettempdir(), "_tokei_scan_cache.json")
-_SCAN_CACHE_VERSION = 18
+_SCAN_CACHE_VERSION = 19
 _GEMINI_DAYS_CACHE_KEY = "_gemini_dashboard_days"
 _GROK_DAYS_CACHE_KEY = "_grok_dashboard_days"
 
@@ -2425,39 +2425,170 @@ def _hermes_db_paths():
 def _scan_hermes_db(db_path, _sq):
     days = {}
     try:
-        conn = _sq.connect(f"file:{db_path}?mode=ro", uri=True)
-        for row in conn.execute("""
-            SELECT date(started_at,'unixepoch','localtime') as day,
-                   CAST(strftime('%H',started_at,'unixepoch','localtime') AS INTEGER) as hour,
-                   COUNT(*) as cnt, model,
-                   COALESCE(SUM(input_tokens),0),
-                   COALESCE(SUM(output_tokens),0),
-                   COALESCE(SUM(cache_read_tokens),0),
-                   COALESCE(SUM(cache_write_tokens),0),
-                   COALESCE(SUM(reasoning_tokens),0),
-                   COALESCE(SUM(COALESCE(actual_cost_usd,estimated_cost_usd)),0)
-            FROM sessions WHERE started_at > 0
-            GROUP BY day, hour, model
-        """):
-            dk, hour, cnt, model, ti, to_, cr, cw, reason, cost = row
-            if not dk:
+        conn = _sq.connect(_sqlite_ro_uri(db_path), uri=True)
+        conn.row_factory = _sq.Row
+
+        tables = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+        if "sessions" not in tables:
+            conn.close()
+            return days
+
+        def columns(table):
+            return {row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')}
+
+        def expr(alias, available, name, fallback="0"):
+            if name in available:
+                return f'{alias}."{name}"'
+            return fallback
+
+        session_columns = columns("sessions")
+        session_query = f"""
+            SELECT s.id AS session_id,
+                   {expr('s', session_columns, 'started_at')} AS started_at,
+                   {expr('s', session_columns, 'model', "''")} AS model,
+                   {expr('s', session_columns, 'input_tokens')} AS input_tokens,
+                   {expr('s', session_columns, 'output_tokens')} AS output_tokens,
+                   {expr('s', session_columns, 'cache_read_tokens')} AS cache_read_tokens,
+                   {expr('s', session_columns, 'cache_write_tokens')} AS cache_write_tokens,
+                   {expr('s', session_columns, 'reasoning_tokens')} AS reasoning_tokens,
+                   {expr('s', session_columns, 'estimated_cost_usd')} AS estimated_cost_usd,
+                   {expr('s', session_columns, 'actual_cost_usd', 'NULL')} AS actual_cost_usd
+            FROM sessions s
+        """
+        sessions = {row["session_id"]: dict(row) for row in conn.execute(session_query)}
+
+        # Hermes 0.19 / schema v22 会把旧表改名为 session_model_usage_v21，再创建
+        # 带 task 维度的新表。旧库含孤立用量行时迁移会被外键约束中断，两张表会
+        # 同时保留；因此两张都读，并按完整主键去重。
+        usage_rows = {}
+        for table in ("session_model_usage_v21", "session_model_usage"):
+            if table not in tables:
                 continue
+            usage_columns = columns(table)
+            if "session_id" not in usage_columns:
+                continue
+            usage_query = f"""
+                SELECT u.session_id AS session_id,
+                       {expr('u', usage_columns, 'model', "''")} AS model,
+                       {expr('u', usage_columns, 'billing_provider', "''")} AS billing_provider,
+                       {expr('u', usage_columns, 'billing_base_url', "''")} AS billing_base_url,
+                       {expr('u', usage_columns, 'billing_mode', "''")} AS billing_mode,
+                       {expr('u', usage_columns, 'task', "''")} AS task,
+                       {expr('u', usage_columns, 'input_tokens')} AS input_tokens,
+                       {expr('u', usage_columns, 'output_tokens')} AS output_tokens,
+                       {expr('u', usage_columns, 'cache_read_tokens')} AS cache_read_tokens,
+                       {expr('u', usage_columns, 'cache_write_tokens')} AS cache_write_tokens,
+                       {expr('u', usage_columns, 'reasoning_tokens')} AS reasoning_tokens,
+                       {expr('u', usage_columns, 'estimated_cost_usd')} AS estimated_cost_usd,
+                       {expr('u', usage_columns, 'actual_cost_usd', 'NULL')} AS actual_cost_usd,
+                       {expr('u', usage_columns, 'first_seen', 'NULL')} AS first_seen,
+                       {expr('u', usage_columns, 'last_seen', 'NULL')} AS last_seen
+                FROM "{table}" u
+            """
+            for row in conn.execute(usage_query):
+                item = dict(row)
+                key = tuple(item.get(name) or "" for name in (
+                    "session_id", "model", "billing_provider", "billing_base_url",
+                    "billing_mode", "task"))
+                previous = usage_rows.get(key)
+                if previous and token_total({
+                    "in": previous.get("input_tokens", 0),
+                    "out": previous.get("output_tokens", 0),
+                    "cr": previous.get("cache_read_tokens", 0),
+                    "cw": previous.get("cache_write_tokens", 0),
+                    "reason": previous.get("reasoning_tokens", 0),
+                }) > token_total({
+                    "in": item.get("input_tokens", 0),
+                    "out": item.get("output_tokens", 0),
+                    "cr": item.get("cache_read_tokens", 0),
+                    "cw": item.get("cache_write_tokens", 0),
+                    "reason": item.get("reasoning_tokens", 0),
+                }):
+                    continue
+                usage_rows[key] = item
+
+        records = list(usage_rows.values())
+        main_usage_sessions = {
+            row.get("session_id") for row in records if not (row.get("task") or "")}
+
+        # 没有用量明细表或主循环明细缺失时，回退到 sessions 汇总。这样既兼容
+        # 老版本，也不会把 v22 的主循环行与 sessions 再算一次。
+        for session_id, session in sessions.items():
+            if session_id in main_usage_sessions:
+                continue
+            records.append({
+                **session,
+                "task": "",
+                "first_seen": session.get("started_at"),
+                "last_seen": session.get("started_at"),
+            })
+
+        def row_cost(row):
+            actual = row.get("actual_cost_usd")
+            return float(actual if actual is not None else row.get("estimated_cost_usd", 0) or 0)
+
+        records_by_session = {}
+        for row in records:
+            records_by_session.setdefault(row.get("session_id"), []).append(row)
+        for session_id, session_records in records_by_session.items():
+            session = sessions.get(session_id)
+            if not session or any(row_cost(row) for row in session_records):
+                continue
+            fallback_cost = row_cost(session)
+            if not fallback_cost:
+                continue
+            main_records = [row for row in session_records if not (row.get("task") or "")]
+            if not main_records:
+                continue
+            target = next(
+                (row for row in main_records if row.get("model") == session.get("model")),
+                main_records[0],
+            )
+            target["actual_cost_usd"] = session.get("actual_cost_usd")
+            target["estimated_cost_usd"] = session.get("estimated_cost_usd")
+
+        session_first_seen = {}
+        for row in records:
+            session_id = row.get("session_id")
+            if not session_id:
+                continue
+            session = sessions.get(session_id) or {}
+            timestamp = session.get("started_at") or row.get("first_seen") or row.get("last_seen")
+            try:
+                timestamp = float(timestamp)
+                if timestamp > 100_000_000_000:
+                    timestamp /= 1000.0
+            except (TypeError, ValueError):
+                continue
+            if timestamp <= 0:
+                continue
+            session_first_seen[session_id] = min(
+                timestamp, session_first_seen.get(session_id, timestamp))
+
+        day_sessions = {}
+        for row in records:
+            session_id = row.get("session_id")
+            timestamp = session_first_seen.get(session_id)
+            if timestamp is None:
+                continue
+            local_dt = datetime.fromtimestamp(timestamp).astimezone()
+            dk = local_dt.date().isoformat()
             day = days.setdefault(dk, {"in": 0, "out": 0, "cr": 0, "cw": 0,
                                        "reason": 0, "cost": 0.0, "sessions": 0,
                                        "models": {}, "hours": [0] * 24})
-            day["in"] += int(ti); day["out"] += int(to_)
-            day["cr"] += int(cr); day["cw"] += int(cw)
-            day["reason"] += int(reason); day["cost"] += float(cost)
-            day["sessions"] += int(cnt)
-            if hour is not None:
-                day["hours"][int(hour)] += int(ti) + int(to_) + int(cr) + int(cw) + int(reason)
-            if model:
-                mm = day["models"].setdefault(
-                    model, {"in": 0, "out": 0, "cr": 0, "cw": 0,
-                            "reason": 0, "cost": 0.0})
-                mm["in"] += int(ti); mm["out"] += int(to_)
-                mm["cr"] += int(cr); mm["cw"] += int(cw)
-                mm["reason"] += int(reason); mm["cost"] += float(cost)
+            inp = int(row.get("input_tokens") or 0)
+            out = int(row.get("output_tokens") or 0)
+            cr = int(row.get("cache_read_tokens") or 0)
+            cw = int(row.get("cache_write_tokens") or 0)
+            reason = int(row.get("reasoning_tokens") or 0)
+            _add_token_usage(day, inp, out, cr, cw, reason, row_cost(row), row.get("model"))
+            day["hours"][local_dt.hour] += inp + out + cr + cw + reason
+            if session_id in sessions:
+                day_sessions.setdefault(dk, set()).add(session_id)
+
+        for dk, session_ids in day_sessions.items():
+            days[dk]["sessions"] = len(session_ids)
         conn.close()
     except Exception:
         pass
@@ -4145,7 +4276,7 @@ def compute():
 
 def _recalc_costs(result):
     """只重算缺少权威账单的工具；已有日志成本的工具保留原值。"""
-    for tool_key in ("gemini", "zcode", "mimocode", "workbuddy", "qwencode"):
+    for tool_key in ("gemini", "hermes", "zcode", "mimocode", "workbuddy", "qwencode"):
         tool = result.get(tool_key)
         if not tool or "ranges" not in tool:
             continue
@@ -4158,8 +4289,16 @@ def _recalc_costs(result):
             for m in r["models"]:
                 name = m.get("name", "")
                 price_id = _pricing_id(name)
+                authoritative_cost = float(m.get("cost", 0) or 0)
+                if tool_key == "hermes" and authoritative_cost:
+                    total_cost += authoritative_cost
+                    if price_id:
+                        price = _raw_price(price_id)
+                        m["pin"] = price["in"]
+                        m["pout"] = price["out"]
+                    continue
                 if not price_id:
-                    total_cost += float(m.get("cost", 0) or 0)
+                    total_cost += authoritative_cost
                     m["pin"] = 0
                     m["pout"] = 0
                     continue
@@ -4171,7 +4310,7 @@ def _recalc_costs(result):
                     thoughts = m.get("thoughts", 0)
                     cost = (ti / 1e6 * p["in"] + (to + thoughts) / 1e6 * p["out"]
                             + cached / 1e6 * p["cache_read"])
-                elif tool_key in ("zcode", "mimocode"):
+                elif tool_key in ("hermes", "zcode", "mimocode"):
                     cr = m.get("cr", 0)
                     cw = m.get("cw", 0)
                     reason = m.get("reason", 0)


### PR DESCRIPTION
## 问题

Hermes 0.19 的 Schema v22 迁移遇到历史孤立记录时，可能同时保留 `session_model_usage_v21` 和新的 `session_model_usage`。采集器仅读取 `sessions`，会遗漏历史用量和审批、标题生成等辅助调用。

## 修改

- 合并两代 Hermes 用量表，并按会话、模型、计费端点和任务去重
- 主循环明细缺失时回退到 `sessions`
- 历史 Token 纳入统计，会话数仍以可见会话为准
- 数据库未提供成本时使用统一价格表估算
- 升级扫描缓存版本，确保已有设备立即重新采集
- 补充旧版数据库、v22 辅助调用、半迁移数据库和重复记录测试

## 验证

- Python 完整测试：85 项全部通过
- Hermes 实库验证：
  - 今日输入 495,772，输出 2,747，会话 1
  - 本年输入 128,064,372，输出 3,010,917，缓存读取 271,068,312
  - 会话数保持 88
- 远程同步执行成功，仓库分叉为 `0/0`