### PR TITLE
feat: add minute-level quota history tracking

### DIFF
--- a/Tokei/Sources/Tokei/DataLoader.swift
+++ b/Tokei/Sources/Tokei/DataLoader.swift
@@ -60,11 +60,13 @@ final class DataLoader {
         var q5Reset: Int?
         var q7: Double?
         var q7Reset: Int?
+        var qf: Double?
+        var qfReset: Int?
         var updated: Int
     }
 
     private struct ClaudeQuotaState: Codable, Equatable {
-        var version = 1
+        var version = 2
         var candidate: ClaudeQuotaCandidate?
         var snapshot: ClaudeQuotaSnapshot?
         var scanModified: TimeInterval = -1
@@ -117,7 +119,7 @@ final class DataLoader {
     private static func loadClaudeQuotaState() -> ClaudeQuotaState {
         guard let data = try? Data(contentsOf: claudeQuotaStateURL),
               let state = try? JSONDecoder().decode(ClaudeQuotaState.self, from: data),
-              state.version == 1 else { return ClaudeQuotaState() }
+              state.version == 2 else { return ClaudeQuotaState() }
         return state
     }
 
@@ -150,14 +152,25 @@ final class DataLoader {
         else { return nil }
         let fiveHour = json["five_hour"] as? [String: Any] ?? [:]
         let sevenDay = json["seven_day"] as? [String: Any] ?? [:]
+        let fableLimit = (json["limits"] as? [[String: Any]])?.first { limit in
+            guard limit["kind"] as? String == "weekly_scoped",
+                  let scope = limit["scope"] as? [String: Any],
+                  let model = scope["model"] as? [String: Any],
+                  let displayName = model["display_name"] as? String
+            else { return false }
+            return displayName.caseInsensitiveCompare("Fable") == .orderedSame
+        } ?? [:]
         let q5 = (fiveHour["utilization"] as? NSNumber)?.doubleValue
         let q7 = (sevenDay["utilization"] as? NSNumber)?.doubleValue
-        guard q5 != nil || q7 != nil else { return nil }
+        let qf = (fableLimit["percent"] as? NSNumber)?.doubleValue
+        guard q5 != nil || q7 != nil || qf != nil else { return nil }
         return ClaudeQuotaSnapshot(
             q5: q5,
             q5Reset: isoToEpoch(fiveHour["resets_at"] as? String),
             q7: q7,
             q7Reset: isoToEpoch(sevenDay["resets_at"] as? String),
+            qf: qf,
+            qfReset: isoToEpoch(fableLimit["resets_at"] as? String),
             updated: Int(record.modified)
         )
     }
@@ -171,12 +184,16 @@ final class DataLoader {
         if let reset = snapshot.q5Reset { result["q5_reset"] = reset }
         if let q7 = snapshot.q7 { result["q7"] = q7 }
         if let reset = snapshot.q7Reset { result["q7_reset"] = reset }
+        if let qf = snapshot.qf { result["qf"] = qf }
+        if let reset = snapshot.qfReset { result["qf_reset"] = reset }
         let age = now - snapshot.updated
         let sourceStale = age > claudeQuotaStaleTTL || age < -300
         result["q5_stale"] = snapshot.q5 != nil &&
             (sourceStale || (snapshot.q5Reset.map { $0 <= now } ?? false))
         result["q7_stale"] = snapshot.q7 != nil &&
             (sourceStale || (snapshot.q7Reset.map { $0 <= now } ?? false))
+        result["qf_stale"] = snapshot.qf != nil &&
+            (sourceStale || (snapshot.qfReset.map { $0 <= now } ?? false))
         return result
     }
 
@@ -337,16 +354,18 @@ final class DataLoader {
             for key in raw.keys where key.hasPrefix("_") { raw.removeValue(forKey: key) }
             if var claude = raw["claude"] as? [String: Any] {
                 let scriptHasQuota = numberValue(claude["q5"]) != nil ||
-                    numberValue(claude["q7"]) != nil
+                    numberValue(claude["q7"]) != nil ||
+                    numberValue(claude["qf"]) != nil
                 let scriptUpdated = intValue(claude["q_updated"]) ?? 0
                 if let nativeQuota = scanClaudeQuota() {
                     let nativeHasQuota = numberValue(nativeQuota["q5"]) != nil ||
-                        numberValue(nativeQuota["q7"]) != nil
+                        numberValue(nativeQuota["q7"]) != nil ||
+                        numberValue(nativeQuota["qf"]) != nil
                     let nativeUpdated = intValue(nativeQuota["q_updated"]) ?? 0
                     if nativeHasQuota && (!scriptHasQuota || nativeUpdated >= scriptUpdated) {
                         for key in [
-                            "q5", "q5_reset", "q7", "q7_reset", "q_updated",
-                            "q5_stale", "q7_stale",
+                            "q5", "q5_reset", "q7", "q7_reset", "qf", "qf_reset",
+                            "q_updated", "q5_stale", "q7_stale", "qf_stale",
                         ] {
                             if let value = nativeQuota[key] {
                                 claude[key] = value
@@ -383,6 +402,7 @@ final class DataLoader {
         for (valueKey, resetKey, staleKey) in [
             ("q5", "q5_reset", "q5_stale"),
             ("q7", "q7_reset", "q7_stale"),
+            ("qf", "qf_reset", "qf_stale"),
         ] {
             guard numberValue(claude[valueKey]) != nil else {
                 claude.removeValue(forKey: staleKey)

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -75,9 +75,12 @@ struct ClaudeStat: Codable {
     var q5_reset: Int?
     var q7: Double?
     var q7_reset: Int?
+    var qf: Double?
+    var qf_reset: Int?
     var q_updated: Int?
     var q5_stale: Bool?
     var q7_stale: Bool?
+    var qf_stale: Bool?
 }
 
 struct CodexRange: Codable {

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -19,7 +19,7 @@ struct PanelView: View {
     @State private var expandedModels: Set<String> = []
     @State private var mode: PanelMode = .cards
     @State private var trailProjects: [TrailProject]?
-    enum PanelMode { case cards, dashboard, projects, settings }
+    enum PanelMode { case cards, quotaHistory, dashboard, projects, settings }
     private struct ToolCardItem: Identifiable {
         let id: String
         let name: String
@@ -75,7 +75,9 @@ struct PanelView: View {
     }
 
     var body: some View {
-        let w = mode == .settings ? settingsPanelWidth : (mode == .cards ? panelWidth : max(panelWidth, 420))
+        let w = (mode == .settings || mode == .quotaHistory)
+            ? settingsPanelWidth
+            : (mode == .cards ? panelWidth : max(panelWidth, 420))
         if scrollable {
             if mode == .projects {
                 projectPanelContent
@@ -115,7 +117,9 @@ struct PanelView: View {
     private var panelContent: some View {
         VStack(alignment: .leading, spacing: 13) {
             header
-            if mode == .dashboard {
+            if mode == .quotaHistory {
+                QuotaHistoryView(history: store.quotaHistory)
+            } else if mode == .dashboard {
                 DashboardView(store: store)
             } else if mode == .projects {
                 ProjectTrailView(cached: $trailProjects)
@@ -209,6 +213,20 @@ struct PanelView: View {
             .buttonStyle(.plain)
             .tip("项目足迹")
             Button {
+                withAnimation(.easeInOut(duration: 0.35)) {
+                    mode = mode == .quotaHistory ? .cards : .quotaHistory
+                }
+            } label: {
+                Image(systemName: "chart.xyaxis.line")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(mode == .quotaHistory ? Theme.claude : Theme.tTertiary)
+                    .frame(width: 24, height: 24)
+                    .background(Circle().fill(Color.primary.opacity(0.06)))
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .tip("额度曲线")
+            Button {
                 withAnimation(.easeInOut(duration: 0.35)) { mode = mode == .dashboard ? .cards : .dashboard }
             } label: {
                 Image(systemName: "chart.bar")
@@ -258,7 +276,8 @@ struct PanelView: View {
         let qcr = u.qwencode.ranges.get(sel)
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude,
-                         active: cr.sessions > 0 || u.claude.q5 != nil || u.claude.q7 != nil,
+                         active: cr.sessions > 0 || u.claude.q5 != nil ||
+                             u.claude.q7 != nil || u.claude.qf != nil,
                          tint: Theme.claude, content: AnyView(claudeBlock(u.claude, cr))),
             ToolCardItem(id: "codex", name: "Codex", visible: showCodex, active: xr.sessions > 0,
                          tint: Theme.codex, content: AnyView(codexBlock(u.codex, xr))),
@@ -339,13 +358,16 @@ struct PanelView: View {
             } else {
                 emptyHint
             }
-            if c.q5 != nil || c.q7 != nil {
+            if c.q5 != nil || c.q7 != nil || c.qf != nil {
                 thinDivider
                 if let q5 = c.q5, c.q5_stale != true {
                     quotaRow(title: "5h 剩余", pct: 100 - q5, reset: c.q5_reset, tint: Theme.claude)
                 }
                 if let q7 = c.q7, c.q7_stale != true {
-                    quotaRow(title: "周剩余", pct: 100 - q7, reset: c.q7_reset, tint: Theme.claude)
+                    quotaRow(title: "周 · 全部剩余", pct: 100 - q7, reset: c.q7_reset, tint: Theme.claude)
+                }
+                if let qf = c.qf, c.qf_stale != true {
+                    quotaRow(title: "周 · Fable 剩余", pct: 100 - qf, reset: c.qf_reset, tint: .orange)
                 }
                 claudeQuotaStatus(c)
             }
@@ -373,10 +395,7 @@ struct PanelView: View {
                     tokenModelDisclosure(r.models, open: $codexModelsOpen, tint: Theme.codex,
                                          reasonIncludedInOutput: true)
                 }
-                if x.p5 != nil || x.pw != nil { thinDivider }
-                if let p5 = x.p5 {
-                    quotaRow(title: "5h 剩余", pct: 100 - p5, reset: x.r5, tint: Theme.codex)
-                }
+                if x.pw != nil { thinDivider }
                 if let pw = x.pw {
                     quotaRow(title: "周剩余", pct: 100 - pw, reset: x.rw, tint: Theme.codex)
                 }
@@ -1074,9 +1093,10 @@ struct PanelView: View {
     }
 
     func claudeQuotaStatus(_ stat: ClaudeStat) -> some View {
-        let staleCount = [stat.q5_stale, stat.q7_stale].filter { $0 == true }.count
+        let staleCount = [stat.q5_stale, stat.q7_stale, stat.qf_stale].filter { $0 == true }.count
         let hasFreshQuota = (stat.q5 != nil && stat.q5_stale != true) ||
-            (stat.q7 != nil && stat.q7_stale != true)
+            (stat.q7 != nil && stat.q7_stale != true) ||
+            (stat.qf != nil && stat.qf_stale != true)
         let stale = staleCount > 0
         let label: String
         if stale {

--- a/Tokei/Sources/Tokei/QuotaHistoryStore.swift
+++ b/Tokei/Sources/Tokei/QuotaHistoryStore.swift
@@ -1,0 +1,235 @@
+import Combine
+import Foundation
+
+struct QuotaModelActivity: Codable, Equatable, Identifiable {
+    var model: String
+    var tokenDelta: Int
+
+    var id: String { model }
+}
+
+struct QuotaHistoryPoint: Codable, Equatable, Identifiable {
+    var timestamp: Int
+    var claudeFiveHourRemaining: Double?
+    var claudeWeekRemaining: Double?
+    var claudeFableWeekRemaining: Double?
+    var codexWeekRemaining: Double?
+    var claudeActivity: [QuotaModelActivity] = []
+    var codexActivity: [QuotaModelActivity] = []
+
+    var id: Int { timestamp }
+}
+
+struct QuotaCapture {
+    var claudeFiveHourRemaining: Double?
+    var claudeWeekRemaining: Double?
+    var claudeFableWeekRemaining: Double?
+    var codexWeekRemaining: Double?
+    var claudeModelTotals: [String: Int]
+    var codexModelTotals: [String: Int]
+
+    init(
+        claudeFiveHourRemaining: Double? = nil,
+        claudeWeekRemaining: Double? = nil,
+        claudeFableWeekRemaining: Double? = nil,
+        codexWeekRemaining: Double? = nil,
+        claudeModelTotals: [String: Int] = [:],
+        codexModelTotals: [String: Int] = [:]
+    ) {
+        self.claudeFiveHourRemaining = claudeFiveHourRemaining
+        self.claudeWeekRemaining = claudeWeekRemaining
+        self.claudeFableWeekRemaining = claudeFableWeekRemaining
+        self.codexWeekRemaining = codexWeekRemaining
+        self.claudeModelTotals = claudeModelTotals
+        self.codexModelTotals = codexModelTotals
+    }
+}
+
+private struct QuotaHistoryState: Codable {
+    var version = 1
+    var points: [QuotaHistoryPoint] = []
+    var lastClaudeModelTotals: [String: Int] = [:]
+    var lastCodexModelTotals: [String: Int] = [:]
+    var hasClaudeBaseline = false
+    var hasCodexBaseline = false
+}
+
+final class QuotaHistoryStore: ObservableObject {
+    static let shared = QuotaHistoryStore()
+
+    @Published private(set) var points: [QuotaHistoryPoint]
+
+    private let fileURL: URL
+    private let retentionSeconds: Int
+    private var state: QuotaHistoryState
+
+    init(
+        fileURL: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".tokei/quota_history.json"),
+        retentionHours: Int = 24 * 7
+    ) {
+        self.fileURL = fileURL
+        retentionSeconds = max(24, retentionHours) * 60 * 60
+        state = Self.loadState(from: fileURL)
+        points = state.points.sorted { $0.timestamp < $1.timestamp }
+    }
+
+    func record(_ capture: QuotaCapture, at date: Date = Date()) {
+        let minute = Int(date.timeIntervalSince1970 / 60) * 60
+        let cutoff = minute - retentionSeconds
+        var changed = false
+
+        let retained = points.filter { $0.timestamp >= cutoff }
+        if retained != points {
+            points = retained
+            changed = true
+        }
+
+        let claudeActivity = activity(
+            current: capture.claudeModelTotals,
+            previous: state.lastClaudeModelTotals,
+            hasBaseline: state.hasClaudeBaseline
+        )
+        let codexActivity = activity(
+            current: capture.codexModelTotals,
+            previous: state.lastCodexModelTotals,
+            hasBaseline: state.hasCodexBaseline
+        )
+
+        let claudeBaselineChanged = !state.hasClaudeBaseline ||
+            state.lastClaudeModelTotals != capture.claudeModelTotals
+        let codexBaselineChanged = !state.hasCodexBaseline ||
+            state.lastCodexModelTotals != capture.codexModelTotals
+        state.lastClaudeModelTotals = capture.claudeModelTotals
+        state.lastCodexModelTotals = capture.codexModelTotals
+        state.hasClaudeBaseline = true
+        state.hasCodexBaseline = true
+
+        let incoming = QuotaHistoryPoint(
+            timestamp: minute,
+            claudeFiveHourRemaining: normalized(capture.claudeFiveHourRemaining),
+            claudeWeekRemaining: normalized(capture.claudeWeekRemaining),
+            claudeFableWeekRemaining: normalized(capture.claudeFableWeekRemaining),
+            codexWeekRemaining: normalized(capture.codexWeekRemaining),
+            claudeActivity: claudeActivity,
+            codexActivity: codexActivity
+        )
+
+        let hasUsefulData = incoming.claudeFiveHourRemaining != nil ||
+            incoming.claudeWeekRemaining != nil ||
+            incoming.claudeFableWeekRemaining != nil ||
+            incoming.codexWeekRemaining != nil ||
+            !incoming.claudeActivity.isEmpty ||
+            !incoming.codexActivity.isEmpty
+
+        if hasUsefulData {
+            if let lastIndex = points.indices.last, points[lastIndex].timestamp == minute {
+                let merged = merge(points[lastIndex], with: incoming)
+                if merged != points[lastIndex] {
+                    points[lastIndex] = merged
+                    changed = true
+                }
+            } else {
+                points.append(incoming)
+                changed = true
+            }
+        }
+
+        if changed || claudeBaselineChanged || codexBaselineChanged {
+            state.points = points
+            saveState()
+        }
+    }
+
+    func points(since date: Date) -> [QuotaHistoryPoint] {
+        let cutoff = Int(date.timeIntervalSince1970)
+        return points.filter { $0.timestamp >= cutoff }
+    }
+
+    private static func loadState(from fileURL: URL) -> QuotaHistoryState {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return QuotaHistoryState()
+        }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let decoded = try JSONDecoder().decode(QuotaHistoryState.self, from: data)
+            guard decoded.version == 1 else {
+                fputs("Tokei quota history version is unsupported: \(decoded.version)\n", stderr)
+                return QuotaHistoryState()
+            }
+            return decoded
+        } catch {
+            fputs("Tokei quota history load failed: \(error)\n", stderr)
+            return QuotaHistoryState()
+        }
+    }
+
+    private func saveState() {
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(state)
+            try data.write(to: fileURL, options: .atomic)
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            fputs("Tokei quota history write failed: \(error)\n", stderr)
+        }
+    }
+
+    private func normalized(_ value: Double?) -> Double? {
+        guard let value, value.isFinite else { return nil }
+        return min(100, max(0, value))
+    }
+
+    private func activity(
+        current: [String: Int],
+        previous: [String: Int],
+        hasBaseline: Bool
+    ) -> [QuotaModelActivity] {
+        guard hasBaseline else { return [] }
+        return current.compactMap { model, total in
+            let delta = total - (previous[model] ?? 0)
+            guard delta > 0 else { return nil }
+            return QuotaModelActivity(model: model, tokenDelta: delta)
+        }.sorted {
+            if $0.tokenDelta == $1.tokenDelta { return $0.model < $1.model }
+            return $0.tokenDelta > $1.tokenDelta
+        }
+    }
+
+    private func merge(
+        _ existing: QuotaHistoryPoint,
+        with incoming: QuotaHistoryPoint
+    ) -> QuotaHistoryPoint {
+        var merged = existing
+        merged.claudeFiveHourRemaining =
+            incoming.claudeFiveHourRemaining ?? existing.claudeFiveHourRemaining
+        merged.claudeWeekRemaining =
+            incoming.claudeWeekRemaining ?? existing.claudeWeekRemaining
+        merged.claudeFableWeekRemaining =
+            incoming.claudeFableWeekRemaining ?? existing.claudeFableWeekRemaining
+        merged.codexWeekRemaining =
+            incoming.codexWeekRemaining ?? existing.codexWeekRemaining
+        merged.claudeActivity = mergeActivity(existing.claudeActivity, incoming.claudeActivity)
+        merged.codexActivity = mergeActivity(existing.codexActivity, incoming.codexActivity)
+        return merged
+    }
+
+    private func mergeActivity(
+        _ existing: [QuotaModelActivity],
+        _ incoming: [QuotaModelActivity]
+    ) -> [QuotaModelActivity] {
+        var totals = Dictionary(uniqueKeysWithValues: existing.map { ($0.model, $0.tokenDelta) })
+        for activity in incoming {
+            totals[activity.model, default: 0] += activity.tokenDelta
+        }
+        return totals.map { QuotaModelActivity(model: $0.key, tokenDelta: $0.value) }
+            .sorted {
+                if $0.tokenDelta == $1.tokenDelta { return $0.model < $1.model }
+                return $0.tokenDelta > $1.tokenDelta
+            }
+    }
+}

--- a/Tokei/Sources/Tokei/QuotaHistoryView.swift
+++ b/Tokei/Sources/Tokei/QuotaHistoryView.swift
@@ -1,0 +1,414 @@
+import Charts
+import SwiftUI
+
+private enum QuotaHistoryTool: String, CaseIterable, Identifiable {
+    case claude = "Claude"
+    case codex = "Codex"
+
+    var id: String { rawValue }
+    var tint: Color { self == .claude ? Theme.claude : Theme.codex }
+}
+
+private enum QuotaHistorySpan: Int, CaseIterable, Identifiable {
+    case hour = 1
+    case sixHours = 6
+    case day = 24
+
+    var id: Int { rawValue }
+    var label: String {
+        switch self {
+        case .hour: return "1h"
+        case .sixHours: return "6h"
+        case .day: return "24h"
+        }
+    }
+    var axisStride: Int {
+        switch self {
+        case .hour: return 1
+        case .sixHours: return 2
+        case .day: return 6
+        }
+    }
+}
+
+private struct QuotaChartDatum: Identifiable {
+    var timestamp: Date
+    var remaining: Double
+    var window: String
+    var activity: [QuotaModelActivity]
+
+    var id: String { "\(Int(timestamp.timeIntervalSince1970)):\(window)" }
+}
+
+private struct QuotaDropEvent: Identifiable {
+    var timestamp: Date
+    var durationMinutes: Int
+    var window: String
+    var drop: Double
+    var activity: [QuotaModelActivity]
+
+    var id: String { "\(Int(timestamp.timeIntervalSince1970)):\(window)" }
+}
+
+struct QuotaHistoryView: View {
+    @ObservedObject var history: QuotaHistoryStore
+    @State private var tool: QuotaHistoryTool = .claude
+    @State private var span: QuotaHistorySpan = .day
+
+    private var now: Date { Date() }
+    private var start: Date { now.addingTimeInterval(TimeInterval(-span.rawValue * 60 * 60)) }
+    private var recentPoints: [QuotaHistoryPoint] { history.points(since: start) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            controls
+            Card(tint: tool.tint) {
+                VStack(alignment: .leading, spacing: 12) {
+                    summary
+                    if chartData.isEmpty {
+                        emptyState
+                    } else {
+                        quotaChart
+                    }
+                }
+            }
+            changesSection
+            activitySection
+            Text("额度曲线来自本机定时快照；模型标记来自同一分钟内本地会话 token 增量，仅表示相关活动，不等同于官方逐模型扣费归因。")
+                .font(.system(size: 9.5))
+                .foregroundStyle(Theme.tTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("额度轨迹")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(Theme.tPrimary)
+                Text("按分钟聚合 · 剩余额度")
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(Theme.tTertiary)
+            }
+            Spacer()
+            Picker("", selection: $tool) {
+                ForEach(QuotaHistoryTool.allCases) { tool in
+                    Text(tool.rawValue).tag(tool)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 145)
+            .controlSize(.mini)
+            Picker("", selection: $span) {
+                ForEach(QuotaHistorySpan.allCases) { span in
+                    Text(span.label).tag(span)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 138)
+            .controlSize(.mini)
+        }
+    }
+
+    private var summary: some View {
+        HStack(spacing: 13) {
+            ForEach(windowNames, id: \.self) { window in
+                quotaSummary(
+                    title: summaryTitle(for: window),
+                    value: latestValue(window: window),
+                    tint: seriesColor(for: window)
+                )
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text("采样点")
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(Theme.tTertiary)
+                Text("\(recentPoints.count)")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundStyle(Theme.tPrimary)
+            }
+            Spacer()
+            if let largest = dropEvents.max(by: { $0.drop < $1.drop }) {
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text("最大区间下降")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(Theme.tTertiary)
+                    Text(String(format: "-%.1f%% / %dmin", largest.drop, largest.durationMinutes))
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(seriesColor(for: largest.window))
+                }
+            }
+        }
+    }
+
+    private func quotaSummary(title: String, value: Double?, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.system(size: 9.5))
+                .foregroundStyle(Theme.tTertiary)
+            Text(value.map { String(format: "%.1f%%", $0) } ?? "—")
+                .font(.system(size: 15, weight: .bold, design: .rounded))
+                .foregroundStyle(value.map { $0 <= 15 ? Color.red : tint } ?? Theme.tTertiary)
+        }
+    }
+
+    private var quotaChart: some View {
+        Chart {
+            ForEach(chartData) { item in
+                LineMark(
+                    x: .value("时间", item.timestamp),
+                    y: .value("剩余额度", item.remaining),
+                    series: .value("额度窗口", item.window)
+                )
+                .foregroundStyle(by: .value("额度窗口", item.window))
+                .interpolationMethod(.stepEnd)
+                .lineStyle(StrokeStyle(lineWidth: 2.2, lineCap: .round, lineJoin: .round))
+
+                let isLatest = item.id == latestDatumID(for: item.window)
+                if !item.activity.isEmpty || isLatest {
+                    PointMark(
+                        x: .value("活动时间", item.timestamp),
+                        y: .value("活动额度", item.remaining)
+                    )
+                    .foregroundStyle(by: .value("额度窗口", item.window))
+                    .symbolSize(isLatest ? 16 : 8)
+                    .opacity(isLatest ? 1 : 0.62)
+                }
+            }
+        }
+        .chartXScale(domain: start ... now)
+        .chartYScale(domain: 0 ... 100)
+        .chartForegroundStyleScale(
+            domain: windowNames,
+            range: windowColors
+        )
+        .chartLegend(position: .top, alignment: .trailing, spacing: 10)
+        .chartXAxis {
+            AxisMarks(values: .stride(by: .hour, count: span.axisStride)) { value in
+                AxisGridLine().foregroundStyle(Color.white.opacity(0.06))
+                AxisTick().foregroundStyle(Color.white.opacity(0.18))
+                AxisValueLabel(format: .dateTime.hour().minute())
+                    .font(.system(size: 8.5, design: .monospaced))
+                    .foregroundStyle(Theme.tTertiary)
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in
+                AxisGridLine().foregroundStyle(Color.white.opacity(0.08))
+                AxisValueLabel {
+                    if let number = value.as(Int.self) {
+                        Text("\(number)%")
+                    }
+                }
+                .font(.system(size: 8.5, design: .monospaced))
+                .foregroundStyle(Theme.tTertiary)
+            }
+        }
+        .frame(height: 235)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.xyaxis.line")
+                .font(.system(size: 24))
+                .foregroundStyle(tool.tint.opacity(0.8))
+            Text("正在开始记录额度轨迹")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Theme.tSecondary)
+            Text("Tokei 每 30 秒刷新，曲线按分钟聚合。保持应用运行后，这里会逐步出现数据。")
+                .font(.system(size: 10))
+                .foregroundStyle(Theme.tTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 210)
+    }
+
+    private var changesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("最近额度变化")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(Theme.tPrimary)
+            if dropEvents.isEmpty {
+                Text("当前时间范围内还没有检测到额度下降")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tTertiary)
+            } else {
+                ForEach(Array(dropEvents.prefix(8))) { event in
+                    HStack(spacing: 8) {
+                        Text(Self.timeFormatter.string(from: event.timestamp))
+                            .font(.system(size: 9.5, design: .monospaced))
+                            .foregroundStyle(Theme.tTertiary)
+                            .frame(width: 40, alignment: .leading)
+                        Text(event.window)
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .foregroundStyle(tool.tint)
+                            .frame(width: 42, alignment: .leading)
+                        Text(String(format: "-%.1f%%", event.drop))
+                            .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Theme.tPrimary)
+                            .frame(width: 54, alignment: .trailing)
+                        Text("\(event.durationMinutes) 分钟")
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.tTertiary)
+                        activityText(event.activity)
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+
+    private var activitySection: some View {
+        let events = activityEvents
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("模型活动标记")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(Theme.tPrimary)
+            if events.isEmpty {
+                Text("尚未检测到该工具的模型 token 增量")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tTertiary)
+            } else {
+                ForEach(Array(events.prefix(8)), id: \.timestamp) { point in
+                    HStack(spacing: 8) {
+                        Text(Self.timeFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(point.timestamp))))
+                            .font(.system(size: 9.5, design: .monospaced))
+                            .foregroundStyle(Theme.tTertiary)
+                            .frame(width: 40, alignment: .leading)
+                        activityText(activity(for: point))
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+
+    private func activityText(_ activity: [QuotaModelActivity]) -> some View {
+        Text(activity.map { "\($0.model) +\(Fmt.human($0.tokenDelta))" }.joined(separator: " · "))
+            .font(.system(size: 9.5, design: .monospaced))
+            .foregroundStyle(Theme.tSecondary)
+            .lineLimit(1)
+    }
+
+    private var chartData: [QuotaChartDatum] {
+        recentPoints.flatMap { point -> [QuotaChartDatum] in
+            let date = Date(timeIntervalSince1970: TimeInterval(point.timestamp))
+            return windowNames.compactMap { window in
+                value(for: window, point: point).map { remaining in
+                    QuotaChartDatum(
+                        timestamp: date,
+                        remaining: remaining,
+                        window: window,
+                        activity: activity(for: point, window: window)
+                    )
+                }
+            }
+        }
+    }
+
+    private var dropEvents: [QuotaDropEvent] {
+        var events: [QuotaDropEvent] = []
+        for window in windowNames {
+            let samples = recentPoints.compactMap { point -> (QuotaHistoryPoint, Double)? in
+                value(for: window, point: point).map { (point, $0) }
+            }
+            for pair in zip(samples, samples.dropFirst()) {
+                let previous = pair.0
+                let current = pair.1
+                let drop = previous.1 - current.1
+                guard drop >= 0.05 else { continue }
+                let minutes = max(1, (current.0.timestamp - previous.0.timestamp) / 60)
+                events.append(.init(
+                    timestamp: Date(timeIntervalSince1970: TimeInterval(current.0.timestamp)),
+                    durationMinutes: minutes,
+                    window: window,
+                    drop: drop,
+                    activity: activity(for: current.0, window: window)
+                ))
+            }
+        }
+        return events.sorted { $0.timestamp > $1.timestamp }
+    }
+
+    private var activityEvents: [QuotaHistoryPoint] {
+        recentPoints.filter { !activity(for: $0).isEmpty }
+            .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    private func activity(for point: QuotaHistoryPoint) -> [QuotaModelActivity] {
+        tool == .claude ? point.claudeActivity : point.codexActivity
+    }
+
+    private func activity(
+        for point: QuotaHistoryPoint,
+        window: String
+    ) -> [QuotaModelActivity] {
+        let all = activity(for: point)
+        guard tool == .claude, window == "周 · Fable" else { return all }
+        return all.filter { $0.model.localizedCaseInsensitiveContains("fable") }
+    }
+
+    private var windowNames: [String] {
+        switch tool {
+        case .claude:
+            return ["5 小时", "周 · 全部", "周 · Fable"]
+        case .codex:
+            return ["周"]
+        }
+    }
+
+    private var windowColors: [Color] {
+        windowNames.map { seriesColor(for: $0) }
+    }
+
+    private func seriesColor(for window: String) -> Color {
+        switch (tool, window) {
+        case (.claude, "5 小时"):
+            return Color(red: 1.00, green: 0.43, blue: 0.28)
+        case (.claude, "周 · 全部"):
+            return Color(red: 0.66, green: 0.55, blue: 1.00)
+        case (.claude, "周 · Fable"):
+            return Color(red: 1.00, green: 0.72, blue: 0.16)
+        case (.codex, "周"):
+            return Theme.codex
+        default:
+            return tool.tint
+        }
+    }
+
+    private func value(for window: String, point: QuotaHistoryPoint) -> Double? {
+        switch (tool, window) {
+        case (.claude, "5 小时"):
+            return point.claudeFiveHourRemaining
+        case (.claude, "周 · 全部"):
+            return point.claudeWeekRemaining
+        case (.claude, "周 · Fable"):
+            return point.claudeFableWeekRemaining
+        case (.codex, "周"):
+            return point.codexWeekRemaining
+        default:
+            return nil
+        }
+    }
+
+    private func summaryTitle(for window: String) -> String {
+        window == "5 小时" ? "5h 剩余" : "\(window)剩余"
+    }
+
+    private func latestValue(window: String) -> Double? {
+        let values = chartData.filter { $0.window == window }
+        return values.last?.remaining
+    }
+
+    private func latestDatumID(for window: String) -> String? {
+        chartData.last(where: { $0.window == window })?.id
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+}

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -16,6 +16,7 @@ final class Store: ObservableObject {
     @Published var peerLoadIssues: [PeerLoadIssue] = []
 
     let syncManager = SyncManager()
+    let quotaHistory = QuotaHistoryStore.shared
     let keepAwake = KeepAwake()
     let sitReminder = SitReminder()
     var autoSyncTimer: Timer?
@@ -66,6 +67,7 @@ final class Store: ObservableObject {
             }
             self.retryCount = 0
             self.loadError = nil
+            self.recordQuotaHistory(local)
             self.localUsage = local
             var allDevices = local
             if self.syncEnabled {
@@ -103,6 +105,30 @@ final class Store: ObservableObject {
         } else {
             refreshInFlight = false
         }
+    }
+
+    private func recordQuotaHistory(_ usage: Usage) {
+        let claudeRange = usage.claude.ranges.get(.today)
+        let codexRange = usage.codex.ranges.get(.today)
+        let claudeModels = claudeRange.models.reduce(into: [String: Int]()) { totals, model in
+            guard model.name != "合成" else { return }
+            totals[model.name, default: 0] += model.in + model.out + model.cr + model.cw
+        }
+        let codexModels = codexRange.models.reduce(into: [String: Int]()) { totals, model in
+            totals[model.name, default: 0] +=
+                model.in + model.out + model.cr + model.cw + model.reason
+        }
+        quotaHistory.record(QuotaCapture(
+            claudeFiveHourRemaining: usage.claude.q5_stale == true
+                ? nil : usage.claude.q5.map { 100 - $0 },
+            claudeWeekRemaining: usage.claude.q7_stale == true
+                ? nil : usage.claude.q7.map { 100 - $0 },
+            claudeFableWeekRemaining: usage.claude.qf_stale == true
+                ? nil : usage.claude.qf.map { 100 - $0 },
+            codexWeekRemaining: usage.codex.pw.map { 100 - $0 },
+            claudeModelTotals: claudeModels,
+            codexModelTotals: codexModels
+        ))
     }
 
     func doSync() {
@@ -249,7 +275,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                      remaining: remaining))
             }
             if ud.object(forKey: "showCodex") as? Bool ?? true,
-               let quota = u.codex.p5 ?? u.codex.pw {
+               let quota = u.codex.pw {
                 let remaining = 100 - quota
                 metrics.append(.init(kind: .codex, value: String(format: "%.0f", remaining),
                                      remaining: remaining))

--- a/tests/swift/QuotaHistoryStoreCheck.swift
+++ b/tests/swift/QuotaHistoryStoreCheck.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+private enum TestFailure: Error {
+    case assertion(String)
+}
+
+@main
+struct QuotaHistoryStoreCheck {
+    static func main() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tokei-quota-history-\(UUID().uuidString)")
+        let fileURL = directory.appendingPathComponent("quota_history.json")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let store = QuotaHistoryStore(fileURL: fileURL)
+        store.record(
+            QuotaCapture(
+                claudeFiveHourRemaining: 82,
+                claudeWeekRemaining: 61,
+                claudeFableWeekRemaining: 17,
+                codexWeekRemaining: 49,
+                claudeModelTotals: ["claude-opus": 100],
+                codexModelTotals: ["gpt-5": 200]
+            ),
+            at: base
+        )
+        try expect(store.points.count == 1, "first capture should create one point")
+        try expect(store.points[0].claudeActivity.isEmpty, "first capture should establish a baseline")
+
+        store.record(
+            QuotaCapture(
+                claudeFiveHourRemaining: 80.5,
+                claudeWeekRemaining: 60.5,
+                claudeFableWeekRemaining: 16.5,
+                codexWeekRemaining: 48.5,
+                claudeModelTotals: ["claude-opus": 130],
+                codexModelTotals: ["gpt-5": 225]
+            ),
+            at: base.addingTimeInterval(30)
+        )
+        try expect(store.points.count == 1, "captures in one minute should merge")
+        try expect(store.points[0].claudeFiveHourRemaining == 80.5, "same-minute quota should use latest value")
+        try expect(store.points[0].claudeFableWeekRemaining == 16.5, "Fable quota should use latest value")
+        try expect(store.points[0].claudeActivity == [
+            QuotaModelActivity(model: "claude-opus", tokenDelta: 30),
+        ], "same-minute model delta should be recorded")
+
+        store.record(
+            QuotaCapture(
+                claudeFiveHourRemaining: 79,
+                claudeWeekRemaining: 60,
+                claudeFableWeekRemaining: 16,
+                codexWeekRemaining: 48,
+                claudeModelTotals: ["claude-opus": 150, "claude-sonnet": 10],
+                codexModelTotals: ["gpt-5": 240]
+            ),
+            at: base.addingTimeInterval(65)
+        )
+        try expect(store.points.count == 2, "next minute should append a point")
+        try expect(store.points[1].claudeActivity.map(\.model) == [
+            "claude-opus", "claude-sonnet",
+        ], "new and growing models should both be attributed")
+
+        let reloaded = QuotaHistoryStore(fileURL: fileURL)
+        try expect(reloaded.points == store.points, "history should survive a reload")
+
+        reloaded.record(
+            QuotaCapture(
+                claudeFiveHourRemaining: 100,
+                claudeWeekRemaining: 100,
+                claudeFableWeekRemaining: 100,
+                codexWeekRemaining: 100
+            ),
+            at: base.addingTimeInterval(8 * 24 * 60 * 60)
+        )
+        try expect(reloaded.points.count == 1, "points outside retention should be pruned")
+
+        print("quota history store checks passed")
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) throws {
+        if !condition() {
+            throw TestFailure.assertion(message)
+        }
+    }
+}

--- a/tests/test_claude_quota_cache.py
+++ b/tests/test_claude_quota_cache.py
@@ -20,8 +20,8 @@ class ClaudeQuotaCacheTests(unittest.TestCase):
     def _iso(self, epoch):
         return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace("+00:00", "Z")
 
-    def _payload(self, q5, q7):
-        return {
+    def _payload(self, q5, q7, qf=None):
+        payload = {
             "five_hour": {
                 "utilization": q5,
                 "resets_at": self._iso(self.now + 3600),
@@ -31,6 +31,18 @@ class ClaudeQuotaCacheTests(unittest.TestCase):
                 "resets_at": self._iso(self.now + 7 * 86400),
             },
         }
+        if qf is not None:
+            payload["limits"] = [{
+                "group": "weekly",
+                "kind": "weekly_scoped",
+                "percent": qf,
+                "resets_at": self._iso(self.now + 7 * 86400),
+                "scope": {
+                    "model": {"display_name": "Fable", "id": None},
+                    "surface": None,
+                },
+            }]
+        return payload
 
     def _write_entry(self, directory, name, marker, modified):
         path = Path(directory) / f"{name}_0"
@@ -67,11 +79,16 @@ class ClaudeQuotaCacheTests(unittest.TestCase):
                 modified = self.now - 499 + index
                 os.utime(path, ns=(modified * 1_000_000_000, modified * 1_000_000_000))
 
-            payloads = {"old": self._payload(37.0, 62.0), "new": self._payload(41.0, 65.0)}
+            payloads = {
+                "old": self._payload(37.0, 62.0, 81.0),
+                "new": self._payload(41.0, 65.0, 83.0),
+            }
             first = self._scan(cache_dir, state_file, self._decoder(payloads))
 
             self.assertEqual(first["q5"], 37.0)
+            self.assertEqual(first["qf"], 81.0)
             self.assertFalse(first["q5_stale"])
+            self.assertFalse(first["qf_stale"])
             state = json.loads(state_file.read_text(encoding="utf-8"))
             self.assertEqual(state["candidate"]["path"], str(valid.resolve()))
 
@@ -84,6 +101,7 @@ class ClaudeQuotaCacheTests(unittest.TestCase):
             newest = self._write_entry(cache_dir, "newest", "new", self.now + 20)
             replaced = self._scan(cache_dir, state_file, self._decoder(payloads), now=self.now + 20)
             self.assertEqual(replaced["q5"], 41.0)
+            self.assertEqual(replaced["qf"], 83.0)
             state = json.loads(state_file.read_text(encoding="utf-8"))
             self.assertEqual(state["candidate"]["path"], str(newest.resolve()))
 
@@ -130,16 +148,20 @@ class ClaudeQuotaCacheTests(unittest.TestCase):
             "q5_reset": self.now + 300,
             "q7": 20.0,
             "q7_reset": self.now - 1,
+            "qf": 30.0,
+            "qf_reset": self.now + 300,
             "q_updated": self.now - 30,
         }
         fresh = USAGE._claude_quota_with_freshness(snapshot, now=self.now)
         self.assertFalse(fresh["q5_stale"])
         self.assertTrue(fresh["q7_stale"])
+        self.assertFalse(fresh["qf_stale"])
 
         snapshot["q_updated"] = self.now - USAGE._CLAUDE_QUOTA_STALE_TTL - 1
         expired = USAGE._claude_quota_with_freshness(snapshot, now=self.now)
         self.assertTrue(expired["q5_stale"])
         self.assertTrue(expired["q7_stale"])
+        self.assertTrue(expired["qf_stale"])
 
 
 if __name__ == "__main__":

--- a/tests/test_quota_history.py
+++ b/tests/test_quota_history.py
@@ -1,0 +1,36 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class QuotaHistoryTests(unittest.TestCase):
+    def test_minute_aggregation_activity_and_retention(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "quota-history-check"
+            subprocess.run(
+                [
+                    "swiftc",
+                    "-parse-as-library",
+                    "-framework", "Combine",
+                    str(ROOT / "Tokei/Sources/Tokei/QuotaHistoryStore.swift"),
+                    str(ROOT / "tests/swift/QuotaHistoryStoreCheck.swift"),
+                    "-o", str(binary),
+                ],
+                check=True,
+                cwd=ROOT,
+            )
+            result = subprocess.run(
+                [str(binary)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("quota history store checks passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -3752,7 +3752,7 @@ def _zstd_decompress(data):
 
 
 # 首次全量定位 /usage，之后只检查变化项并复用最近一次有效候选。
-_CLAUDE_QUOTA_STATE_VERSION = 1
+_CLAUDE_QUOTA_STATE_VERSION = 2
 _CLAUDE_QUOTA_STALE_TTL = 1800
 _CLAUDE_QUOTA_FULL_SCAN_INTERVAL = 6 * 3600
 _CLAUDE_QUOTA_RETRY_SCAN_INTERVAL = 5 * 60
@@ -3807,14 +3807,28 @@ def _parse_claude_quota_record(record):
         five_hour = {}
     if not isinstance(seven_day, dict):
         seven_day = {}
+    fable_limit = {}
+    limits = payload.get("limits") or []
+    if isinstance(limits, list):
+        for limit in limits:
+            if not isinstance(limit, dict) or limit.get("kind") != "weekly_scoped":
+                continue
+            scope = limit.get("scope") or {}
+            model = scope.get("model") or {} if isinstance(scope, dict) else {}
+            display_name = model.get("display_name") if isinstance(model, dict) else None
+            if isinstance(display_name, str) and display_name.casefold() == "fable":
+                fable_limit = limit
+                break
     result = {
         "q5": five_hour.get("utilization"),
         "q5_reset": _iso_to_epoch(five_hour.get("resets_at")),
         "q7": seven_day.get("utilization"),
         "q7_reset": _iso_to_epoch(seven_day.get("resets_at")),
+        "qf": fable_limit.get("percent"),
+        "qf_reset": _iso_to_epoch(fable_limit.get("resets_at")),
         "q_updated": int(record["mtime_ns"] // 1_000_000_000),
     }
-    return result if result["q5"] is not None or result["q7"] is not None else None
+    return result if any(result[key] is not None for key in ("q5", "q7", "qf")) else None
 
 
 def _claude_quota_with_freshness(snapshot, now=None):
@@ -3832,6 +3846,7 @@ def _claude_quota_with_freshness(snapshot, now=None):
     for value_key, reset_key, stale_key in (
         ("q5", "q5_reset", "q5_stale"),
         ("q7", "q7_reset", "q7_stale"),
+        ("qf", "qf_reset", "qf_stale"),
     ):
         reset = result.get(reset_key)
         try:
@@ -4089,8 +4104,10 @@ def compute():
             "session_name": cur["name"], "session_total": cur_total,
             "q5": plan.get("q5"), "q5_reset": plan.get("q5_reset"),
             "q7": plan.get("q7"), "q7_reset": plan.get("q7_reset"),
+            "qf": plan.get("qf"), "qf_reset": plan.get("qf_reset"),
             "q_updated": plan.get("q_updated"),
             "q5_stale": plan.get("q5_stale"), "q7_stale": plan.get("q7_stale"),
+            "qf_stale": plan.get("qf_stale"),
         },
         "codex": {
             "ranges": xranges,


### PR DESCRIPTION
## 背景

Tokei 目前只显示当前额度快照，无法回答“某个模型在过去一段时间里何时消耗了多少额度”。同时，Claude 最新本地 `/usage` 缓存已经把 Fable 周额度放在 `limits[].kind = weekly_scoped` 中，而 Codex 当前只提供周额度。

## 改动

- 新增本地额度历史存储，按分钟聚合，保留最近 7 天数据
- 新增 1h / 6h / 24h 额度轨迹页，支持 Claude / Codex 切换
- 展示额度下降区间、持续分钟数，以及同一分钟内的本地模型 token 增量
- Claude 分别显示 5 小时、周全部模型、周 Fable 三条独立曲线
- Codex 卡片、菜单栏和曲线只显示周额度
- 从 Claude Chromium 缓存的 `limits[].weekly_scoped` 解析 Fable 百分比与重置时间
- 使用珊瑚红、紫色、金色区分 Claude 三条序列，并降低活动点尺寸，避免遮挡曲线

## 数据与隐私

- 历史文件写入 `~/.tokei/quota_history.json`，权限设为 `0600`
- 额度来源仍为本机缓存，不增加网络请求
- 模型活动来自相邻刷新间本地 token 累计值的增量，只表示时间相关性；界面明确声明它不等同于官方逐模型扣费归因
- 同一分钟的多次刷新会合并，旧历史文件缺少新字段时可兼容读取

## 验证

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`：81/81 通过
- `swift build --disable-sandbox -c release`：通过
- `bash package.sh`：成功生成 App 与 DMG
- `codesign --verify --deep --strict /Applications/Tokei.app`：通过
- 使用真实 Claude 缓存验证 Fable `weekly_scoped` 解析
- 本机安装后人工检查 Claude 三序列和 Codex 周额度单序列布局
