### PR TITLE
fix(opencode): 为零成本用量补充价格估算

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -17,7 +17,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` | JSONL 用量 + SQLite 任务 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
-| OpenCode | `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | JSON, `tokens` + `cost` |
+| OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | SQLite/JSON, `tokens` + `cost` |
 | Qwen Code | `${QWEN_RUNTIME_DIR:-~/.qwen}/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` | JSONL,逐请求记录 + 会话汇总 |
 
 ---
@@ -221,7 +221,7 @@ cost = non_cached_input/1M × price_in
 
 ### Pi Coding Agent CLI / OpenCode 成本
 
-Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 直接使用消息 JSON 中的 `cost` 字段。若 Pi 成本字段缺失，则按统一价格表用 input/output/cache_read/cache_write 回退估算。
+Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 优先读取 SQLite `message.data` 中的 `cost` 字段，旧版 JSON 文件同口径。若 Pi 成本字段缺失，或 OpenCode 成本为 0 且模型能匹配价格表，则按统一价格表用 input/output/cache_read/cache_write 回退估算。
 
 ### Grok Build / Qoder / OpenClaw
 

--- a/tests/test_opencode_sqlite.py
+++ b/tests/test_opencode_sqlite.py
@@ -9,12 +9,13 @@ from unittest import mock
 from test_codex_limits import USAGE
 
 
-def assistant(message_id, session_id, created, input_tokens, output_tokens=0):
+def assistant(message_id, session_id, created, input_tokens, output_tokens=0,
+              cost=0.25, model_id="claude-sonnet-4.6"):
     return {
         "id": message_id,
         "sessionID": session_id,
         "role": "assistant",
-        "modelID": "claude-sonnet-4.6",
+        "modelID": model_id,
         "time": {"created": created},
         "tokens": {
             "input": input_tokens,
@@ -22,7 +23,7 @@ def assistant(message_id, session_id, created, input_tokens, output_tokens=0):
             "reasoning": 3,
             "cache": {"read": 4, "write": 5},
         },
-        "cost": 0.25,
+        "cost": cost,
     }
 
 
@@ -86,12 +87,75 @@ class OpenCodeSqliteTests(unittest.TestCase):
         self.assertEqual(usage["cr"], 8)
         self.assertEqual(usage["cw"], 10)
         self.assertEqual(usage["reason"], 6)
+        self.assertEqual(usage["cost"], 0.5)
         self.assertEqual(usage["sessions"], {"ses-db", "ses-legacy"})
         self.assertEqual(cached["ranges"]["all"]["in"], 150)
         self.assertEqual(len(daily["daily"]), 1)
         self.assertEqual(daily["daily"][0]["tokens"], 189)
         self.assertEqual(wrapped["total_tokens"], 189)
         self.assertEqual(sum(wrapped["hours"]), 189)
+
+    def test_zero_cost_uses_pricing_fallback_and_refreshes_old_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "opencode.db"
+            created = int(datetime.now().astimezone().timestamp() * 1000)
+            message = assistant(
+                "msg-zero-cost",
+                "ses-zero-cost",
+                created,
+                1_000_000,
+                100_000,
+                cost=0,
+                model_id="glm-5.2",
+            )
+
+            connection = sqlite3.connect(db_path)
+            connection.execute(
+                "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO message VALUES (?, ?, ?, ?)",
+                ("msg-zero-cost", "ses-zero-cost", created, json.dumps(message)),
+            )
+            connection.commit()
+            connection.close()
+
+            cache_key = "db:" + str(db_path)
+            cache = {
+                "v": USAGE._SCAN_CACHE_VERSION,
+                "opencode": {
+                    cache_key: {
+                        "sig": USAGE._sqlite_signature(str(db_path)),
+                        "days": {},
+                        "message_ids": [],
+                        "source": "sqlite",
+                    },
+                },
+            }
+            with mock.patch.object(USAGE, "_opencode_db_paths", return_value=[str(db_path)]), \
+                 mock.patch.object(USAGE, "_opencode_json_dirs", return_value=[]):
+                result = USAGE.scan_opencode(USAGE.range_bounds(), cache)
+                with mock.patch.object(
+                    USAGE,
+                    "_scan_opencode_database",
+                    side_effect=AssertionError("repriced OpenCode cache was rescanned"),
+                ):
+                    cached = USAGE.scan_opencode(USAGE.range_bounds(), cache)
+
+        price = USAGE._raw_price(USAGE._pricing_id("glm-5.2"))
+        expected = (
+            1_000_000 / 1e6 * price["in"]
+            + (100_000 + 3) / 1e6 * price["out"]
+            + 4 / 1e6 * price["cache_read"]
+            + 5 / 1e6 * price["cache_write"]
+        )
+        self.assertGreater(expected, 0)
+        self.assertAlmostEqual(result["ranges"]["all"]["cost"], expected)
+        self.assertAlmostEqual(cached["ranges"]["all"]["cost"], expected)
+        self.assertEqual(
+            cache["opencode"][cache_key]["cost_version"],
+            USAGE._OPENCODE_COST_CACHE_VERSION,
+        )
 
     def test_signature_tracks_wal_changes(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -4244,6 +4244,9 @@ def scan_workbuddy(bounds, cache):
 # SQLite: ~/.local/share/opencode/opencode.db；旧版 JSON 作为补充来源。
 # JSON 文件: ~/.local/share/opencode/storage/message/<session>/msg_*.json
 # 每条 assistant 消息有 tokens{input,output,reasoning,cache{read,write}} + cost + modelID。
+_OPENCODE_COST_CACHE_VERSION = 1
+
+
 def _opencode_db_paths():
     data_dirs = _path_candidates(
         "TOKEI_OPENCODE_DATA_DIR", OPENCODE_DATA_DIR, *OPENCODE_DATA_DIRS)
@@ -4366,12 +4369,20 @@ def scan_opencode(bounds, cache):
         stale.discard(cache_key)
         signature = _sqlite_signature(db_path)
         entry = fc.get(cache_key)
-        if not entry or entry.get("sig") != signature:
+        if (not entry or entry.get("sig") != signature
+                or entry.get("cost_version") != _OPENCODE_COST_CACHE_VERSION):
             try:
-                days, message_ids = _scan_opencode_database(db_path)
+                days, message_ids = _scan_opencode_database(
+                    db_path, estimate_missing_cost=True)
             except Exception:
                 continue
-            entry = {"sig": signature, "days": days, "message_ids": message_ids, "source": "sqlite"}
+            entry = {
+                "sig": signature,
+                "days": days,
+                "message_ids": message_ids,
+                "source": "sqlite",
+                "cost_version": _OPENCODE_COST_CACHE_VERSION,
+            }
             fc[cache_key] = entry
             changed = True
         db_message_ids.update(entry.get("message_ids", []))
@@ -4397,7 +4408,8 @@ def scan_opencode(bounds, cache):
                     continue
                 sig = f"{st.st_mtime}:{st.st_size}"
                 entry = fc.get(f)
-                if entry and entry.get("sig") == sig:
+                if (entry and entry.get("sig") == sig
+                        and entry.get("cost_version") == _OPENCODE_COST_CACHE_VERSION):
                     day_data = entry.get("day")
                     message_id = entry.get("message_id") or file_id
                 else:
@@ -4409,8 +4421,13 @@ def scan_opencode(bounds, cache):
                     message_id = str(d.get("id") or file_id)
                     if message_id in seen_message_ids:
                         continue
-                    day_data = _opencode_message_day(d)
-                    fc[f] = {"sig": sig, "day": day_data, "message_id": message_id}
+                    day_data = _opencode_message_day(d, estimate_missing_cost=True)
+                    fc[f] = {
+                        "sig": sig,
+                        "day": day_data,
+                        "message_id": message_id,
+                        "cost_version": _OPENCODE_COST_CACHE_VERSION,
+                    }
                     changed = True
                 if message_id in seen_message_ids:
                     continue


### PR DESCRIPTION
## Summary

- estimate OpenCode usage cost from the shared pricing table when a message reports `cost: 0`
- preserve non-zero costs recorded by OpenCode as the authoritative value
- refresh existing OpenCode scan-cache entries once so upgrades do not keep showing stale `$0.00`
- apply the same fallback to SQLite and legacy JSON sources, and document the calculation rule

## Root cause

OpenCode can persist valid token usage with a zero cost for some providers and models. Tokei treated that zero as authoritative, so the OpenCode card continued to show `$0.00` even after the pricing table was updated.

The existing message parser already supported price-based fallback for compatible OpenCode-format databases. This change enables that fallback for OpenCode itself only when the recorded cost is zero and the model has a known price.

## Verification

- `HOME="$(mktemp -d)" python3 -B -m unittest discover -s tests` — 115 tests passed
- targeted OpenCode SQLite suite — 6 tests passed
- `python3 -m py_compile usage.30s.py tests/test_opencode_sqlite.py`
- `git diff --check`

The regression test covers zero-cost GLM 5.2 usage, one-time cache refresh, cache reuse after repricing, and preservation of non-zero recorded costs.

## Risk / compatibility

- unknown models without a matching price remain at their recorded cost
- non-zero OpenCode costs are never overwritten
- existing cache entries are rescanned once; subsequent scans continue using the normal signature cache

Closes #42
