### PR TITLE
fix: stabilize header layout and popover interactions

### DIFF
--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -166,7 +166,7 @@ struct RingGauge: View {
             }
         }
         .frame(width: size, height: size)
-        .animation(.easeOut(duration: 0.5), value: value)
+        .animation(.easeOut(duration: 0.18), value: value)
     }
 }
 
@@ -184,7 +184,7 @@ struct MiniBar: View {
             }
         }
         .frame(height: 5)
-        .animation(.easeOut(duration: 0.45), value: value)
+        .animation(.easeOut(duration: 0.18), value: value)
     }
 }
 
@@ -293,11 +293,18 @@ struct CostHeadline: View {
 // 自定义滑动分段控件(替代原生 segmented),选中态滑动高亮。
 struct SegmentedTabs: View {
     @Binding var sel: RangeKey
+    @State private var highlighted: RangeKey
     @Namespace private var ns
+
+    init(sel: Binding<RangeKey>) {
+        _sel = sel
+        _highlighted = State(initialValue: sel.wrappedValue)
+    }
+
     var body: some View {
         HStack(spacing: 2) {
             ForEach(RangeKey.displayCases) { k in
-                let on = k == sel
+                let on = k == highlighted
                 Text(k.label)
                     .font(.system(size: 12, weight: on ? .semibold : .regular))
                     .foregroundStyle(on ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
@@ -316,7 +323,9 @@ struct SegmentedTabs: View {
                     }
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) { sel = k }
+                        guard sel != k else { return }
+                        sel = k
+                        withAnimation(.easeOut(duration: 0.18)) { highlighted = k }
                     }
             }
         }
@@ -325,6 +334,10 @@ struct SegmentedTabs: View {
             RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .fill(Color.primary.opacity(0.06))
         )
+        .onChange(of: sel) { value in
+            guard highlighted != value else { return }
+            highlighted = value
+        }
     }
 }
 

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -191,10 +191,13 @@ struct PanelView: View {
                         Text("Tokei")
                             .font(.system(size: 15, weight: .bold, design: .rounded))
                             .tracking(0.5)
+                            .lineLimit(1)
                         Text("知度 · AI 用量")
                             .font(.system(size: 9))
                             .foregroundStyle(Theme.tTertiary)
+                            .lineLimit(1)
                     }
+                    .fixedSize(horizontal: true, vertical: false)
                 }
                 .contentShape(Rectangle())
             }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -176,7 +176,7 @@ struct PanelView: View {
     var header: some View {
         HStack(spacing: 9) {
             Button {
-                if mode != .cards { withAnimation(.easeInOut(duration: 0.35)) { mode = .cards } }
+                if mode != .cards { mode = .cards }
             } label: {
                 HStack(spacing: 9) {
                     Image(systemName: "timer")
@@ -218,7 +218,7 @@ struct PanelView: View {
                 .font(.system(size: 9.5, design: .monospaced))
                 .foregroundStyle(Theme.tTertiary)
             Button {
-                withAnimation(.easeInOut(duration: 0.35)) { mode = mode == .projects ? .cards : .projects }
+                mode = mode == .projects ? .cards : .projects
             } label: {
                 Image(systemName: "folder")
                     .font(.system(size: 11, weight: .medium))
@@ -230,9 +230,7 @@ struct PanelView: View {
             .buttonStyle(.plain)
             .tip("项目足迹")
             Button {
-                withAnimation(.easeInOut(duration: 0.35)) {
-                    mode = mode == .quotaHistory ? .cards : .quotaHistory
-                }
+                mode = mode == .quotaHistory ? .cards : .quotaHistory
             } label: {
                 Image(systemName: "chart.xyaxis.line")
                     .font(.system(size: 11, weight: .medium))
@@ -244,7 +242,7 @@ struct PanelView: View {
             .buttonStyle(.plain)
             .tip("额度曲线")
             Button {
-                withAnimation(.easeInOut(duration: 0.35)) { mode = mode == .dashboard ? .cards : .dashboard }
+                mode = mode == .dashboard ? .cards : .dashboard
             } label: {
                 Image(systemName: "chart.bar")
                     .font(.system(size: 11, weight: .medium))
@@ -256,7 +254,7 @@ struct PanelView: View {
             .buttonStyle(.plain)
             .tip("数据面板")
             Button {
-                withAnimation(.easeInOut(duration: 0.35)) { mode = mode == .settings ? .cards : .settings }
+                mode = mode == .settings ? .cards : .settings
             } label: {
                 Image(systemName: "gearshape")
                     .font(.system(size: 11, weight: .medium))
@@ -350,7 +348,7 @@ struct PanelView: View {
     }
 
     private func cardContentIdentity(for item: ToolCardItem) -> String {
-        "\(item.id):\(sel.rawValue):\(store.syncEnabled):\(store.showAllDevices)"
+        "\(item.id):\(store.syncEnabled):\(store.showAllDevices)"
     }
 
     // MARK: - Claude 卡片
@@ -2034,7 +2032,7 @@ struct PanelView: View {
             }
             updatePill
             Button {
-                withAnimation(.easeInOut(duration: 0.25)) { mode = .cards }
+                mode = .cards
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .bold))

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -91,6 +91,9 @@ final class Store: ObservableObject {
             let f = DateFormatter(); f.dateFormat = "HH:mm:ss"
             self.lastUpdated = "更新 " + f.string(from: Date())
             (NSApp.delegate as? AppDelegate)?.updateStatusTitle()
+            DispatchQueue.main.async {
+                (NSApp.delegate as? AppDelegate)?.prewarmPopoverContentIfNeeded()
+            }
             if !self.refreshPending && !self.dashboardPrewarmStarted {
                 self.dashboardPrewarmStarted = true
                 DashboardRepository.shared.load(.all, force: true)
@@ -206,6 +209,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }()
     var timer: Timer?
     var globalMouseMonitor: Any?
+    private var didPrewarmPopoverContent = false
 
     // 菜单栏额度颜色(与面板 Theme.claude/codex/grok 一致)。
     static let claudeColor = NSColor(red: 0.92, green: 0.52, blue: 0.40, alpha: 1)
@@ -225,11 +229,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         host.sizingOptions = .preferredContentSize
         popover.contentViewController = host
         popover.behavior = .applicationDefined
-        // The panel can be nearly screen-height and contains a full SwiftUI card tree.
-        // NSPopover's native animation lays out that entire tree synchronously while
-        // opening, which makes a menu-bar click feel delayed. Show it immediately;
-        // lightweight in-panel transitions remain available where they add context.
-        popover.animates = false
+        popover.animates = true
 
         // 启动时先把 Qoder IDE / Grok 实时额度开关落盘到 config.json,
         // 确保随后的 refresh() 触发的 Python 扫描能读到正确配置。
@@ -386,6 +386,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let accessibility = summary.isEmpty ? "Tokei" : "Tokei · \(summary)"
         b.toolTip = accessibility
         b.setAccessibilityLabel(accessibility)
+    }
+
+    func prewarmPopoverContentIfNeeded() {
+        guard !didPrewarmPopoverContent,
+              !popover.isShown,
+              let contentView = popover.contentViewController?.view else { return }
+
+        didPrewarmPopoverContent = true
+        let size = contentView.fittingSize
+        guard size.width.isFinite, size.height.isFinite,
+              size.width > 0, size.height > 0 else {
+            didPrewarmPopoverContent = false
+            return
+        }
+        contentView.setFrameSize(size)
+        contentView.layoutSubtreeIfNeeded()
     }
 
     private func fitStatusItemWidth(_ button: NSStatusBarButton) {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -225,7 +225,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         host.sizingOptions = .preferredContentSize
         popover.contentViewController = host
         popover.behavior = .applicationDefined
-        popover.animates = true
+        // The panel can be nearly screen-height and contains a full SwiftUI card tree.
+        // NSPopover's native animation lays out that entire tree synchronously while
+        // opening, which makes a menu-bar click feel delayed. Show it immediately;
+        // lightweight in-panel transitions remain available where they add context.
+        popover.animates = false
 
         // 启动时先把 Qoder IDE / Grok 实时额度开关落盘到 config.json,
         // 确保随后的 refresh() 触发的 Python 扫描能读到正确配置。


### PR DESCRIPTION
## What changed

- keep the Tokei brand title and subtitle on one line in the compact header
- prewarm the hidden SwiftUI content after the first successful refresh while preserving the native popover animation
- switch between cards, projects, charts, dashboard, and settings without animating the entire popover geometry
- keep the range selector highlight animation while updating card data outside that animation transaction
- preserve card identity across range changes and shorten gauge/bar value transitions to 180 ms

## Why

The compact header could compress the brand text into multiple lines when the update label and action buttons consumed the available width.

The popover can also be nearly screen-height and contains a large SwiftUI card tree. A macOS `sample` capture showed about 0.54 seconds in the toggle path, with most of the work in popover positioning and SwiftUI layout. Prewarming the hidden content moves its first full layout away from the click path without removing the expected native animation. Range and mode changes also animated popover geometry, recreated every card, and ran several 450–500 ms value animations together, making otherwise simple interactions feel delayed.

## Impact

The header remains stable at compact widths. The native open/close animation remains intact, while initial layout work is prepared before interaction and in-panel switches avoid unnecessary full-tree animation. The existing layout, colors, and data remain unchanged.

## Validation

- `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX26.5.sdk swift build -c release --scratch-path /tmp/tokei-build-performance-20260730`
- `git diff --check`
- installed the release binary into the local Tokei 1.0.20 app, re-signed it, and verified normal launch
- captured a macOS `sample` trace to identify the popover layout hotspot

The default macOS 27 beta SDK currently fails because the installed Command Line Tools cannot resolve `SwiftUIMacros`; the compatible macOS 26.5 SDK build completes successfully.
