### PR TITLE
fix: preserve Codex gpt-5.6-* model identity (don't remap to 5.5)

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -158,9 +158,14 @@ hit% = cached / input × 100
 本地模型名 → OpenRouter canonical ID:
 - `claude-opus-4-8` → `anthropic/claude-opus-4.8`
 - `gpt-5.5` → `openai/gpt-5.5`
+- `gpt-5.6-luna` → `openai/gpt-5.6-luna`（展示/分桶保留真实 id）
 - `gemini-3.5-flash` → `google/gemini-3.5-flash`
 - `:free` / `-free` 后缀去除,按基础价计算
-- 未知模型按 `anthropic/claude-opus-4.8` 兜底(偏保守)
+
+**身份 vs 计价（分开处理）:**
+- 用量分桶与界面展示使用真实模型 id（如 `openai/gpt-5.6-luna` → 显示 `GPT-5.6 Luna`）
+- 价目表无该 id 时，**仅查价**按家族关键字回退（如未知 `gpt-5*` → `openai/gpt-5.5` 单价），不把统计身份改写成回退 id
+- 完全无法归类时，查价才按 `anthropic/claude-opus-4.8` 兜底(偏保守)
 
 ### Claude Code 成本公式
 

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -835,7 +835,7 @@ struct DashboardView: View {
                 }
             }
         } else if codexTokens > 0 || codex.cost > 0 {
-            out.append(modelCost(name: "GPT-5.5 (Codex)", cost: codex.cost, tool: "codex",
+            out.append(modelCost(name: "Codex", cost: codex.cost, tool: "codex",
                                  input: codex.in + codex.cached, out: codex.out,
                                  reason: codex.reason, tokens: codexTokens))
         }

--- a/tests/test_codex_dedup.py
+++ b/tests/test_codex_dedup.py
@@ -252,6 +252,45 @@ class CodexScanDedupTests(unittest.TestCase):
         self.assertEqual(models["openai/gpt-5.5"]["in"], 10)
         self.assertEqual(models["openai/gpt-5.5"]["cr"], 40)
 
+    def test_scan_keeps_unknown_gpt56_variant_identity(self):
+        """gpt-5.6-luna must bucket as itself, not collapse into openai/gpt-5.5."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rollout-luna.jsonl"
+            path.write_text("\n".join([
+                self.session_meta("luna"),
+                self.turn_context("2024-01-08T00:00:00Z", "gpt-5.6-luna"),
+                self.token_count("2024-01-08T00:01:00Z", (100, 80, 10, 4), (100, 80, 10, 4)),
+                self.turn_context("2024-01-08T00:02:00Z", "gpt-5.6-terra"),
+                self.token_count("2024-01-08T00:03:00Z", (150, 120, 15, 6), (50, 40, 5, 2)),
+            ]) + "\n", encoding="utf-8")
+            bounds = self.bounds()
+            old_dir = USAGE.CODEX_DIR
+            old_archive_dir = USAGE.CODEX_ARCHIVED_DIR
+            USAGE.CODEX_DIR = tmp
+            USAGE.CODEX_ARCHIVED_DIR = str(Path(tmp) / "archived_sessions")
+            try:
+                with mock.patch.object(USAGE, "fetch_codex_live_limits", return_value=None):
+                    result = USAGE.scan_codex(bounds, {"v": USAGE._SCAN_CACHE_VERSION})
+            finally:
+                USAGE.CODEX_DIR = old_dir
+                USAGE.CODEX_ARCHIVED_DIR = old_archive_dir
+
+        models = result["ranges"]["all"]["models"]
+        self.assertIn("openai/gpt-5.6-luna", models)
+        self.assertIn("openai/gpt-5.6-terra", models)
+        self.assertNotIn("openai/gpt-5.5", models)
+        self.assertEqual(models["openai/gpt-5.6-luna"]["in"], 20)
+        self.assertEqual(models["openai/gpt-5.6-luna"]["cr"], 80)
+        self.assertEqual(models["openai/gpt-5.6-terra"]["in"], 10)
+        self.assertEqual(models["openai/gpt-5.6-terra"]["cr"], 40)
+        # Cost may use gpt-5.5 family price, but identity stays 5.6-*.
+        self.assertGreater(models["openai/gpt-5.6-luna"]["cost"], 0)
+        formatted = USAGE._format_token_models(models)
+        names = {row["name"] for row in formatted}
+        self.assertIn("GPT-5.6 Luna", names)
+        self.assertIn("GPT-5.6 Terra", names)
+        self.assertNotIn("GPT-5.5", names)
+
     def test_scan_parses_only_appended_codex_records(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "rollout-growing.jsonl"
@@ -565,7 +604,7 @@ class ScanCacheMigrationTests(unittest.TestCase):
                         "events": [first, second],
                         "days": {},
                         "session_id": "migrate",
-                        "model_version": 2,
+                        "model_version": USAGE._CODEX_MODEL_VERSION,
                         "parsed_size": 0,
                     },
                 },

--- a/tests/test_gpt56_model_identity.py
+++ b/tests/test_gpt56_model_identity.py
@@ -1,0 +1,67 @@
+"""Identity vs price: unknown gpt-5.6 variants must not display as GPT-5.5."""
+import unittest
+
+from test_codex_limits import USAGE
+
+
+class Gpt56ModelIdentityTests(unittest.TestCase):
+    def test_known_id_preserves_luna_terra_sol(self):
+        for raw, expected in (
+            ("gpt-5.6-luna", "openai/gpt-5.6-luna"),
+            ("gpt-5.6-terra", "openai/gpt-5.6-terra"),
+            ("gpt-5.6-sol", "openai/gpt-5.6-sol"),
+            ("openai/gpt-5.6-luna", "openai/gpt-5.6-luna"),
+        ):
+            self.assertEqual(USAGE._known_id_or_raw(raw), expected, raw)
+            self.assertNotEqual(USAGE._known_id_or_raw(raw), "openai/gpt-5.5", raw)
+
+    def test_known_priced_gpt55_still_canonical(self):
+        self.assertEqual(USAGE._known_id_or_raw("gpt-5.5"), "openai/gpt-5.5")
+        self.assertEqual(USAGE._known_id_or_raw("openai/gpt-5.5"), "openai/gpt-5.5")
+
+    def test_price_fallback_does_not_rewrite_identity(self):
+        # Use a codename that is not expected in pricing.json so identity
+        # and price resolution stay clearly separated on any machine.
+        raw = "gpt-5.6-aurora"
+        identity = USAGE._known_id_or_raw(raw)
+        self.assertEqual(identity, "openai/gpt-5.6-aurora")
+        self.assertNotEqual(identity, "openai/gpt-5.5")
+        self.assertFalse(
+            USAGE._has_known_price(identity),
+            "test assumes aurora is unpriced; if priced, pick another codename",
+        )
+        # Pricing may fall back to a known gpt-5 family row.
+        resolved = USAGE._resolve_id(raw)
+        self.assertEqual(resolved, "openai/gpt-5.5")
+        price = USAGE._raw_price(raw)
+        fallback = USAGE._raw_price("openai/gpt-5.5")
+        self.assertEqual(price["in"], fallback["in"])
+        self.assertEqual(price["out"], fallback["out"])
+        self.assertEqual(USAGE.nice_model(identity), "GPT-5.6 Aurora")
+
+    def test_nice_model_includes_variant_suffix(self):
+        cases = {
+            "gpt-5.6-luna": "GPT-5.6 Luna",
+            "openai/gpt-5.6-luna": "GPT-5.6 Luna",
+            "gpt-5.6-terra": "GPT-5.6 Terra",
+            "gpt-5.6-sol": "GPT-5.6 Sol",
+            "openai/gpt-5.5": "GPT-5.5",
+            "gpt-5-mini": "GPT-5 Mini",
+        }
+        for raw, display in cases.items():
+            self.assertEqual(USAGE.nice_model(raw), display, raw)
+
+    def test_format_token_models_shows_luna_not_55(self):
+        models = {
+            "openai/gpt-5.6-luna": {
+                "in": 20, "out": 10, "cr": 80, "cw": 0, "reason": 4, "cost": 0.01,
+            },
+        }
+        rows = USAGE._format_token_models(models)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "GPT-5.6 Luna")
+        self.assertNotEqual(rows[0]["name"], "GPT-5.5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpt56_model_identity.py
+++ b/tests/test_gpt56_model_identity.py
@@ -47,6 +47,11 @@ class Gpt56ModelIdentityTests(unittest.TestCase):
             "gpt-5.6-sol": "GPT-5.6 Sol",
             "openai/gpt-5.5": "GPT-5.5",
             "gpt-5-mini": "GPT-5 Mini",
+            # Glued letter versions must not become "GPT-4 O"
+            "gpt-4o": "GPT-4o",
+            "openai/gpt-4o": "GPT-4o",
+            "gpt-4o-mini": "GPT-4o Mini",
+            "gpt-4o-2024-08-06": "GPT-4o 2024-08-06",
         }
         for raw, display in cases.items():
             self.assertEqual(USAGE.nice_model(raw), display, raw)

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -247,7 +247,11 @@ def _resolve_id(model: str):
 
 
 def _known_id_or_raw(model: str):
-    """Return a canonical priced ID when known, preserving unknown model names."""
+    """Identity for bucketing/display: priced canonical when known, else keep real id.
+
+    Family/default price fallbacks belong in `_resolve_id` / `_raw_price` only.
+    Unknown variants such as gpt-5.6-luna must not be rewritten to openai/gpt-5.5.
+    """
     s = (model or "").strip()
     if not s or s.lower() == "<synthetic>":
         return None
@@ -256,13 +260,8 @@ def _known_id_or_raw(model: str):
     norm = _normalize(s)
     if norm and (norm in _OV_MODELS or norm in _PRICING_DB or norm in _DEFAULT_PRICES):
         return norm
-    low = s.lower()
-    if "gemini" in low:
-        return "google/gemini-3.1-pro-preview" if "pro" in low else "google/gemini-3.5-flash"
-    for keyword, representative in _FAMILY:
-        if keyword in low:
-            return representative
-    return s
+    # Preserve identity (prefer normalized openrouter-style id when available).
+    return norm or s
 
 
 def _has_known_price(model: str):
@@ -270,13 +269,20 @@ def _has_known_price(model: str):
 
 
 def _pricing_id(model: str):
-    canonical = _known_id_or_raw(model)
-    if canonical and (canonical in _OV_MODELS or canonical in _PRICING_DB or canonical in _DEFAULT_PRICES):
-        return canonical
+    """Return an id that has a price row, without rewriting display identity."""
+    s = (model or "").strip()
+    if not s or s.lower() == "<synthetic>":
+        return None
+    if s in _OV_ALIASES:
+        alias = _OV_ALIASES[s]
+        if alias in _OV_MODELS or alias in _PRICING_DB or alias in _DEFAULT_PRICES:
+            return alias
+    norm = _normalize(s)
+    if norm and (norm in _OV_MODELS or norm in _PRICING_DB or norm in _DEFAULT_PRICES):
+        return norm
     # ZCode currently reports GLM-5.2, whose public price is not listed yet.
     # Use the documented GLM-5.1 equivalent until the pricing feed adds 5.2.
-    normalized = _normalize(model)
-    if normalized == "z-ai/glm-5.2" and "z-ai/glm-5.1" in _PRICING_DB:
+    if norm == "z-ai/glm-5.2" and "z-ai/glm-5.1" in _PRICING_DB:
         return "z-ai/glm-5.1"
     return None
 
@@ -325,10 +331,25 @@ def nice_model(m: str) -> str:
             mt = re.search(r"(\d+)-(\d+)", s)
             return f"{disp} {mt.group(1)}.{mt.group(2)}" if mt else disp
     if "gpt" in s:
-        mt = re.search(r"gpt[- ]?(\d+(?:\.\d+)?)", s)
-        version = mt.group(1) if mt else ""
-        suffix = " Mini" if "mini" in s else ""
-        return f"GPT-{version}{suffix}" if version else "GPT"
+        name = m.split("/")[-1]
+        mt = re.search(r"gpt[- ]?(\d+(?:\.\d+)?)", name, re.I)
+        if not mt:
+            return "GPT"
+        version = mt.group(1)
+        after = name[mt.end():]
+        parts = [p for p in re.split(r"[-_\s]+", after) if p]
+        skip = {"free", "preview", "latest"}
+        labels = [f"GPT-{version}"]
+        for part in parts:
+            pl = part.lower()
+            if pl in skip:
+                continue
+            if pl in ("mini", "nano", "pro", "codex", "chat"):
+                labels.append(pl[:1].upper() + pl[1:])
+            else:
+                # Variant codenames: luna / terra / sol → Luna / Terra / Sol
+                labels.append(part[:1].upper() + part[1:].lower() if part[:1].isalpha() else part)
+        return " ".join(labels)
     if "mimo" in s:
         name = m.split("/")[-1]
         version = re.sub(r"^mimo[- ]?v?", "", name, flags=re.I).strip()
@@ -417,8 +438,12 @@ def human(n: float) -> str:
 # ---------- 增量扫描缓存 ----------
 import tempfile as _tempfile
 _SCAN_CACHE_FILE = os.path.join(_tempfile.gettempdir(), "_tokei_scan_cache.json")
-_SCAN_CACHE_VERSION = 20
-_SCAN_CACHE_MIGRATABLE_VERSION = 19
+_SCAN_CACHE_VERSION = 21
+# Older versions that can be upgraded in place (sidecar migration, etc.).
+# Wrong gpt-5.6 identity buckets are fixed by _CODEX_MODEL_VERSION bump below.
+_SCAN_CACHE_MIGRATABLE_VERSIONS = frozenset({19, 20})
+_SCAN_CACHE_MIGRATABLE_VERSION = 20  # backward-compat alias for tests/tools
+_CODEX_MODEL_VERSION = 3
 _CODEX_EVENT_CACHE_SUFFIX = ".codex-events"
 _GEMINI_DAYS_CACHE_KEY = "_gemini_dashboard_days"
 _GROK_DAYS_CACHE_KEY = "_grok_dashboard_days"
@@ -434,14 +459,14 @@ def _load_scan_cache():
         with open(_SCAN_CACHE_FILE, "r") as f:
             c = json.load(f)
         version = c.get("v")
-        if version not in (_SCAN_CACHE_VERSION, _SCAN_CACHE_MIGRATABLE_VERSION):
-            _remove_codex_event_cache_dir()
-            return {"v": _SCAN_CACHE_VERSION, "_dirty": True}
-        if version == _SCAN_CACHE_MIGRATABLE_VERSION:
+        if version == _SCAN_CACHE_VERSION:
+            c["_dirty"] = False
+        elif version in _SCAN_CACHE_MIGRATABLE_VERSIONS:
             c["v"] = _SCAN_CACHE_VERSION
             c["_dirty"] = True
         else:
-            c["_dirty"] = False
+            _remove_codex_event_cache_dir()
+            return {"v": _SCAN_CACHE_VERSION, "_dirty": True}
         c["_keys"] = {k for k in c if not k.startswith("_")}
         return c
     except Exception:
@@ -1880,12 +1905,13 @@ def scan_codex(bounds, cache):
             cur_file = f
         sig = f"{st.st_mtime_ns}:{size}"
         entry = fc.get(f)
-        if (not entry or entry.get("sig") != sig or entry.get("model_version") != 2
+        if (not entry or entry.get("sig") != sig
+                or entry.get("model_version") != _CODEX_MODEL_VERSION
                 or not _codex_event_cache_ready(f, entry)):
             complete_offset = _codex_complete_offset(f, size)
             file_id = f"{st.st_dev}:{st.st_ino}"
             append_from = None
-            if isinstance(entry, dict) and entry.get("model_version") == 2:
+            if isinstance(entry, dict) and entry.get("model_version") == _CODEX_MODEL_VERSION:
                 old_offset = int(entry.get("parsed_size", 0) or 0)
                 if (entry.get("file_id") == file_id and old_offset <= complete_offset
                         and entry.get("parsed_guard") == _codex_offset_guard(f, old_offset)
@@ -1958,8 +1984,12 @@ def scan_codex(bounds, cache):
                         lc = last.get("cached_input_tokens", 0) or 0
                         lo = last.get("output_tokens", 0) or 0
                         lr = last.get("reasoning_output_tokens", 0) or 0
-                        model = _known_id_or_raw(file_model) or "openai/gpt-5.5"
-                        price_model = model if _has_known_price(model) else "openai/gpt-5.5"
+                        # Keep real model identity for buckets/display; price may fall back.
+                        model = _known_id_or_raw(file_model) or "unknown"
+                        if _has_known_price(model):
+                            price_model = model
+                        else:
+                            price_model = _resolve_id(file_model or model) or "openai/gpt-5.5"
                         cx_base = _raw_price(price_model)
                         hi = li > 272_000
                         p_in = cx_base["in"] * (2 if hi else 1)
@@ -2015,7 +2045,7 @@ def scan_codex(bounds, cache):
                 "limits": file_limits, "limits_ts": file_limits_ts, "plan": file_plan,
                 "g_limits": file_g_limits, "g_ts": file_g_ts, "g_plan": file_g_plan,
                 "last_total": file_last_total, "prev_total_key": prev_total_key,
-                "active_model": file_model, "model_version": 2,
+                "active_model": file_model, "model_version": _CODEX_MODEL_VERSION,
                 "file_id": file_id, "parsed_size": complete_offset,
                 "parsed_guard": _codex_offset_guard(f, complete_offset),
                 "event_cache_size": event_cache_size,
@@ -6125,8 +6155,8 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
     codex_out = sum(d["x_out"] for d in days.values())
     codex_reason = sum(d["x_reason"] for d in days.values())
     if codex_total > 0 and not any(v.get("tool") == "codex" for v in models.values()):
-        models["GPT-5.5 (Codex)"] = {"cost": round(codex_total, 2), "in": codex_in, "out": codex_out,
-                                      "reason": codex_reason, "tool": "codex"}
+        models["Codex"] = {"cost": round(codex_total, 2), "in": codex_in, "out": codex_out,
+                           "reason": codex_reason, "tool": "codex"}
 
     daily = [{"date": dk, "claude": round(v["claude"], 2), "codex": round(v["codex"], 2),
               "gemini": round(v["gemini"], 2), "hermes": round(v["hermes"], 2),

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -332,14 +332,22 @@ def nice_model(m: str) -> str:
             return f"{disp} {mt.group(1)}.{mt.group(2)}" if mt else disp
     if "gpt" in s:
         name = m.split("/")[-1]
-        mt = re.search(r"gpt[- ]?(\d+(?:\.\d+)?)", name, re.I)
+        # Keep glued letter suffixes on the version (4o → 4o), not "4 O".
+        # Separators still split codenames (5.6-luna) and tiers (4o-mini).
+        mt = re.search(r"gpt[- ]?(\d+(?:\.\d+)?[a-z]*)", name, re.I)
         if not mt:
             return "GPT"
-        version = mt.group(1)
+        version_raw = mt.group(1)
+        vm = re.match(r"(\d+(?:\.\d+)?)([a-zA-Z]*)$", version_raw)
+        version = (vm.group(1) + vm.group(2).lower()) if vm else version_raw.lower()
         after = name[mt.end():]
         parts = [p for p in re.split(r"[-_\s]+", after) if p]
         skip = {"free", "preview", "latest"}
         labels = [f"GPT-{version}"]
+        # Snapshot tails like 2024-08-06 stay as one token, not "2024 08 06".
+        if parts and all(p.isdigit() for p in parts):
+            labels.append("-".join(parts))
+            return " ".join(labels)
         for part in parts:
             pl = part.lower()
             if pl in skip:


### PR DESCRIPTION
## Summary
- **Bug:** Codex sessions using `gpt-5.6-luna` / `terra` / `sol` were bucketed and shown as **GPT-5.5** because `_known_id_or_raw` applied the `gpt-5 → openai/gpt-5.5` family fallback for *identity*, not only for pricing.
- **Fix:** Separate identity from price lookup. Unknown models keep their real id for stats/UI; missing prices still fall back via `_resolve_id` / family (e.g. unpriced `gpt-5.6-*` → gpt-5.5 rates).
- **Display:** `nice_model` now keeps variant suffixes (`GPT-5.6 Luna`, `Terra`, `Sol`).
- **Fallbacks:** Hardcoded `GPT-5.5 (Codex)` labels (Python dashboard + Swift) → neutral `Codex`.
- **Cache:** Bump scan cache to v21 and Codex `model_version` to 3 so old remapped day buckets are rebuilt.
- **Docs:** `CALCULATION.md` documents identity vs price fallback.

## Test plan
- [x] `PYTHONPATH=tests python3 -m unittest tests.test_gpt56_model_identity tests.test_codex_dedup.CodexScanDedupTests.test_scan_keeps_unknown_gpt56_variant_identity -v`
- [x] `PYTHONPATH=tests python3 -m unittest tests.test_gpt56_model_identity tests.test_codex_dedup tests.test_cost_recalculation tests.test_codex_limits tests.test_dashboard_cache tests.test_pricing_cache -v` (44 tests OK)
- [x] Live `python3 usage.30s.py --json` after clearing temp scan cache: today shows `GPT-5.6 Luna` / `Terra`; all-time includes Luna/Terra/Sol (plus real historical GPT-5.5). Screenshots optional — JSON evidence is the bar for this collector bug.

## Notes
- Screenshots not required for merge; this is primarily a collector/model-identity fix verified by unit tests + `--json`.
- After upgrade, first refresh may re-scan Codex rollouts (model_version 3).
- Opened from fork `mammut001/tokei` (no direct push to `cclank/tokei`).