### PR TITLE
feat(prime-agent): add token usage tracking

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -16,6 +16,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `session_model_usage*` 用量表，回退 `sessions` 表 |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` | JSONL 用量 + SQLite 任务 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
+| Prime Agent | `~/.prime/agent/sessions/*.jsonl` + `session-artifacts/**/**/*.jsonl` | JSONL, assistant `message.usage` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
 | OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | SQLite/JSON, `tokens` + `cost` |
 | Qwen Code | `${QWEN_RUNTIME_DIR:-~/.qwen}/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` | JSONL,逐请求记录 + 会话汇总 |
@@ -88,6 +89,16 @@ token 快照误删。
 - 缓存写 = `usage.cacheWrite`
 - 推理 = `usage.reasoning`(如果存在)
 - 成本 = `usage.cost.total`(优先使用)
+
+**Prime Agent** — Usage 字段与 Pi Coding Agent 一致:
+- 输入 = `usage.input`
+- 输出 = `usage.output`
+- 缓存读 = `usage.cacheRead`
+- 缓存写 = `usage.cacheWrite`
+- 推理 = `usage.reasoning`（通常没有，按 0 处理）
+- 成本 = `usage.cost.total`，缺失时按价格表估算
+
+只读取 assistant message 的逐次 usage；`child_usage_attributed` 是父会话聚合 bookkeeping，不重复计入。RLM 子代理日志按独立 session 参与统计。
 
 **Qwen Code** — `inputTokens` 已包含缓存,`thoughtsTokens` 独立:
 - 输入 = `inputTokens - cachedTokens`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,10 @@
+# Domain Glossary
+
+## Tool Usage
+
+- **Tool**: An AI coding application whose locally persisted model activity is reported separately by Tokei. Prime Agent and Pi Coding Agent are distinct tools even though they share a session format.
+- **Session**: One persisted session JSONL file. A Prime Agent root session and each RLM child session are separate sessions.
+- **Usage Event**: The usage attached to one persisted assistant message. It represents one provider response and is the unit Tokei adds to token and cost totals.
+- **Attributed Child Usage**: A Prime Agent parent-session bookkeeping event that summarizes usage produced by a child session. It is not a usage event and is excluded when the child session's own usage events are available.
+- **Project**: The working directory recorded by a session header. Usage from root and child sessions is assigned to that recorded directory.
+- **Actual Cost**: Cost persisted with a usage event by the tool. Tokei uses the model price table only when actual cost is absent.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
 
 ### 支持的工具
 
@@ -32,6 +32,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 | **Hermes** | Token、成本、缓存命中率、模型 |
 | **OpenClaw** | Token、成本、任务、模型 |
 | **Pi Coding Agent CLI** | Token、成本、缓存命中率、模型、项目 |
+| **Prime Agent** | Token、成本、缓存命中率、模型、项目（含 RLM 子代理） |
 | **WorkBuddy** | Token、成本、缓存命中率、模型、项目 |
 | **OpenCode** | Token、成本、缓存命中率、模型 |
 | **Qwen Code** | Token、思考量、成本、模型 |
@@ -159,6 +160,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
+| Prime Agent | `~/.prime/agent/sessions/*.jsonl` + `session-artifacts/**/**/*.jsonl` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` |
 | OpenCode | `~/.opencode/sessions/*.json` |
 | Qwen Code | `~/.qwen/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` |
@@ -318,7 +320,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **12 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **13 AI coding tools** in real-time — all from local log files, with zero network traffic.
 
 **Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local logs only) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -6,6 +6,7 @@ struct DailyCost: Codable, Identifiable {
     var codex: Double
     var grok: Double?
     var pi: Double = 0
+    var prime_agent: Double?
     var workbuddy: Double?
     var qwencode: Double?
     var total: Double
@@ -22,6 +23,11 @@ struct DailyCost: Codable, Identifiable {
     var p_cr: Int = 0
     var p_cw: Int = 0
     var p_reason: Int = 0
+    var pa_in: Int = 0
+    var pa_out: Int = 0
+    var pa_cr: Int = 0
+    var pa_cw: Int = 0
+    var pa_reason: Int = 0
     var w_in: Int?
     var w_out: Int?
     var w_cr: Int?
@@ -200,6 +206,7 @@ struct DashboardView: View {
         case "mimocode": return Theme.mimocode
         case "openclaw": return Theme.openclaw
         case "pi": return Theme.pi
+        case "prime_agent": return Theme.primeAgent
         case "workbuddy": return Theme.workbuddy
         case "opencode": return Theme.opencode
         case "qwencode": return Theme.qwencode
@@ -310,6 +317,16 @@ struct DashboardView: View {
                     Text("\(Fmt.human(d.p_in + d.p_out + d.p_cr + d.p_cw + d.p_reason)) tok")
                         .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
                     Text(String(format: "$%.2f", d.pi))
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced)).foregroundStyle(Theme.tSecondary)
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 4) {
+                        Circle().fill(Theme.primeAgent).frame(width: 6, height: 6)
+                        Text("Prime Agent").font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.primeAgent)
+                    }
+                    Text("\(Fmt.human((d.pa_in) + d.pa_out + d.pa_cr + d.pa_cw + d.pa_reason)) tok")
+                        .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
+                    Text(String(format: "$%.2f", d.prime_agent ?? 0))
                         .font(.system(size: 12, weight: .semibold, design: .monospaced)).foregroundStyle(Theme.tSecondary)
                 }
                 VStack(alignment: .leading, spacing: 3) {
@@ -740,6 +757,11 @@ struct DashboardView: View {
                   p_cr: lhs.p_cr + rhs.p_cr,
                   p_cw: lhs.p_cw + rhs.p_cw,
                   p_reason: lhs.p_reason + rhs.p_reason,
+                  pa_in: lhs.pa_in + rhs.pa_in,
+                  pa_out: lhs.pa_out + rhs.pa_out,
+                  pa_cr: lhs.pa_cr + rhs.pa_cr,
+                  pa_cw: lhs.pa_cw + rhs.pa_cw,
+                  pa_reason: lhs.pa_reason + rhs.pa_reason,
                   w_in: (lhs.w_in ?? 0) + (rhs.w_in ?? 0),
                   w_out: (lhs.w_out ?? 0) + (rhs.w_out ?? 0),
                   w_cr: (lhs.w_cr ?? 0) + (rhs.w_cr ?? 0),
@@ -881,6 +903,7 @@ struct DashboardView: View {
         appendTokenModels(usage.mimocode.ranges.get(key).models, tool: "mimocode", suffix: "MiMoCode", to: &out)
         appendTokenModels(usage.openclaw.ranges.get(key).models, tool: "openclaw", suffix: "OpenClaw", to: &out)
         appendTokenModels(usage.pi.ranges.get(key).models, tool: "pi", suffix: "Pi", to: &out)
+        appendTokenModels(usage.prime_agent.ranges.get(key).models, tool: "prime_agent", suffix: "Prime Agent", to: &out)
         appendTokenModels(usage.workbuddy.ranges.get(key).models, tool: "workbuddy", suffix: "WorkBuddy", to: &out)
         appendTokenModels(usage.opencode.ranges.get(key).models, tool: "opencode", suffix: "OpenCode", to: &out)
         appendTokenModels(usage.qwencode.ranges.get(key).models, tool: "qwencode", suffix: "Qwen Code", to: &out)
@@ -950,6 +973,7 @@ struct DashboardView: View {
             + usage.mimocode.ranges.get(key).cost
             + usage.openclaw.ranges.get(key).cost
             + usage.pi.ranges.get(key).cost
+             + usage.prime_agent.ranges.get(key).cost
             + usage.workbuddy.ranges.get(key).cost
             + usage.opencode.ranges.get(key).cost
             + usage.qwencode.ranges.get(key).cost

--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -41,6 +41,7 @@ enum Theme {
     static let mimocode = Color(red: 0.95, green: 0.50, blue: 0.26) // 暖橙
     static let openclaw = Color(red: 0.85, green: 0.45, blue: 0.68) // 玫红
     static let pi = Color(red: 0.74, green: 0.58, blue: 0.95)       // 柔紫
+    static let primeAgent = Color(red: 0.96, green: 0.58, blue: 0.28) // 活力橙
     static let workbuddy = Color(red: 0.25, green: 0.78, blue: 0.72) // 青绿
     static let opencode = Color(red: 0.55, green: 0.75, blue: 0.90) // 天蓝灰
     static let qwencode = Color(red: 0.48, green: 0.55, blue: 0.95) // 靛蓝

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -672,13 +672,14 @@ struct Usage: Codable {
     var mimocode: TokenUsageStat
     var openclaw: OpenClawStat
     var pi: TokenUsageStat
+    var prime_agent: TokenUsageStat
     var workbuddy: TokenUsageStat
     var opencode: TokenUsageStat
     var qwencode: TokenUsageStat
 
     enum CodingKeys: String, CodingKey {
         case claude, codex, gemini, grok, qoder, qoderwork, qodercli, hermes, zcode, mimocode
-        case openclaw, pi, workbuddy, opencode, qwencode
+        case openclaw, pi, prime_agent, workbuddy, opencode, qwencode
     }
 
     init(from decoder: Decoder) throws {
@@ -699,6 +700,7 @@ struct Usage: Codable {
         mimocode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .mimocode) ?? TokenUsageStat(ranges: .empty)
         openclaw = try c.decode(OpenClawStat.self, forKey: .openclaw)
         pi = try c.decodeIfPresent(TokenUsageStat.self, forKey: .pi) ?? TokenUsageStat(ranges: .empty)
+        prime_agent = try c.decodeIfPresent(TokenUsageStat.self, forKey: .prime_agent) ?? TokenUsageStat(ranges: .empty)
         workbuddy = try c.decodeIfPresent(TokenUsageStat.self, forKey: .workbuddy) ?? TokenUsageStat(ranges: .empty)
         opencode = try c.decode(TokenUsageStat.self, forKey: .opencode)
         qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -14,6 +14,7 @@ struct PanelView: View {
     @State private var zcodeModelsOpen = false
     @State private var mimocodeModelsOpen = false
     @State private var piModelsOpen = false
+    @State private var primeAgentModelsOpen = false
     @State private var workBuddyModelsOpen = false
     @State private var openCodeModelsOpen = false
     @State private var qwenCodeModelsOpen = false
@@ -41,6 +42,7 @@ struct PanelView: View {
     @AppStorage("showMimoCode") private var showMimoCode = true
     @AppStorage("showOpenClaw") private var showOpenClaw = true
     @AppStorage("showPi") private var showPi = true
+    @AppStorage("showPrimeAgent") private var showPrimeAgent = true
     @AppStorage("showWorkBuddy") private var showWorkBuddy = true
     @AppStorage("showOpenCode") private var showOpenCode = true
     @AppStorage("showQwenCode") private var showQwenCode = true
@@ -53,7 +55,7 @@ struct PanelView: View {
 
     private var visibleCount: Int {
         [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showQoderCli, showHermes, showZcode, showMimoCode,
-         showOpenClaw, showPi, showWorkBuddy, showOpenCode, showQwenCode].filter { $0 }.count
+         showOpenClaw, showPi, showPrimeAgent, showWorkBuddy, showOpenCode, showQwenCode].filter { $0 }.count
     }
     private var hasMultipleDevices: Bool { store.syncEnabled && !store.peers.isEmpty }
     private var useWide: Bool { visibleCount > 2 }
@@ -285,6 +287,7 @@ struct PanelView: View {
         let hr = u.hermes.ranges.get(sel)
         let zr = u.zcode.ranges.get(sel), mr = u.mimocode.ranges.get(sel)
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel)
+        let par = u.prime_agent.ranges.get(sel)
         let wr = u.workbuddy.ranges.get(sel), or = u.opencode.ranges.get(sel)
         let qcr = u.qwencode.ranges.get(sel)
         return [
@@ -318,6 +321,8 @@ struct PanelView: View {
                          tint: Theme.openclaw, content: AnyView(openclawBlock(lr))),
             ToolCardItem(id: "pi", name: "Pi", visible: showPi, active: pr.sessions > 0,
                          tint: Theme.pi, content: AnyView(tokenUsageBlock(title: "Pi Coding Agent", pr, tint: Theme.pi, modelsOpen: $piModelsOpen))),
+            ToolCardItem(id: "prime_agent", name: "Prime Agent", visible: showPrimeAgent, active: par.sessions > 0,
+                         tint: Theme.primeAgent, content: AnyView(tokenUsageBlock(title: "Prime Agent", par, tint: Theme.primeAgent, modelsOpen: $primeAgentModelsOpen))),
             ToolCardItem(id: "workbuddy", name: "WorkBuddy", visible: showWorkBuddy, active: wr.sessions > 0,
                          tint: Theme.workbuddy, content: AnyView(tokenUsageBlock(title: "WorkBuddy", wr, tint: Theme.workbuddy, modelsOpen: $workBuddyModelsOpen))),
             ToolCardItem(id: "opencode", name: "OpenCode", visible: showOpenCode, active: or.sessions > 0,
@@ -1611,6 +1616,7 @@ struct PanelView: View {
                 settingsRow("MiMoCode", tint: Theme.mimocode, isOn: $showMimoCode)
                 settingsRow("OpenClaw", tint: Theme.openclaw, isOn: $showOpenClaw)
                 settingsRow("Pi", tint: Theme.pi, isOn: $showPi)
+                settingsRow("Prime Agent", tint: Theme.primeAgent, isOn: $showPrimeAgent)
                 settingsRow("WorkBuddy", tint: Theme.workbuddy, isOn: $showWorkBuddy)
                 settingsRow("OpenCode", tint: Theme.opencode, isOn: $showOpenCode)
                 settingsRow("Qwen Code", tint: Theme.qwencode, isOn: $showQwenCode)
@@ -2278,7 +2284,7 @@ struct PanelView: View {
         if let data = result.stdout.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             let tools = ["claude", "codex", "gemini", "grok", "qoder", "qoderwork", "hermes",
-                         "zcode", "mimocode", "openclaw", "pi", "workbuddy", "opencode", "qwencode"]
+                         "zcode", "mimocode", "openclaw", "pi", "prime_agent", "workbuddy", "opencode", "qwencode"]
                 .filter { json[$0] != nil }
                 .joined(separator: ",")
             lines.append("json: ok tools: \(tools)")

--- a/Tokei/Sources/Tokei/ProjectTrailView.swift
+++ b/Tokei/Sources/Tokei/ProjectTrailView.swift
@@ -254,6 +254,7 @@ struct ProjectTrailView: View {
         case "zcode": return Theme.zcode
         case "mimocode": return Theme.mimocode
         case "pi": return Theme.pi
+        case "prime_agent": return Theme.primeAgent
         case "workbuddy": return Theme.workbuddy
         default: return Theme.tTertiary
         }

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -371,6 +371,7 @@ final class SyncManager {
             mergeRanges(&u.mimocode.ranges, peer.usage.mimocode.ranges, pairs)
             mergeRanges(&u.openclaw.ranges, peer.usage.openclaw.ranges, pairs)
             mergeRanges(&u.pi.ranges, peer.usage.pi.ranges, pairs)
+            mergeRanges(&u.prime_agent.ranges, peer.usage.prime_agent.ranges, pairs)
             mergeRanges(&u.workbuddy.ranges, peer.usage.workbuddy.ranges, pairs)
             mergeRanges(&u.opencode.ranges, peer.usage.opencode.ranges, pairs)
             mergeRanges(&u.qwencode.ranges, peer.usage.qwencode.ranges, pairs)

--- a/tests/test_prime_agent_usage.py
+++ b/tests/test_prime_agent_usage.py
@@ -1,0 +1,107 @@
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+try:
+    from .test_codex_limits import USAGE
+except ImportError:
+    from test_codex_limits import USAGE
+
+
+class PrimeAgentUsageTests(unittest.TestCase):
+    def write_session(self, path, session_id, project, messages):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        records = [{"type": "session", "version": 3, "id": session_id,
+                    "timestamp": "2026-08-06T09:00:00Z", "cwd": project}, *messages]
+        path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+    def assistant(self, timestamp, model="gpt-5.6-sol", stop_reason="stop", **usage):
+        return {"type": "message", "timestamp": timestamp,
+                "message": {"role": "assistant", "provider": "metarouter", "model": model,
+                             "stopReason": stop_reason, "usage": {
+                                 "input": usage.get("input", 0), "output": usage.get("output", 0),
+                                 "cacheRead": usage.get("cache_read", 0), "cacheWrite": usage.get("cache_write", 0),
+                                 "cost": usage.get("cost", {})}}}
+
+    def scan(self, agent_dir):
+        with mock.patch.object(USAGE, "PRIME_AGENT_DIR", str(agent_dir)), \
+             mock.patch.dict(os.environ, {}, clear=False):
+            for key in ("TOKEI_PRIME_AGENT_SESSION_DIR", "PRIME_AGENT_SESSION_DIR",
+                        "PRIME_AGENT_CODING_AGENT_SESSION_DIR", "PRIME_AGENT_CODING_AGENT_DIR"):
+                os.environ.pop(key, None)
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            return USAGE.scan_prime_agent(USAGE.range_bounds(), cache), cache
+
+    def test_root_and_nested_children_are_counted_without_attribution_double_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_dir = Path(tmp) / ".prime" / "agent"
+            now = datetime.now().astimezone().replace(microsecond=0).isoformat()
+            root_message = self.assistant(now, input=100, output=20, cache_read=30,
+                                          cache_write=4, cost={"total": 0.42})
+            root_message["id"] = "root-assistant"
+            attributed = {"type": "child_usage_attributed", "timestamp": now,
+                          "targetId": "root-assistant", "childUsage": {
+                              "input": 50, "output": 10, "cacheRead": 5, "cacheWrite": 1,
+                              "cost": {"total": 0.2}}}
+            self.write_session(agent_dir / "sessions" / "root.jsonl", "root", "/tmp/root-project",
+                               [root_message, attributed])
+            self.write_session(agent_dir / "sessions" / "root-copy.jsonl", "root", "/tmp/root-project",
+                               [root_message, attributed])
+            self.write_session(agent_dir / "session-artifacts" / "root" / "sub-a" / "child.jsonl",
+                               "child", "/tmp/child-project",
+                               [self.assistant(now, input=50, output=10, cache_read=5, cache_write=1,
+                                                cost={"input": 0.1, "output": 0.1})])
+            self.write_session(agent_dir / "session-artifacts" / "root" / "sub-a" /
+                               "session-artifacts" / "child" / "sub-b" / "grandchild.jsonl",
+                               "grandchild", "/tmp/grandchild-project",
+                               [self.assistant(now, stop_reason="error", input=25, output=5,
+                                                cache_read=2, cost={"total": 0.08})])
+            result, cache = self.scan(agent_dir)
+        usage = result["ranges"]["all"]
+        self.assertEqual((usage["in"], usage["out"], usage["cr"], usage["cw"]), (175, 35, 37, 5))
+        self.assertEqual(usage["sessions"], {"root", "child", "grandchild"})
+        self.assertAlmostEqual(usage["cost"], 0.70)
+        self.assertEqual(len(cache["prime_agent"]), 3)
+
+    def test_model_project_and_unchanged_cache_are_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_dir = Path(tmp) / "agent"
+            session = agent_dir / "sessions" / "session.jsonl"
+            now = datetime.now().astimezone().replace(microsecond=0).isoformat()
+            self.write_session(session, "session-id", "/tmp/prime-project",
+                               [self.assistant(now, input=10, output=2, cost={"total": 0.12})])
+            with mock.patch.object(USAGE, "PRIME_AGENT_DIR", str(agent_dir)), \
+                 mock.patch.dict(os.environ, {}, clear=False):
+                for key in ("TOKEI_PRIME_AGENT_SESSION_DIR", "PRIME_AGENT_SESSION_DIR",
+                            "PRIME_AGENT_CODING_AGENT_SESSION_DIR", "PRIME_AGENT_CODING_AGENT_DIR"):
+                    os.environ.pop(key, None)
+                cache = {"v": USAGE._SCAN_CACHE_VERSION}
+                first = USAGE.scan_prime_agent(USAGE.range_bounds(), cache)
+                cache["_dirty"] = False
+                with mock.patch.object(USAGE, "_parse_prime_session_file",
+                                       side_effect=AssertionError("reparsed")):
+                    second = USAGE.scan_prime_agent(USAGE.range_bounds(), cache)
+        self.assertEqual(first, second)
+        self.assertEqual(cache["prime_agent"][str(session.resolve())]["proj"], "/tmp/prime-project")
+        self.assertIn("metarouter/gpt-5.6-sol", first["ranges"]["all"]["models"])
+        self.assertFalse(cache["_dirty"])
+
+    def test_explicit_session_override_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); default_dir = root / "agent"; override = root / "custom-sessions"
+            now = datetime.now().astimezone().replace(microsecond=0).isoformat()
+            self.write_session(override / "custom.jsonl", "custom", "/tmp/custom",
+                               [self.assistant(now, input=7, output=3, cost={"total": 0.01})])
+            with mock.patch.object(USAGE, "PRIME_AGENT_DIR", str(default_dir)), \
+                 mock.patch.dict(os.environ, {"TOKEI_PRIME_AGENT_SESSION_DIR": str(override)}):
+                result = USAGE.scan_prime_agent(USAGE.range_bounds(), {"v": USAGE._SCAN_CACHE_VERSION})
+        self.assertEqual(result["ranges"]["all"]["in"], 7)
+        self.assertEqual(result["ranges"]["all"]["sessions"], {"custom"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -118,6 +118,11 @@ OPENCLAW_STATE_DB = os.path.join(HOME, ".openclaw", "state", "openclaw.sqlite")
 OPENCLAW_AGENTS = os.path.join(HOME, ".openclaw", "agents")
 PI_AGENT_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_DIR", os.path.join(HOME, ".pi", "agent")))
 PI_SESSION_DIR = os.path.expanduser(os.environ.get("PI_CODING_AGENT_SESSION_DIR", os.path.join(PI_AGENT_DIR, "sessions")))
+PRIME_AGENT_DIR = os.path.expanduser(os.environ.get(
+    "PRIME_AGENT_CODING_AGENT_DIR", os.path.join(HOME, ".prime", "agent")))
+PRIME_AGENT_SESSION_DIR = os.path.expanduser(os.environ.get(
+    "PRIME_AGENT_SESSION_DIR", os.environ.get(
+        "PRIME_AGENT_CODING_AGENT_SESSION_DIR", os.path.join(PRIME_AGENT_DIR, "sessions"))))
 OMP_SESSION_DIR = os.path.expanduser(os.environ.get(
     "OMP_CODING_AGENT_SESSION_DIR", os.path.join(HOME, ".omp", "agent", "sessions")))
 QWEN_CODE_DIR = os.path.abspath(os.path.expanduser(
@@ -586,6 +591,10 @@ def _empty_opencode():
 
 
 def _empty_pi():
+    return _empty_opencode()
+
+
+def _empty_prime_agent():
     return _empty_opencode()
 
 
@@ -4050,6 +4059,145 @@ def scan_pi(bounds, cache):
     return {"ranges": B}
 
 
+# ---------- Prime Agent ----------
+# JSONL 文件: ~/.prime/agent/sessions/*.jsonl plus session-artifacts/**/**/*.jsonl.
+# Prime Agent uses the Pi Coding Agent Usage shape; child attribution records are bookkeeping only.
+def _prime_agent_session_dirs():
+    explicit = os.environ.get("TOKEI_PRIME_AGENT_SESSION_DIR")
+    if explicit:
+        return _existing_dirs([explicit])
+    agent_dir = os.path.expanduser(os.environ.get(
+        "PRIME_AGENT_CODING_AGENT_DIR", PRIME_AGENT_DIR))
+    session_override = os.environ.get(
+        "PRIME_AGENT_SESSION_DIR", os.environ.get("PRIME_AGENT_CODING_AGENT_SESSION_DIR"))
+    return _existing_dirs([
+        session_override or os.path.join(agent_dir, "sessions"),
+        os.path.join(agent_dir, "session-artifacts"),
+    ])
+
+
+def _parse_prime_session_file(path):
+    days = {}
+    events = []
+    project = None
+    session_id = os.path.basename(path)
+    model = ""
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            for line_no, line in enumerate(fh, 1):
+                if '"type"' not in line and '"usage"' not in line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                if obj.get("type") == "session":
+                    session_id = str(obj.get("id") or session_id)
+                    project = obj.get("cwd") or project
+                    continue
+                if obj.get("type") == "model_change":
+                    model = _pi_model_id({"provider": obj.get("provider"),
+                                           "model": obj.get("modelId")})
+                    continue
+                if obj.get("type") != "message":
+                    continue
+                msg = obj.get("message") or {}
+                if msg.get("role") != "assistant":
+                    continue
+                usage = msg.get("usage") or {}
+                if not usage:
+                    continue
+                dt = parse_ts(obj.get("timestamp") or msg.get("timestamp") or "")
+                if dt is None:
+                    continue
+                current_model = _pi_model_id(msg)
+                current_model = current_model if current_model != "unknown" else model
+                inp = _pi_usage_int(usage, "input")
+                out = _pi_usage_int(usage, "output")
+                cr = _pi_usage_int(usage, "cacheRead", "cache_read")
+                cw = _pi_usage_int(usage, "cacheWrite", "cache_write")
+                reason = _pi_usage_int(usage, "reasoning", "reason", "reasoningTokens")
+                cost = _pi_usage_cost(usage, current_model)
+                if inp + out + cr + cw + reason == 0 and cost <= 0:
+                    continue
+                event_id = obj.get("id") or msg.get("id") or msg.get("responseId")
+                key = f"{session_id}:{event_id}" if event_id else f"{session_id}:{line_no}"
+                events.append({"key": key, "date": dt.astimezone().date().isoformat(),
+                               "hour": dt.astimezone().hour, "in": inp, "out": out,
+                               "cr": cr, "cw": cw, "reason": reason, "cost": cost,
+                               "model": current_model})
+    except OSError:
+        return {"session": session_id, "proj": project, "events": [], "days": {}}
+    for event in events:
+        day = days.setdefault(event["date"], _empty_token_day())
+        _add_token_usage(day, event["in"], event["out"], event["cr"], event["cw"],
+                         event["reason"], event["cost"], event["model"])
+        day["hours"][event["hour"]] += token_total(event)
+    return {"session": session_id, "sid": session_id, "proj": project,
+            "events": events, "days": days}
+
+
+def scan_prime_agent(bounds, cache):
+    fc = cache.setdefault("prime_agent", {})
+    B = _empty_token_ranges()
+    roots = _prime_agent_session_dirs()
+    seen_files = set()
+    for root in roots:
+        seen_files.update(os.path.realpath(f) for f in glob.glob(
+            os.path.join(root, "**", "*.jsonl"), recursive=True))
+    stale = set(fc.keys()) - seen_files
+    changed = bool(stale)
+    for path in sorted(seen_files):
+        try:
+            st = os.stat(path)
+        except OSError:
+            continue
+        sig = f"{st.st_mtime_ns}:{st.st_size}"
+        entry = fc.get(path)
+        if not isinstance(entry, dict) or entry.get("sig") != sig:
+            parsed = _parse_prime_session_file(path)
+            parsed["sig"] = sig
+            fc[path] = parsed
+            changed = True
+    for path in stale:
+        fc.pop(path, None)
+    # Prefer one physical copy of a logical session, then dedupe message IDs globally.
+    canonical = {}
+    for path, entry in fc.items():
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("sid") or path
+        old = canonical.get(sid)
+        if old is None or len(entry.get("events", [])) > len(old[1].get("events", [])):
+            canonical[sid] = (path, entry)
+    canonical_paths = {path for path, _ in canonical.values()}
+    for path in list(fc):
+        if not path.startswith("_") and path not in canonical_paths:
+            fc.pop(path, None)
+            changed = True
+    used = set()
+    for path, entry in canonical.values():
+        for event in entry.get("events", []):
+            if event.get("key") in used:
+                continue
+            used.add(event.get("key"))
+            day = B["all"]
+            _add_token_usage(day, event.get("in", 0), event.get("out", 0),
+                             event.get("cr", 0), event.get("cw", 0), event.get("reason", 0),
+                             event.get("cost", 0), event.get("model"))
+            for key in classify_date(date.fromisoformat(event["date"]), bounds):
+                if key == "all":
+                    continue
+                _add_token_usage(B[key], event.get("in", 0), event.get("out", 0),
+                                 event.get("cr", 0), event.get("cw", 0), event.get("reason", 0),
+                                 event.get("cost", 0), event.get("model"))
+                B[key]["sessions"].add(entry.get("sid") or path)
+        B["all"]["sessions"].add(entry.get("sid") or path)
+    if changed:
+        cache["_dirty"] = True
+    return {"ranges": B}
+
+
 # ---------- WorkBuddy ----------
 # JSONL 文件: ~/.workbuddy/projects/<encoded-cwd>/<session>.jsonl
 # 每个带 usage 的 item 代表一次模型调用。providerData 中的同一份 usage 仅作字段补全，
@@ -5168,6 +5316,7 @@ def compute():
     mc = _safe_scan("mimocode", lambda: scan_mimocode(bounds, cache), _empty_mimocode, errors)
     oc = _safe_scan("openclaw", lambda: scan_openclaw(bounds, cache), _empty_openclaw, errors)
     pi = _safe_scan("pi", lambda: scan_pi(bounds, cache), _empty_pi, errors)
+    prime = _safe_scan("prime_agent", lambda: scan_prime_agent(bounds, cache), _empty_prime_agent, errors)
     wb = _safe_scan("workbuddy", lambda: scan_workbuddy(bounds, cache), _empty_workbuddy, errors)
     ocode = _safe_scan("opencode", lambda: scan_opencode(bounds, cache), _empty_opencode, errors)
     qwc = _safe_scan("qwencode", lambda: scan_qwencode(bounds, cache), _empty_qwencode, errors)
@@ -5291,6 +5440,7 @@ def compute():
                 "models": _format_token_models(b["models"])}
 
     piranges = {k: token_usage_range(pi["ranges"][k]) for k in RANGE_KEYS}
+    paranges = {k: token_usage_range(prime["ranges"][k]) for k in RANGE_KEYS}
     zcranges = {k: token_usage_range(zc["ranges"][k]) for k in RANGE_KEYS}
     mcranges = {k: token_usage_range(mc["ranges"][k]) for k in RANGE_KEYS}
     wbranges = {k: token_usage_range(wb["ranges"][k]) for k in RANGE_KEYS}
@@ -5367,6 +5517,9 @@ def compute():
         },
         "pi": {
             "ranges": piranges,
+        },
+        "prime_agent": {
+            "ranges": paranges,
         },
         "workbuddy": {
             "ranges": wbranges,
@@ -5922,11 +6075,12 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
 
     _empty = lambda: {"claude": 0.0, "codex": 0.0, "gemini": 0.0, "grok": 0.0,
                        "zcode": 0.0, "mimocode": 0.0, "pi": 0.0,
-                       "workbuddy": 0.0, "opencode": 0.0, "qwencode": 0.0,
+                       "workbuddy": 0.0, "prime_agent": 0.0, "opencode": 0.0, "qwencode": 0.0,
                        "hermes": 0.0, "openclaw": 0.0,
                        "c_in": 0, "c_out": 0, "c_cr": 0, "c_cw": 0,
                        "x_in": 0, "x_out": 0, "x_cached": 0, "x_reason": 0,
                        "p_in": 0, "p_out": 0, "p_cr": 0, "p_cw": 0, "p_reason": 0,
+                        "pa_in": 0, "pa_out": 0, "pa_cr": 0, "pa_cw": 0, "pa_reason": 0,
                        "w_in": 0, "w_out": 0, "w_cr": 0, "w_cw": 0,
                        "q_in": 0, "q_out": 0, "q_cr": 0, "q_reason": 0,
                        "g_in": 0, "g_out": 0, "g_cr": 0, "g_reason": 0,
@@ -5984,6 +6138,27 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
             model["out"] += int(usage.get("out", 0) or 0)
             model["cr"] += cached
             model["reason"] += int(usage.get("thoughts", 0) or 0)
+
+    for fp, entry in cache.get("prime_agent", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        for dk, day in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            d = days.setdefault(dk, _empty())
+            d["prime_agent"] += day.get("cost", 0)
+            d["pa_in"] += day.get("in", 0); d["pa_out"] += day.get("out", 0)
+            d["pa_cr"] += day.get("cr", 0); d["pa_cw"] += day.get("cw", 0)
+            d["pa_reason"] += day.get("reason", 0)
+            d["tokens"] += token_total(day)
+            for model_name, usage in day.get("models", {}).items():
+                name = f"{nice_model(model_name)} (Prime Agent)"
+                model = models.setdefault(name, {"cost": 0.0, "in": 0, "out": 0,
+                                                 "cr": 0, "cw": 0, "reason": 0,
+                                                 "tool": "prime_agent"})
+                model["cost"] += usage.get("cost", 0)
+                for key in TOKEN_FIELDS:
+                    model[key] += usage.get(key, 0)
 
     for dk, day in cache.get(_GROK_DAYS_CACHE_KEY, {}).items():
         if cutoff and dk < cutoff:
@@ -6162,14 +6337,15 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
               "hermes": round(v["hermes"], 2),
               "openclaw": round(v["openclaw"], 2),
               "zcode": round(v["zcode"], 2), "mimocode": round(v["mimocode"], 2), "pi": round(v["pi"], 2),
-              "workbuddy": round(v["workbuddy"], 2), "qwencode": round(v["qwencode"], 2),
+              "workbuddy": round(v["workbuddy"], 2), "prime_agent": round(v["prime_agent"], 2), "qwencode": round(v["qwencode"], 2),
               "total": round(v["claude"] + v["codex"] + v["gemini"] + v["grok"] + v["zcode"]
-                             + v["mimocode"] + v["pi"] + v["workbuddy"]
+                             + v["mimocode"] + v["pi"] + v["prime_agent"] + v["workbuddy"]
                              + v["opencode"] + v["qwencode"] + v["hermes"]
                              + v["openclaw"], 2),
               "c_in": v["c_in"], "c_out": v["c_out"], "c_cr": v["c_cr"], "c_cw": v["c_cw"],
               "x_in": v["x_in"], "x_out": v["x_out"], "x_cached": v["x_cached"], "x_reason": v["x_reason"],
               "p_in": v["p_in"], "p_out": v["p_out"], "p_cr": v["p_cr"], "p_cw": v["p_cw"], "p_reason": v["p_reason"],
+               "pa_in": v["pa_in"], "pa_out": v["pa_out"], "pa_cr": v["pa_cr"], "pa_cw": v["pa_cw"], "pa_reason": v["pa_reason"],
               "w_in": v["w_in"], "w_out": v["w_out"], "w_cr": v["w_cr"], "w_cw": v["w_cw"],
               "q_in": v["q_in"], "q_out": v["q_out"], "q_cr": v["q_cr"], "q_reason": v["q_reason"],
               "g_in": v["g_in"], "g_out": v["g_out"], "g_cr": v["g_cr"], "g_reason": v["g_reason"],
@@ -6431,6 +6607,23 @@ def build_wrapped(period="all", refresh=True, _cache=None):
                 nm = f"{nice_model(mn)} (Pi)"
                 model_tok[nm] = model_tok.get(nm, 0) + token_total(mv)
 
+    # --- Prime Agent (Pi-compatible persisted assistant usage) ---
+    for f, entry in cache.get("prime_agent", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        for dk, day in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            tok = token_total(day)
+            day_tokens[dk] = day_tokens.get(dk, 0) + tok
+            total_tokens += tok
+            total_cost += day.get("cost", 0)
+            weekday[date.fromisoformat(dk).weekday()] += tok
+            add_hours(dk, day.get("hours"))
+            for mn, mv in day.get("models", {}).items():
+                nm = f"{nice_model(mn)} (Prime Agent)"
+                model_tok[nm] = model_tok.get(nm, 0) + token_total(mv)
+
     # --- WorkBuddy (逐次调用，output 已含 reasoning) ---
     for _, entry, record in _iter_workbuddy_records(cache.get("workbuddy", {})):
         dk = record.get("date", "")
@@ -6675,6 +6868,25 @@ def projects():
                 p["last_active"] = dk
             for mn, mv in day.get("models", {}).items():
                 nm = f"{nice_model(mn)} (Pi)"
+                p["model_tok"][nm] = p["model_tok"].get(nm, 0) + token_total(mv)
+
+    # Prime Agent sessions
+    for f, entry in cache.get("prime_agent", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        proj_path = entry.get("proj") or ""
+        if not proj_path or proj_path == "?":
+            continue
+        p = proj_map.setdefault(proj_path, {"sessions": 0, "tokens": 0, "cost": 0.0,
+                                             "last_active": "", "model_tok": {}, "tools": set()})
+        p["sessions"] += 1
+        p["tools"].add("prime_agent")
+        for dk, day in entry.get("days", {}).items():
+            tok = token_total(day)
+            p["tokens"] += tok; p["cost"] += day.get("cost", 0)
+            if dk > p["last_active"]: p["last_active"] = dk
+            for mn, mv in day.get("models", {}).items():
+                nm = f"{nice_model(mn)} (Prime Agent)"
                 p["model_tok"][nm] = p["model_tok"].get(nm, 0) + token_total(mv)
 
     # WorkBuddy sessions


### PR DESCRIPTION
## Summary

- add Prime Agent token and cost collection from local session JSONL files
- include root sessions and nested RLM child sessions with physical-session deduplication
- expose Prime Agent in the card UI, Dashboard, Wrapped, project view, and device sync
- document storage paths and add focused parser/cache/override regression tests

## Data semantics

Prime Agent usage follows the existing Pi Coding Agent schema. `child_usage_attributed` bookkeeping records are ignored because child session JSONL contains the underlying assistant usage.

## Verification

- `python3 -m unittest discover -s tests -p test_prime_agent*.py`
- `python3 -m py_compile usage.30s.py`
- `swift build`
- `git diff --check`

The full Python suite still has two pre-existing environment-isolation failures in Pi/OpenCode tests when local real logs are present; the focused Prime Agent suite passes 3/3.
