### PR TITLE
fix(codex): 第三方 provider 下正确显示 token 用量并屏蔽官方额度

### DIFF
--- a/tests/test_codex_limits.py
+++ b/tests/test_codex_limits.py
@@ -31,6 +31,14 @@ class _Response:
 
 
 class CodexQuotaValuesTests(unittest.TestCase):
+    def setUp(self):
+        self.patchers = [
+            mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=False),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
     def test_legacy_primary_5h_secondary_week(self):
         limits = {
             "primary": {"used_percent": 25.0, "window_minutes": 300, "resets_at": 200},
@@ -120,6 +128,94 @@ class CodexQuotaValuesTests(unittest.TestCase):
             "Bearer test-token",
         )
         self.assertEqual(limits["primary"]["used_percent"], 25.0)
+
+
+class CodexCustomProviderTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.config_path = Path(self.tmp.name) / "config.toml"
+        self.quota_cache_path = Path(self.tmp.name) / "quota_cache.json"
+        self.reset_cards_cache_path = Path(self.tmp.name) / "reset_cards_cache.json"
+        self.auth_path = Path(self.tmp.name) / "auth.json"
+        self.auth_path.write_text(json.dumps({
+            "tokens": {"access_token": "test-token", "account_id": "test-account"}
+        }))
+        self.patchers = [
+            mock.patch.object(USAGE, "CODEX_CONFIG", str(self.config_path)),
+            mock.patch.object(USAGE, "CODEX_QUOTA_CACHE", str(self.quota_cache_path)),
+            mock.patch.object(USAGE, "CODEX_RESET_CARDS_CACHE", str(self.reset_cards_cache_path)),
+            mock.patch.object(USAGE, "CODEX_AUTH", str(self.auth_path)),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _write_config(self, text):
+        self.config_path.write_text(text)
+
+    def test_is_custom_provider_with_explicit_custom(self):
+        self._write_config('model_provider = "custom"\nmodel = "deepseek-v4-flash"\n')
+        self.assertTrue(USAGE._codex_is_custom_provider())
+
+    def test_is_not_custom_provider_with_openai(self):
+        self._write_config('model_provider = "openai"\nmodel = "gpt-5.5"\n')
+        self.assertFalse(USAGE._codex_is_custom_provider())
+
+    def test_is_not_custom_provider_without_config(self):
+        self.assertFalse(USAGE._codex_is_custom_provider())
+
+    def test_live_quota_skipped_for_custom_provider(self):
+        self._write_config('model_provider = "custom"\n')
+        # Pre-populate a stale official cache to prove it gets cleared.
+        self.quota_cache_path.write_text(json.dumps({
+            "fetched_at": 1_785_000_000,
+            "limits": {"primary": {"used_percent": 80.0}},
+            "plan": "pro",
+        }))
+        opener = mock.Mock(side_effect=AssertionError("should not call API"))
+        with mock.patch("urllib.request.urlopen", opener):
+            self.assertIsNone(USAGE.fetch_codex_live_limits())
+        self.assertFalse(self.quota_cache_path.exists())
+
+    def test_reset_cards_skipped_for_custom_provider(self):
+        self._write_config('model_provider = "custom"\n')
+        self.reset_cards_cache_path.write_text(json.dumps({
+            "account_key": "x", "auth_key": "y", "cards": {"count": 1, "expires": [], "updated": 0}
+        }))
+        opener = mock.Mock(side_effect=AssertionError("should not call API"))
+        with mock.patch("urllib.request.urlopen", opener):
+            self.assertEqual(USAGE.fetch_codex_reset_cards(now_epoch=1_785_000_000), {})
+        self.assertFalse(self.reset_cards_cache_path.exists())
+
+    def test_iter_records_parses_token_count_with_ordinal_field(self):
+        """Custom-provider Codex logs insert an 'ordinal' field between timestamp and type."""
+        session_path = Path(self.tmp.name) / "rollout-ordinal.jsonl"
+        session_path.write_text(json.dumps({
+            "timestamp": "2026-08-07T08:00:01.000Z",
+            "ordinal": 0,
+            "type": "session_meta",
+            "payload": {"model": "deepseek-v4-flash"}
+        }) + "\n" + json.dumps({
+            "timestamp": "2026-08-07T08:00:04.000Z",
+            "ordinal": 18,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 1000,
+                        "cached_input_tokens": 800,
+                        "output_tokens": 200,
+                        "reasoning_output_tokens": 50,
+                    }
+                }
+            }
+        }) + "\n")
+        records = list(USAGE._iter_codex_usage_records(str(session_path)))
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0], ("model", "deepseek-v4-flash"))
+        self.assertEqual(records[1][0], "token")
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_reset_cards.py
+++ b/tests/test_codex_reset_cards.py
@@ -48,6 +48,7 @@ class CodexResetCardsTests(unittest.TestCase):
         self.patchers = [
             mock.patch.object(USAGE, "CODEX_AUTH", str(self.auth_path)),
             mock.patch.object(USAGE, "CODEX_RESET_CARDS_CACHE", str(self.cache_path)),
+            mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=False),
         ]
         for patcher in self.patchers:
             patcher.start()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import math
 import re
+import tomllib
 from datetime import datetime, timedelta, date
 from pathlib import Path
 
@@ -78,6 +79,7 @@ CLAUDE_DIR = os.path.join(HOME, ".claude", "projects")
 CODEX_DIR = os.path.join(HOME, ".codex", "sessions")
 CODEX_ARCHIVED_DIR = os.path.join(HOME, ".codex", "archived_sessions")
 CODEX_AUTH = os.path.join(HOME, ".codex", "auth.json")
+CODEX_CONFIG = os.path.join(HOME, ".codex", "config.toml")
 GEMINI_DIR = os.path.join(HOME, ".gemini", "tmp")
 GEMINI_DIRS = _path_candidates(
     "TOKEI_GEMINI_DIR", GEMINI_DIR,
@@ -1022,6 +1024,29 @@ def _decode_jwt_claims(token):
         return {}
 
 
+def _codex_config():
+    """Read Codex CLI config.toml; return empty dict on any error."""
+    try:
+        with open(CODEX_CONFIG, "rb") as f:
+            return tomllib.load(f) or {}
+    except Exception:
+        return {}
+
+
+def _codex_is_custom_provider():
+    """True when Codex is pointed at a non-OpenAI provider (cc Switch, etc.)."""
+    cfg = _codex_config()
+    provider = cfg.get("model_provider")
+    # Explicit custom provider
+    if provider and provider != "openai":
+        return True
+    # No provider declared but a custom block exists without openai
+    providers = cfg.get("model_providers") or {}
+    if providers and "openai" not in providers:
+        return True
+    return False
+
+
 def _codex_auth_context(auth):
     if not isinstance(auth, dict):
         return {}
@@ -1060,6 +1085,17 @@ def _codex_auth_context(auth):
 
 def fetch_codex_live_limits():
     if os.environ.get("TOKEI_CODEX_LIVE_QUOTA") == "0":
+        return None
+    # When the user has switched to a third-party provider (cc Switch, etc.),
+    # the official OpenAI quota endpoint is no longer relevant. Skip it and
+    # clear any stale cached official quota so the dashboard falls back to
+    # showing only token usage/cost.
+    if _codex_is_custom_provider():
+        try:
+            if os.path.exists(CODEX_QUOTA_CACHE):
+                os.remove(CODEX_QUOTA_CACHE)
+        except Exception:
+            pass
         return None
     cached = _cached_codex_live_limits(_CODEX_QUOTA_TTL)
     if cached:
@@ -1168,6 +1204,14 @@ def _save_codex_reset_cards_state(state):
 def fetch_codex_reset_cards(now_epoch=None):
     """Return available reset-card expirations with a persistent low-frequency cache."""
     if os.environ.get("TOKEI_CODEX_LIVE_QUOTA") == "0":
+        return {}
+    # Reset cards are an OpenAI-account concept; ignore them for third-party providers.
+    if _codex_is_custom_provider():
+        try:
+            if os.path.exists(CODEX_RESET_CARDS_CACHE):
+                os.remove(CODEX_RESET_CARDS_CACHE)
+        except Exception:
+            pass
         return {}
     now_epoch = int(datetime.now().timestamp()) if now_epoch is None else int(now_epoch)
     auth = _load_json(CODEX_AUTH, {})
@@ -1620,13 +1664,15 @@ def _codex_deduped_days(file_cache):
 
 
 _CODEX_TOKEN_EVENT_HEADER = re.compile(
-    rb'^\s*\{\s*"timestamp"\s*:\s*"[^"]+"\s*,\s*'
-    rb'"type"\s*:\s*"event_msg"\s*,\s*'
+    rb'^\s*\{\s*"timestamp"\s*:\s*"[^"]+"'
+    rb'(?:\s*,\s*"[^"]+"\s*:\s*[^,]+)*'
+    rb'\s*,\s*"type"\s*:\s*"event_msg"\s*,\s*'
     rb'"payload"\s*:\s*\{\s*"type"\s*:\s*"token_count"'
 )
 _CODEX_MODEL_RECORD_HEADER = re.compile(
-    rb'^\s*\{\s*"timestamp"\s*:\s*"[^"]+"\s*,\s*'
-    rb'"type"\s*:\s*"(?:turn_context|session_meta)"'
+    rb'^\s*\{\s*"timestamp"\s*:\s*"[^"]+"'
+    rb'(?:\s*,\s*"[^"]+"\s*:\s*[^,]+)*'
+    rb'\s*,\s*"type"\s*:\s*"(?:turn_context|session_meta)"'
 )
 _CODEX_MODEL_FIELD = re.compile(rb'"model"\s*:\s*"((?:\\.|[^"\\])*)"')
 
@@ -1888,12 +1934,12 @@ def scan_codex(bounds, cache):
             cur_file = f
         sig = f"{st.st_mtime_ns}:{size}"
         entry = fc.get(f)
-        if (not entry or entry.get("sig") != sig or entry.get("model_version") != 2
+        if (not entry or entry.get("sig") != sig or entry.get("model_version") != 3
                 or not _codex_event_cache_ready(f, entry)):
             complete_offset = _codex_complete_offset(f, size)
             file_id = f"{st.st_dev}:{st.st_ino}"
             append_from = None
-            if isinstance(entry, dict) and entry.get("model_version") == 2:
+            if isinstance(entry, dict) and entry.get("model_version") == 3:
                 old_offset = int(entry.get("parsed_size", 0) or 0)
                 if (entry.get("file_id") == file_id and old_offset <= complete_offset
                         and entry.get("parsed_guard") == _codex_offset_guard(f, old_offset)
@@ -2025,7 +2071,7 @@ def scan_codex(bounds, cache):
                 "limits": file_limits, "limits_ts": file_limits_ts, "plan": file_plan,
                 "g_limits": file_g_limits, "g_ts": file_g_ts, "g_plan": file_g_plan,
                 "last_total": file_last_total, "prev_total_key": prev_total_key,
-                "active_model": file_model, "model_version": 2,
+                "active_model": file_model, "model_version": 3,
                 "file_id": file_id, "parsed_size": complete_offset,
                 "parsed_guard": _codex_offset_guard(f, complete_offset),
                 "event_cache_size": event_cache_size,
@@ -2125,6 +2171,12 @@ def scan_codex(bounds, cache):
     if live:
         latest_limits, live_plan = live
         plan_type = live_plan or (latest_limits or {}).get("plan_type") or plan_type
+
+    # For third-party providers the official OpenAI quota is not meaningful,
+    # and stale limits from older sessions must not be shown.
+    if _codex_is_custom_provider():
+        latest_limits = None
+        plan_type = None
 
     cur_total = None
     if cur_file:


### PR DESCRIPTION
Fixes #54

## 现象

当用户通过 cc Switch / cc-switch-helper 等工具把 Codex 从官方 OpenAI 切换到第三方 provider 时，Tokei 出现以下问题：

1. **状态栏仍显示官方 OpenAI 的剩余额度**（例如 "周剩余 20%"），即使用户早已没有官方额度或已切换到第三方 provider。
2. **第三方 provider 的 token 用量可能统计为 0**。部分 provider 的 rollout JSONL 会在 `timestamp` 和 `type` 之间插入 `ordinal` 等额外字段，导致原有严格正则无法匹配 `token_count` 事件。

## 修复内容

- 新增 `_codex_config()` / `_codex_is_custom_provider()`，读取 `~/.codex/config.toml` 判断当前是否为非 OpenAI provider。
- 当使用第三方 provider 时：
  - `fetch_codex_live_limits()` 直接返回 `None`，并删除可能过期的官方 quota 缓存。
  - `fetch_codex_reset_cards()` 直接返回 `{}`，并删除官方 reset cards 缓存。
  - `scan_codex()` 中丢弃旧 session 回退出的官方 `rate_limits` / `plan_type`。
- 放宽 `_CODEX_TOKEN_EVENT_HEADER` 和 `_CODEX_MODEL_RECORD_HEADER` 正则，允许 `timestamp` 和 `type` 之间存在任意额外字段。
- 将 scan cache 的 `model_version` 从 `2` 提升到 `3`，确保旧缓存被重新解析。
- 补充单元测试覆盖自定义 provider 检测、quota/reset-cards 跳过逻辑，以及带 `ordinal` 字段的 rollout JSONL 解析。

## 兼容性

- 官方 OpenAI Codex 用户：行为不变，继续显示官方额度和 reset cards。
- 第三方 provider 用户：不再显示无意义的官方额度，token 统计正常计入。

## 测试

```bash
python -m unittest tests.test_codex_limits tests.test_codex_reset_cards
```

全部通过。
