### PR TITLE
feat: 新增 DeepSeek Harness 用量支持

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -19,6 +19,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
 | OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | SQLite/JSON, `tokens` + `cost` |
 | Qwen Code | `${QWEN_RUNTIME_DIR:-~/.qwen}/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` | JSONL,逐请求记录 + 会话汇总 |
+| DeepSeek Harness | `${DSH_HOME:-~/.dsh}/sessions/**/session.jsonl.zstd`，兼容 `session.jsonl` | zstd 压缩或明文 JSONL，`assistant/message.data.usage` |
 
 ---
 
@@ -99,6 +100,19 @@ token 快照误删。
 Tokei 优先读取逐请求日志以获得进行中会话和小时分布。旧版 `usage_record.jsonl`
 按 `sessionId` 取最后一份快照,用于补齐逐请求日志出现前的历史。同一会话同时存在两种来源时,
 逐请求日志优先,避免重复累计。
+
+**DeepSeek Harness** — usage bucket 相互独立，但 `reasoningTokens` 是 `outputTokens` 的子集:
+- 输入 = `inputTokens`
+- 输出 = `outputTokens - reasoningTokens`
+- 缓存读 = `cacheReadTokens`
+- 缓存写 = `cacheWriteTokens`
+- 推理 = `reasoningTokens`
+- 总量 = `inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens`
+
+同一次调用会先出现 `assistant/chunk` usage，再出现 `assistant/message` 最终 usage。Tokei
+按 `(turn, step)` 使用后者覆盖前者，避免重复计数；模型取该调用之前最近的
+`request/context`，会话 identity 取日志首行 `session.id`。当前只接受官方 session format v0，
+遇到未来版本会保留上次成功缓存并在诊断中报告，而不会按未知 schema 猜测。
 
 **Grok Build** — `unified.jsonl` 中每条带 token 字段的 `shell.turn.inference_done` 代表一次模型调用：
 - 输入 = `prompt_tokens - cached_prompt_tokens`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **16 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
 
 ### 支持的工具
 
@@ -35,8 +35,12 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 | **WorkBuddy** | Token、成本、缓存命中率、模型、项目 |
 | **OpenCode** | Token、成本、缓存命中率、模型 |
 | **Qwen Code** | Token、思考量、成本、模型 |
-| **Qoder** | Token、调用次数、配额 |
+| **DeepSeek Harness** | Token（输入/输出/缓存/推理）、成本、模型、会话 |
+| **Qoder Desktop** | Token、调用次数、配额 |
 | **QoderWork** | Token、调用次数、配额 |
+| **Qoder CLI** | Token、调用次数、工具调用 |
+| **ZCode** | Token、成本、缓存命中率、模型 |
+| **MiMoCode** | Token、成本、缓存命中率、模型 |
 
 ## 功能一览
 
@@ -162,14 +166,18 @@ chmod +x ~/.tokei/tokei-sync.sh
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` |
 | OpenCode | `~/.opencode/sessions/*.json` |
 | Qwen Code | `~/.qwen/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` |
-| Qoder | `~/.qodo-ai/sessions/*.jsonl` |
+| DeepSeek Harness | `${DSH_HOME:-~/.dsh}/sessions/**/session.jsonl.zstd`（兼容 `session.jsonl`） |
+| Qoder Desktop | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 | QoderWork | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
+| Qoder CLI | `~/.qoder/cli/` |
+| ZCode | `~/.zcode/cli/db/db.sqlite` |
+| MiMoCode | 自动发现 MiMoCode/OpenCode SQLite 数据库 |
 
 ## 对比 CodexBar
 
 | 功能 | Tokei | [CodexBar](https://github.com/steipete/CodexBar) |
 |------|:-----:|:---------:|
-| 支持工具 | 12 | 40+ |
+| 支持工具 | 16 | 40+ |
 | Token 级用量分析 | ✅ | — |
 | 成本估算（317 模型） | ✅ | 部分 |
 | 数据面板（图表 + 热力图） | ✅ | — |
@@ -318,11 +326,11 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **12 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **16 AI coding tools** in real-time — all from local log files, with zero network traffic.
 
 **Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local logs only) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 
-**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok Build, Hermes, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, Qoder, QoderWork
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok Build, Qoder Desktop, QoderWork, Qoder CLI, Hermes, ZCode, MiMoCode, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, DeepSeek Harness
 
 For full documentation, visit [tokei.lanshuagent.com](https://tokei.lanshuagent.com).
 

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -8,6 +8,7 @@ struct DailyCost: Codable, Identifiable {
     var pi: Double = 0
     var workbuddy: Double?
     var qwencode: Double?
+    var deepseek_harness: Double?
     var total: Double
     var c_in: Int = 0
     var c_out: Int = 0
@@ -30,6 +31,11 @@ struct DailyCost: Codable, Identifiable {
     var q_out: Int?
     var q_cr: Int?
     var q_reason: Int?
+    var dsh_in: Int?
+    var dsh_out: Int?
+    var dsh_cr: Int?
+    var dsh_cw: Int?
+    var dsh_reason: Int?
     var g_in: Int?
     var g_out: Int?
     var g_cr: Int?
@@ -203,6 +209,7 @@ struct DashboardView: View {
         case "workbuddy": return Theme.workbuddy
         case "opencode": return Theme.opencode
         case "qwencode": return Theme.qwencode
+        case "deepseek_harness": return Theme.deepseekHarness
         default: return Theme.claude
         }
     }
@@ -331,6 +338,21 @@ struct DashboardView: View {
                         .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
                     Text(String(format: "$%.2f", d.qwencode ?? 0))
                         .font(.system(size: 12, weight: .semibold, design: .monospaced)).foregroundStyle(Theme.tSecondary)
+                }
+                if (d.dsh_in ?? 0) + (d.dsh_out ?? 0) + (d.dsh_cr ?? 0) +
+                    (d.dsh_cw ?? 0) + (d.dsh_reason ?? 0) > 0 {
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 4) {
+                            Circle().fill(Theme.deepseekHarness).frame(width: 6, height: 6)
+                            Text("DeepSeek Harness").font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(Theme.deepseekHarness)
+                        }
+                        Text("\(Fmt.human((d.dsh_in ?? 0) + (d.dsh_out ?? 0) + (d.dsh_cr ?? 0) + (d.dsh_cw ?? 0) + (d.dsh_reason ?? 0))) tok")
+                            .font(.system(size: 11, design: .monospaced)).foregroundStyle(Theme.tTertiary)
+                        Text(String(format: "$%.2f", d.deepseek_harness ?? 0))
+                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Theme.tSecondary)
+                    }
                 }
                 if (d.g_in ?? 0) + (d.g_out ?? 0) + (d.g_cr ?? 0) + (d.g_reason ?? 0) > 0 {
                     VStack(alignment: .leading, spacing: 3) {
@@ -745,6 +767,7 @@ struct DashboardView: View {
                   pi: lhs.pi + rhs.pi,
                   workbuddy: (lhs.workbuddy ?? 0) + (rhs.workbuddy ?? 0),
                   qwencode: (lhs.qwencode ?? 0) + (rhs.qwencode ?? 0),
+                  deepseek_harness: (lhs.deepseek_harness ?? 0) + (rhs.deepseek_harness ?? 0),
                   total: lhs.total + rhs.total,
                   c_in: lhs.c_in + rhs.c_in,
                   c_out: lhs.c_out + rhs.c_out,
@@ -767,6 +790,11 @@ struct DashboardView: View {
                   q_out: (lhs.q_out ?? 0) + (rhs.q_out ?? 0),
                   q_cr: (lhs.q_cr ?? 0) + (rhs.q_cr ?? 0),
                   q_reason: (lhs.q_reason ?? 0) + (rhs.q_reason ?? 0),
+                  dsh_in: (lhs.dsh_in ?? 0) + (rhs.dsh_in ?? 0),
+                  dsh_out: (lhs.dsh_out ?? 0) + (rhs.dsh_out ?? 0),
+                  dsh_cr: (lhs.dsh_cr ?? 0) + (rhs.dsh_cr ?? 0),
+                  dsh_cw: (lhs.dsh_cw ?? 0) + (rhs.dsh_cw ?? 0),
+                  dsh_reason: (lhs.dsh_reason ?? 0) + (rhs.dsh_reason ?? 0),
                   g_in: (lhs.g_in ?? 0) + (rhs.g_in ?? 0),
                   g_out: (lhs.g_out ?? 0) + (rhs.g_out ?? 0),
                   g_cr: (lhs.g_cr ?? 0) + (rhs.g_cr ?? 0),
@@ -903,6 +931,8 @@ struct DashboardView: View {
         appendTokenModels(usage.workbuddy.ranges.get(key).models, tool: "workbuddy", suffix: "WorkBuddy", to: &out)
         appendTokenModels(usage.opencode.ranges.get(key).models, tool: "opencode", suffix: "OpenCode", to: &out)
         appendTokenModels(usage.qwencode.ranges.get(key).models, tool: "qwencode", suffix: "Qwen Code", to: &out)
+        appendTokenModels(usage.deepseek_harness.ranges.get(key).models, tool: "deepseek_harness",
+                          suffix: "DeepSeek Harness", to: &out)
 
         return out.sorted {
             if ($0.tokens ?? 0) != ($1.tokens ?? 0) { return ($0.tokens ?? 0) > ($1.tokens ?? 0) }
@@ -958,6 +988,7 @@ struct DashboardView: View {
             + tokenUsageTotal(usage.workbuddy.ranges.get(key))
             + tokenUsageTotal(usage.opencode.ranges.get(key))
             + tokenUsageTotal(usage.qwencode.ranges.get(key))
+            + tokenUsageTotal(usage.deepseek_harness.ranges.get(key))
     }
 
     static func usageTotalCost(_ usage: Usage, _ key: RangeKey) -> Double {
@@ -972,6 +1003,7 @@ struct DashboardView: View {
             + usage.workbuddy.ranges.get(key).cost
             + usage.opencode.ranges.get(key).cost
             + usage.qwencode.ranges.get(key).cost
+            + usage.deepseek_harness.ranges.get(key).cost
     }
 
     static func tokenUsageTotal(_ r: TokenUsageRange) -> Int {

--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -44,6 +44,7 @@ enum Theme {
     static let workbuddy = Color(red: 0.25, green: 0.78, blue: 0.72) // 青绿
     static let opencode = Color(red: 0.55, green: 0.75, blue: 0.90) // 天蓝灰
     static let qwencode = Color(red: 0.48, green: 0.55, blue: 0.95) // 靛蓝
+    static let deepseekHarness = Color(red: 0.18, green: 0.68, blue: 0.88) // 深海蓝
 
     static let panelWidth: CGFloat = 322
     static let cardRadius: CGFloat = 16

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -675,10 +675,11 @@ struct Usage: Codable {
     var workbuddy: TokenUsageStat
     var opencode: TokenUsageStat
     var qwencode: TokenUsageStat
+    var deepseek_harness: TokenUsageStat
 
     enum CodingKeys: String, CodingKey {
         case claude, codex, gemini, grok, qoder, qoderwork, qodercli, hermes, zcode, mimocode
-        case openclaw, pi, workbuddy, opencode, qwencode
+        case openclaw, pi, workbuddy, opencode, qwencode, deepseek_harness
     }
 
     init(from decoder: Decoder) throws {
@@ -702,6 +703,8 @@ struct Usage: Codable {
         workbuddy = try c.decodeIfPresent(TokenUsageStat.self, forKey: .workbuddy) ?? TokenUsageStat(ranges: .empty)
         opencode = try c.decode(TokenUsageStat.self, forKey: .opencode)
         qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)
+        deepseek_harness = try c.decodeIfPresent(TokenUsageStat.self, forKey: .deepseek_harness)
+            ?? TokenUsageStat(ranges: .empty)
     }
 }
 

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -17,6 +17,7 @@ struct PanelView: View {
     @State private var workBuddyModelsOpen = false
     @State private var openCodeModelsOpen = false
     @State private var qwenCodeModelsOpen = false
+    @State private var deepSeekHarnessModelsOpen = false
     @State private var expandedModels: Set<String> = []
     @State private var mode: PanelMode = .cards
     @State private var trailProjects: [TrailProject]?
@@ -44,6 +45,7 @@ struct PanelView: View {
     @AppStorage("showWorkBuddy") private var showWorkBuddy = true
     @AppStorage("showOpenCode") private var showOpenCode = true
     @AppStorage("showQwenCode") private var showQwenCode = true
+    @AppStorage("showDeepSeekHarness") private var showDeepSeekHarness = true
     /// 默认关闭：Grok 额度只读本地日志；开启后才用登录凭据请求实时账单接口。
     @AppStorage("grokLiveQuotaEnabled") private var grokLiveQuotaEnabled = false
     /// 菜单栏额度来源（与显示卡片独立）。Grok 默认关，避免新额度源抢占状态栏。
@@ -53,7 +55,7 @@ struct PanelView: View {
 
     private var visibleCount: Int {
         [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showQoderCli, showHermes, showZcode, showMimoCode,
-         showOpenClaw, showPi, showWorkBuddy, showOpenCode, showQwenCode].filter { $0 }.count
+         showOpenClaw, showPi, showWorkBuddy, showOpenCode, showQwenCode, showDeepSeekHarness].filter { $0 }.count
     }
     private var hasMultipleDevices: Bool { store.syncEnabled && !store.peers.isEmpty }
     private var useWide: Bool { visibleCount > 2 }
@@ -287,6 +289,7 @@ struct PanelView: View {
         let lr = u.openclaw.ranges.get(sel), pr = u.pi.ranges.get(sel)
         let wr = u.workbuddy.ranges.get(sel), or = u.opencode.ranges.get(sel)
         let qcr = u.qwencode.ranges.get(sel)
+        let dshr = u.deepseek_harness.ranges.get(sel)
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude,
                          active: cr.sessions > 0 || u.claude.q5 != nil ||
@@ -324,6 +327,11 @@ struct PanelView: View {
                          tint: Theme.opencode, content: AnyView(tokenUsageBlock(title: "OpenCode", or, tint: Theme.opencode, modelsOpen: $openCodeModelsOpen))),
             ToolCardItem(id: "qwencode", name: "Qwen Code", visible: showQwenCode, active: qcr.sessions > 0,
                          tint: Theme.qwencode, content: AnyView(tokenUsageBlock(title: "Qwen Code", qcr, tint: Theme.qwencode, modelsOpen: $qwenCodeModelsOpen))),
+            ToolCardItem(id: "deepseek_harness", name: "DeepSeek Harness", visible: showDeepSeekHarness,
+                         active: dshr.sessions > 0, tint: Theme.deepseekHarness,
+                         content: AnyView(tokenUsageBlock(title: "DeepSeek Harness", dshr,
+                                                          tint: Theme.deepseekHarness,
+                                                          modelsOpen: $deepSeekHarnessModelsOpen))),
         ]
     }
 
@@ -1614,6 +1622,7 @@ struct PanelView: View {
                 settingsRow("WorkBuddy", tint: Theme.workbuddy, isOn: $showWorkBuddy)
                 settingsRow("OpenCode", tint: Theme.opencode, isOn: $showOpenCode)
                 settingsRow("Qwen Code", tint: Theme.qwencode, isOn: $showQwenCode)
+                settingsRow("DeepSeek Harness", tint: Theme.deepseekHarness, isOn: $showDeepSeekHarness)
             }
         }
         .onChange(of: showQoder) { enabled in
@@ -2278,7 +2287,8 @@ struct PanelView: View {
         if let data = result.stdout.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             let tools = ["claude", "codex", "gemini", "grok", "qoder", "qoderwork", "hermes",
-                         "zcode", "mimocode", "openclaw", "pi", "workbuddy", "opencode", "qwencode"]
+                         "zcode", "mimocode", "openclaw", "pi", "workbuddy", "opencode", "qwencode",
+                         "deepseek_harness"]
                 .filter { json[$0] != nil }
                 .joined(separator: ",")
             lines.append("json: ok tools: \(tools)")

--- a/Tokei/Sources/Tokei/ProjectTrailView.swift
+++ b/Tokei/Sources/Tokei/ProjectTrailView.swift
@@ -255,6 +255,7 @@ struct ProjectTrailView: View {
         case "mimocode": return Theme.mimocode
         case "pi": return Theme.pi
         case "workbuddy": return Theme.workbuddy
+        case "deepseek_harness": return Theme.deepseekHarness
         default: return Theme.tTertiary
         }
     }

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -374,6 +374,7 @@ final class SyncManager {
             mergeRanges(&u.workbuddy.ranges, peer.usage.workbuddy.ranges, pairs)
             mergeRanges(&u.opencode.ranges, peer.usage.opencode.ranges, pairs)
             mergeRanges(&u.qwencode.ranges, peer.usage.qwencode.ranges, pairs)
+            mergeRanges(&u.deepseek_harness.ranges, peer.usage.deepseek_harness.ranges, pairs)
         }
         return u
     }

--- a/Tokei/Sources/Tokei/WrappedView.swift
+++ b/Tokei/Sources/Tokei/WrappedView.swift
@@ -402,7 +402,7 @@ struct ConfettiView: View {
     @State private var fall = false
     private let palette: [Color] = [Theme.claude, Theme.qoder, Theme.qoderwork, Theme.hermes,
                                     Theme.codex, Theme.gemini, Theme.zcode, Theme.mimocode,
-                                    Theme.openclaw]
+                                    Theme.openclaw, Theme.deepseekHarness]
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .top) {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -334,6 +334,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     let showQ = ud.object(forKey: "showQoderIde") as? Bool ?? false
                     let showZ = ud.object(forKey: "showZcode") as? Bool ?? true
                     let showM = ud.object(forKey: "showMimoCode") as? Bool ?? true
+                    let showDSH = ud.object(forKey: "showDeepSeekHarness") as? Bool ?? true
                     var total = 0
                     if showC { let r = u.claude.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw) }
                     if showX { let r = u.codex.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
@@ -344,6 +345,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if showQ { let r = u.qoder.ranges.get(.today); total += Int(r.in + r.out + r.cached) }
                     if showZ { let r = u.zcode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
                     if showM { let r = u.mimocode.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
+                    if showDSH { let r = u.deepseek_harness.ranges.get(.today); total += Int(r.in + r.out + r.cr + r.cw + r.reason) }
                     if total > 0 {
                         metrics.append(.init(kind: .total, value: Fmt.human(total)))
                     } else {

--- a/site/index.html
+++ b/site/index.html
@@ -895,8 +895,8 @@ body::after{
     <div class="sec-centered rv">
       <div class="sec-label"><span class="en">Supported Tools</span><span class="zh">支持的工具</span></div>
       <h2 class="sec-title">
-        <span class="en">12 AI agents.<br>One dashboard.</span>
-        <span class="zh">12 款 AI agent<br>一个面板</span>
+        <span class="en">16 AI agents.<br>One dashboard.</span>
+        <span class="zh">16 款 AI agent<br>一个面板</span>
       </h2>
       <p class="sec-sub">
         <span class="en">Tokei reads local session logs from each tool. No API keys, no network access.</span>
@@ -929,6 +929,26 @@ body::after{
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--amber),#C49A30)">Qo</div>
         <h3>Qoder</h3>
         <p><span class="en">Calls, duration, context</span><span class="zh">调用 · 时长 · 上下文</span></p>
+      </div>
+      <div class="tool-card rv rv-d4" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#E8C45F,#B4872B)">QC</div>
+        <h3>Qoder CLI</h3>
+        <p><span class="en">Tokens, calls, tools</span><span class="zh">Token · 调用 · 工具</span></p>
+      </div>
+      <div class="tool-card rv rv-d5" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#85CC57,#4B9B34)">ZC</div>
+        <h3>ZCode</h3>
+        <p><span class="en">Tokens, cache, cost, models</span><span class="zh">Token · 缓存 · 成本 · 模型</span></p>
+      </div>
+      <div class="tool-card rv rv-d6" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#F28043,#CE5427)">Mi</div>
+        <h3>MiMoCode</h3>
+        <p><span class="en">Tokens, cache, cost, models</span><span class="zh">Token · 缓存 · 成本 · 模型</span></p>
+      </div>
+      <div class="tool-card rv rv-d7" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#2CB6E4,#177CA8)">DS</div>
+        <h3>DeepSeek Harness</h3>
+        <p><span class="en">Tokens, cache, reasoning, models</span><span class="zh">Token · 缓存 · 推理 · 模型</span></p>
       </div>
       <div class="tool-card rv rv-d6" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--emerald),#40A870)">He</div>
@@ -1056,7 +1076,7 @@ body::after{
             <td style="text-align:left;padding:10px 16px;color:var(--t2)">
               <span class="en">Supported tools</span><span class="zh">支持工具</span>
             </td>
-            <td style="padding:10px 16px;color:var(--t2)">10</td>
+            <td style="padding:10px 16px;color:var(--t2)">16</td>
             <td style="padding:10px 16px;color:var(--t2)">40+</td>
           </tr>
           <tr style="border-bottom:1px solid var(--border)">

--- a/tests/test_deepseek_harness.py
+++ b/tests/test_deepseek_harness.py
@@ -1,0 +1,201 @@
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+from test_codex_limits import USAGE
+
+
+def event(event_type, seq, timestamp_ms, data):
+    return {"type": event_type, "seq": seq, "time": timestamp_ms, "data": data}
+
+
+class DeepSeekHarnessScanTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime.now().astimezone().replace(hour=10, minute=0, second=0, microsecond=0)
+        self.now_ms = int(self.now.timestamp() * 1000)
+
+    def write_session(self, root, records, compressed=False, session_id="session-test"):
+        session_dir = Path(root) / "sessions" / "--project--" / session_id
+        session_dir.mkdir(parents=True)
+        suffix = "session.jsonl.zstd" if compressed else "session.jsonl"
+        path = session_dir / suffix
+        rows = [{
+            "type": "session", "version": 0, "id": session_id,
+            "createdAt": self.now_ms - 1000, "cwd": "/tmp/private/project",
+            "delegationDepth": 0,
+        }, *records]
+        payload = "".join(json.dumps(row) + "\n" for row in rows)
+        if compressed:
+            from compression import zstd
+            with zstd.open(path, "wt", encoding="utf-8") as f:
+                f.write(payload)
+        else:
+            path.write_text(payload, encoding="utf-8")
+        return path
+
+    def scan(self, root, cache=None):
+        scan_cache = cache if cache is not None else {"v": USAGE._SCAN_CACHE_VERSION}
+        with mock.patch.dict(os.environ, {"TOKEI_DSH_DIR": str(Path(root) / "sessions")}, clear=False), \
+             mock.patch.object(USAGE, "ledger_touch"), \
+             mock.patch.object(USAGE, "ledger_reconcile", side_effect=lambda _tool, days: days):
+            result = USAGE.scan_deepseek_harness(USAGE.range_bounds(), scan_cache)
+        return result, scan_cache
+
+    def test_last_sample_wins_and_reasoning_is_not_double_counted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [
+                event("request/context", 1, self.now_ms, {
+                    "provider": "deepseek-official", "model": "deepseek-v4-pro",
+                    "contextWindow": 1_000_000,
+                }),
+                event("assistant/chunk", 2, self.now_ms + 1, {
+                    "turn": 1, "step": 1,
+                    "chunk": {"type": "usage", "usage": {
+                        "inputTokens": 10, "outputTokens": 5, "cacheReadTokens": 20,
+                        "reasoningTokens": 2,
+                    }},
+                }),
+                event("assistant/message", 3, self.now_ms + 2, {
+                    "turn": 1, "step": 1, "message": {"role": "assistant", "content": []},
+                    "usage": {"inputTokens": 12, "outputTokens": 7,
+                              "cacheReadTokens": 30, "cacheWriteTokens": 4,
+                              "reasoningTokens": 3},
+                }),
+            ]
+            self.write_session(tmp, records)
+            result, cache = self.scan(tmp)
+
+        usage = result["ranges"]["all"]
+        self.assertEqual((usage["in"], usage["out"], usage["cr"], usage["cw"], usage["reason"]),
+                         (12, 4, 30, 4, 3))
+        self.assertEqual(USAGE.token_total(usage), 53)
+        self.assertEqual(len(usage["sessions"]), 1)
+        entry = next(value for key, value in cache["deepseek_harness"].items()
+                     if not key.startswith("_"))
+        day = entry["days"][self.now.date().isoformat()]
+        self.assertEqual(day["projects"], ["project"])
+        self.assertEqual(entry["proj"], "/tmp/private/project")
+        self.assertIn("deepseek-v4-pro", day["models"])
+
+    def test_model_context_change_applies_to_following_steps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [
+                event("request/context", 1, self.now_ms, {"model": "deepseek-v4-flash"}),
+                event("assistant/message", 2, self.now_ms + 1, {
+                    "turn": 1, "step": 1, "message": {},
+                    "usage": {"inputTokens": 1, "outputTokens": 2},
+                }),
+                event("request/context", 3, self.now_ms + 2, {"model": "deepseek-v4-pro"}),
+                event("assistant/message", 4, self.now_ms + 3, {
+                    "turn": 1, "step": 2, "message": {},
+                    "usage": {"inputTokens": 3, "outputTokens": 4},
+                }),
+            ]
+            self.write_session(tmp, records)
+            result, _ = self.scan(tmp)
+
+        models = result["ranges"]["all"]["models"]
+        self.assertEqual(models["deepseek-v4-flash"]["in"], 1)
+        self.assertEqual(models["deepseek-v4-pro"]["out"], 4)
+
+    def test_zstd_and_malformed_lines_are_supported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_session(tmp, [
+                event("request/header", 1, self.now_ms, {
+                    "reason": "initial", "header": {"config": {"model": "deepseek-v4-flash"}},
+                }),
+                event("assistant/message", 2, self.now_ms + 1, {
+                    "turn": 1, "step": 1, "message": {},
+                    "usage": {"inputTokens": 5, "outputTokens": 6},
+                }),
+            ], compressed=True)
+            # packed chunk storage rows and unknown UI events are layout details; the
+            # collector ignores them while retaining the final assistant usage record.
+            parsed = USAGE._dsh_parse_session(str(path))
+
+        day = parsed["days"][self.now.date().isoformat()]
+        self.assertEqual((day["in"], day["out"]), (5, 6))
+
+    def test_system_libzstd_fallback_decodes_concatenated_frames(self):
+        try:
+            from compression import zstd
+        except ImportError:
+            self.skipTest("test writer needs compression.zstd")
+        first = zstd.compress(b"first\n")
+        second = zstd.compress(b"second\n")
+        try:
+            decoded = USAGE._dsh_zstd_ctypes(first + second)
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+        self.assertEqual(decoded, b"first\nsecond\n")
+
+    def test_future_session_version_fails_closed_and_previous_cache_survives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_session(tmp, [
+                event("assistant/message", 1, self.now_ms, {
+                    "turn": 1, "step": 1, "message": {},
+                    "usage": {"inputTokens": 1, "outputTokens": 1},
+                })
+            ])
+            result, cache = self.scan(tmp)
+            self.assertEqual(result["ranges"]["all"]["in"], 1)
+            rows = path.read_text(encoding="utf-8").splitlines()
+            header = json.loads(rows[0]); header["version"] = 1
+            path.write_text(json.dumps(header) + "\n" + "\n".join(rows[1:]) + "\n",
+                            encoding="utf-8")
+            result, cache = self.scan(tmp, cache)
+
+        self.assertEqual(result["ranges"]["all"]["in"], 1)
+        self.assertTrue(result["errors"])
+
+    def test_tokei_override_precedes_dsh_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"TOKEI_DSH_DIR": tmp, "DSH_HOME": "/ignored"}, clear=False):
+                self.assertEqual(USAGE._dsh_sessions_root(), os.path.abspath(tmp))
+
+    def test_missing_route_keeps_unknown_model_without_fake_cost(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_session(tmp, [
+                event("assistant/message", 1, self.now_ms, {
+                    "turn": 1, "step": 1, "message": {},
+                    "usage": {"inputTokens": 100, "outputTokens": 50},
+                })
+            ])
+            parsed = USAGE._dsh_parse_session(str(path))
+
+        day = parsed["days"][self.now.date().isoformat()]
+        self.assertIn("unknown", day["models"])
+        self.assertEqual(day["cost"], 0)
+
+    def test_dashboard_and_wrapped_include_usage_models_and_hours(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.write_session(tmp, [
+                event("request/context", 1, self.now_ms, {"model": "deepseek-v4-pro"}),
+                event("assistant/message", 2, self.now_ms + 1, {
+                    "turn": 1, "step": 1, "message": {},
+                    "usage": {"inputTokens": 10, "outputTokens": 8,
+                              "cacheReadTokens": 20, "reasoningTokens": 3},
+                }),
+            ])
+            _, cache = self.scan(tmp)
+            with mock.patch.object(USAGE, "_load_ledger", return_value={"v": 1, "tools": {}}):
+                daily = USAGE.build_daily_costs("all", refresh=False, _cache=cache)
+                wrapped = USAGE.build_wrapped("all", refresh=False, _cache=cache)
+
+        row = daily["daily"][0]
+        self.assertEqual(row["dsh_in"], 10)
+        self.assertEqual(row["dsh_out"], 5)
+        self.assertEqual(row["dsh_cr"], 20)
+        self.assertEqual(row["dsh_reason"], 3)
+        self.assertEqual(row["tokens"], 38)
+        self.assertEqual(daily["models"][0]["tool"], "deepseek_harness")
+        self.assertEqual(wrapped["total_tokens"], 38)
+        self.assertEqual(wrapped["hours"][10], 38)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tokei-collector-skill.md
+++ b/tokei-collector-skill.md
@@ -40,6 +40,10 @@ curl -sL https://raw.githubusercontent.com/<user>/tokei-sync/main/install.sh | b
 - Pi Coding Agent CLI (`~/.pi/agent/sessions/`)
 - OpenCode (`~/.local/share/opencode/`)
 - Qwen Code (`~/.qwen/`)
+- DeepSeek Harness (`${DSH_HOME:-~/.dsh}/sessions/`)
+- Qoder CLI (`~/.qoder/cli/`)
+- ZCode (`~/.zcode/cli/db/db.sqlite`)
+- MiMoCode (自动发现本地 SQLite 数据库)
 
 ## 卸载
 

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -14,6 +14,7 @@
 #   Pi:          ~/.pi/agent/sessions/**/*.jsonl + ~/.omp/agent/sessions/**/*.jsonl
 #   WorkBuddy:   ~/.workbuddy/projects/**/*.jsonl (逐次模型调用 message.usage)
 #   Qwen Code:   ~/.qwen/usage/token-usage-*.jsonl (逐请求,usage_record.jsonl 补历史)
+#   DeepSeek Harness: ~/.dsh/sessions/**/session.jsonl{,.zstd} (逐次 assistant usage)
 
 import os
 import sys
@@ -122,6 +123,8 @@ OMP_SESSION_DIR = os.path.expanduser(os.environ.get(
     "OMP_CODING_AGENT_SESSION_DIR", os.path.join(HOME, ".omp", "agent", "sessions")))
 QWEN_CODE_DIR = os.path.abspath(os.path.expanduser(
     os.environ.get("QWEN_HOME", os.path.join(HOME, ".qwen"))))
+DSH_HOME = os.path.abspath(os.path.expanduser(
+    os.environ.get("DSH_HOME", os.path.join(HOME, ".dsh"))))
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _USER_DIR = os.path.join(HOME, ".tokei")
@@ -814,6 +817,10 @@ def _empty_workbuddy():
 
 
 def _empty_qwencode():
+    return _empty_opencode()
+
+
+def _empty_deepseek_harness():
     return _empty_opencode()
 
 
@@ -5471,6 +5478,298 @@ def scan_qwencode(bounds, cache):
     return {"ranges": B}
 
 
+# ---------- DeepSeek Harness ----------
+# 官方 v0 session 日志是 append-only logical JSONL；默认物理编码为一串 zstd frame。
+# assistant/chunk usage 与随后的 assistant/message usage 是同一步的先后样本，按
+# (turn, step) last-wins 折叠，不能相加。reasoningTokens 已包含在 outputTokens 中，
+# 因此写入 Tokei 通用桶时拆成 out=非推理输出、reason=推理输出。
+_DSH_SESSION_FORMAT_VERSION = 0
+_DSH_PARSER_VERSION = 1
+
+
+def _dsh_sessions_root():
+    override = _expand_path(os.environ.get("TOKEI_DSH_DIR"))
+    if override:
+        return override
+    home = _expand_path(os.environ.get("DSH_HOME")) or DSH_HOME
+    return os.path.join(home, "sessions")
+
+
+def _dsh_session_files():
+    root = _dsh_sessions_root()
+    if not os.path.isdir(root):
+        return []
+    # compression 配置切换后同一 session 目录理论上可能同时残留两种 artifact；
+    # 每个目录只选一份，优先当前默认的 zstd，避免重复计费。
+    selected = {}
+    for name in ("session.jsonl", "session.jsonl.zstd"):
+        for path in glob.glob(os.path.join(root, "**", name), recursive=True):
+            selected[os.path.dirname(path)] = os.path.realpath(path)
+    return sorted(selected.values())
+
+
+def _dsh_file_signature(path):
+    st = os.stat(path)
+    return ":".join(str(value) for value in (
+        getattr(st, "st_dev", 0), getattr(st, "st_ino", 0), st.st_size,
+        st.st_mtime_ns, getattr(st, "st_ctime_ns", 0), _DSH_PARSER_VERSION))
+
+
+def _dsh_read_text(path):
+    if not path.endswith(".zstd"):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    try:
+        from compression import zstd
+        with zstd.open(path, "rt", encoding="utf-8") as f:
+            return f.read()
+    except ImportError:
+        pass
+    try:
+        import zstandard
+        with open(path, "rb") as f:
+            with zstandard.ZstdDecompressor().stream_reader(f) as reader:
+                return reader.read().decode("utf-8")
+    except ImportError:
+        pass
+    with open(path, "rb") as f:
+        return _dsh_zstd_ctypes(f.read()).decode("utf-8")
+
+
+def _dsh_zstd_ctypes(source):
+    """用系统 libzstd 解开 Harness 的 concatenated frames，不依赖外部命令。"""
+    import ctypes
+    import ctypes.util
+    library = ctypes.util.find_library("zstd")
+    if not library:
+        for candidate in (
+            "/opt/homebrew/lib/libzstd.dylib", "/usr/local/lib/libzstd.dylib",
+            "/opt/homebrew/lib/libzstd.so", "/usr/local/lib/libzstd.so",
+            "/usr/lib/libzstd.dylib", "/usr/lib/libzstd.so",
+        ):
+            if os.path.isfile(candidate):
+                library = candidate
+                break
+    if not library:
+        raise RuntimeError("Python 和系统均缺少 zstd 解压支持")
+    zstd = ctypes.CDLL(library)
+    size_t = ctypes.c_size_t
+    zstd.ZSTD_findFrameCompressedSize.argtypes = [ctypes.c_void_p, size_t]
+    zstd.ZSTD_findFrameCompressedSize.restype = size_t
+    zstd.ZSTD_getFrameContentSize.argtypes = [ctypes.c_void_p, size_t]
+    zstd.ZSTD_getFrameContentSize.restype = ctypes.c_ulonglong
+    zstd.ZSTD_decompressBound.argtypes = [ctypes.c_void_p, size_t]
+    zstd.ZSTD_decompressBound.restype = ctypes.c_ulonglong
+    zstd.ZSTD_decompress.argtypes = [ctypes.c_void_p, size_t, ctypes.c_void_p, size_t]
+    zstd.ZSTD_decompress.restype = size_t
+    zstd.ZSTD_isError.argtypes = [size_t]
+    zstd.ZSTD_isError.restype = ctypes.c_uint
+    zstd.ZSTD_getErrorName.argtypes = [size_t]
+    zstd.ZSTD_getErrorName.restype = ctypes.c_char_p
+
+    if not source:
+        return b""
+    src = ctypes.create_string_buffer(source)
+    base = ctypes.addressof(src)
+    offset = 0
+    decoded = []
+    unknown = (1 << 64) - 1
+    error_size = unknown - 1
+    while offset < len(source):
+        ptr = ctypes.c_void_p(base + offset)
+        remaining = len(source) - offset
+        frame_size = zstd.ZSTD_findFrameCompressedSize(ptr, remaining)
+        if zstd.ZSTD_isError(frame_size):
+            name = zstd.ZSTD_getErrorName(frame_size).decode("utf-8", errors="replace")
+            raise ValueError(f"无效的 zstd frame: {name}")
+        content_size = zstd.ZSTD_getFrameContentSize(ptr, frame_size)
+        if content_size in (unknown, error_size):
+            content_size = zstd.ZSTD_decompressBound(ptr, frame_size)
+        if content_size <= 0 or content_size > 512 * 1024 * 1024:
+            raise ValueError("zstd frame 解压大小无效")
+        out = ctypes.create_string_buffer(content_size)
+        written = zstd.ZSTD_decompress(out, content_size, ptr, frame_size)
+        if zstd.ZSTD_isError(written):
+            name = zstd.ZSTD_getErrorName(written).decode("utf-8", errors="replace")
+            raise ValueError(f"zstd 解压失败: {name}")
+        decoded.append(out.raw[:written])
+        offset += frame_size
+    return b"".join(decoded)
+
+
+def _dsh_nonnegative_int(value):
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _dsh_route_from_header(data):
+    header = data.get("header") if isinstance(data, dict) else None
+    config = header.get("config") if isinstance(header, dict) else None
+    if not isinstance(config, dict):
+        return None
+    model = config.get("model")
+    return str(model).strip() if model else None
+
+
+def _dsh_parse_session(path):
+    text = _dsh_read_text(path)
+    lines = text.splitlines()
+    if not lines:
+        raise ValueError("空的 DeepSeek Harness session 日志")
+    try:
+        header = json.loads(lines[0])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("无效的 DeepSeek Harness session header") from exc
+    if not isinstance(header, dict) or header.get("type") != "session" or not header.get("id"):
+        raise ValueError("缺少 DeepSeek Harness session identity")
+    if header.get("version") != _DSH_SESSION_FORMAT_VERSION:
+        raise ValueError(f"不支持的 DeepSeek Harness session version: {header.get('version')}")
+
+    session_id = str(header["id"])
+    cwd = str(header.get("cwd") or "")
+    project = os.path.basename(cwd.rstrip(os.sep)) or "?"
+    current_model = "unknown"
+    calls = {}
+    malformed = 0
+
+    for raw in lines[1:]:
+        if not raw.strip():
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            malformed += 1
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        data = event.get("data")
+        if event_type == "request/context" and isinstance(data, dict):
+            model = data.get("model")
+            if model:
+                current_model = str(model).strip() or current_model
+            continue
+        if event_type == "request/header" and isinstance(data, dict):
+            current_model = _dsh_route_from_header(data) or current_model
+            continue
+
+        usage = None
+        if event_type == "assistant/message" and isinstance(data, dict):
+            usage = data.get("usage")
+        elif event_type == "assistant/chunk" and isinstance(data, dict):
+            chunk = data.get("chunk")
+            if isinstance(chunk, dict) and chunk.get("type") == "usage":
+                usage = chunk.get("usage")
+        if not isinstance(usage, dict) or not isinstance(data, dict):
+            continue
+
+        turn = data.get("turn")
+        step = data.get("step")
+        if turn is None or step is None:
+            continue
+        try:
+            event_time = datetime.fromtimestamp(int(event.get("time")) / 1000).astimezone()
+        except (TypeError, ValueError, OSError, OverflowError):
+            continue
+        inp = _dsh_nonnegative_int(usage.get("inputTokens"))
+        output_total = _dsh_nonnegative_int(usage.get("outputTokens"))
+        reason = min(_dsh_nonnegative_int(usage.get("reasoningTokens")), output_total)
+        out = output_total - reason
+        cr = _dsh_nonnegative_int(usage.get("cacheReadTokens"))
+        cw = _dsh_nonnegative_int(usage.get("cacheWriteTokens"))
+        model = current_model or "unknown"
+        price_id = _pricing_id(model)
+        p = _raw_price(price_id) if price_id else {
+            "in": 0.0, "out": 0.0, "cache_read": 0.0, "cache_write": 0.0}
+        cost = ((inp * p["in"] + cr * p["cache_read"] + cw * p["cache_write"]
+                 + output_total * p["out"]) / 1e6)
+        # Log ordering guarantees samples for a step are adjacent. Assignment provides
+        # the same replacement semantics as Harness tokenUsageProjectionDefinition.
+        calls[(turn, step)] = {
+            "date": event_time.date().isoformat(), "hour": event_time.hour,
+            "in": inp, "out": out, "cr": cr, "cw": cw, "reason": reason,
+            "cost": cost, "model": model,
+        }
+
+    days = {}
+    for call in calls.values():
+        day = days.setdefault(call["date"], _empty_token_day())
+        _add_token_usage(day, call["in"], call["out"], call["cr"], call["cw"],
+                         call["reason"], call["cost"], call["model"])
+        day["hours"][call["hour"]] += token_total(call)
+        day.setdefault("projects", []).append(project)
+    for day in days.values():
+        day["projects"] = sorted(set(day.get("projects", [])))
+    return {"session": session_id, "proj": cwd, "project": project, "days": days,
+            "version": header["version"], "malformed": malformed}
+
+
+def scan_deepseek_harness(bounds, cache):
+    ledger_touch("deepseek_harness")
+    fc = cache.setdefault("deepseek_harness", {})
+    B = _empty_token_ranges()
+    paths = _dsh_session_files()
+    present = set(paths)
+    scan_errors = []
+
+    for path in paths:
+        try:
+            sig = _dsh_file_signature(path)
+        except OSError as exc:
+            scan_errors.append(f"{os.path.basename(os.path.dirname(path))}: {exc}")
+            continue
+        entry = fc.get(path)
+        if not isinstance(entry, dict) or entry.get("sig") != sig:
+            try:
+                parsed = _dsh_parse_session(path)
+            except Exception as exc:
+                # Writer 中途追加或暂时无法解压时保留上次完整快照，避免统计闪零。
+                scan_errors.append(f"{os.path.basename(os.path.dirname(path))}: {type(exc).__name__}: {exc}")
+                continue
+            parsed["sig"] = sig
+            fc[path] = parsed
+            cache["_dirty"] = True
+
+    for key in list(fc):
+        if key.startswith("_"):
+            continue
+        if key not in present:
+            del fc[key]
+            cache["_dirty"] = True
+    if scan_errors:
+        fc["_errors"] = scan_errors[:5]
+    elif fc.pop("_errors", None) is not None:
+        cache["_dirty"] = True
+
+    live_days = {}
+    for path, entry in fc.items():
+        if path.startswith("_") or not isinstance(entry, dict):
+            continue
+        session = entry.get("session")
+        for day_key, day_usage in entry.get("days", {}).items():
+            agg = live_days.setdefault(day_key, _empty_token_day())
+            _merge_live_token_day(agg, day_usage)
+            try:
+                day = date.fromisoformat(day_key)
+            except (TypeError, ValueError):
+                continue
+            for key in classify_date(day, bounds):
+                B[key]["sessions"].add(session)
+
+    for day_key, day_usage in ledger_reconcile("deepseek_harness", live_days).items():
+        try:
+            day = date.fromisoformat(day_key)
+        except (TypeError, ValueError):
+            continue
+        for key in classify_date(day, bounds):
+            _merge_token_day(B[key], day_usage)
+    return {"ranges": B, "errors": scan_errors}
+
+
 def fmt_reset(epoch):
     try:
         return datetime.fromtimestamp(int(epoch)).astimezone().strftime("%m-%d %H:%M")
@@ -5751,6 +6050,10 @@ def compute():
     wb = _safe_scan("workbuddy", lambda: scan_workbuddy(bounds, cache), _empty_workbuddy, errors)
     ocode = _safe_scan("opencode", lambda: scan_opencode(bounds, cache), _empty_opencode, errors)
     qwc = _safe_scan("qwencode", lambda: scan_qwencode(bounds, cache), _empty_qwencode, errors)
+    dsh = _safe_scan("deepseek_harness", lambda: scan_deepseek_harness(bounds, cache),
+                     _empty_deepseek_harness, errors)
+    if dsh.get("errors"):
+        errors["deepseek_harness"] = "; ".join(dsh["errors"])
     _cache_dashboard_days(cache, _GEMINI_DAYS_CACHE_KEY, gm.get("days", {}))
     _cache_dashboard_days(cache, _GROK_DAYS_CACHE_KEY, gk.get("days", {}))
     _save_scan_cache(cache)
@@ -5877,6 +6180,7 @@ def compute():
     wbranges = {k: token_usage_range(wb["ranges"][k]) for k in RANGE_KEYS}
     ocranges = {k: token_usage_range(ocode["ranges"][k]) for k in RANGE_KEYS}
     qwcranges = {k: token_usage_range(qwc["ranges"][k]) for k in RANGE_KEYS}
+    dshranges = {k: token_usage_range(dsh["ranges"][k]) for k in RANGE_KEYS}
 
     cur = cc["cur"]
     cur_total = cur["in"] + cur["out"] + cur["cr"] + cur["cw"]
@@ -5958,6 +6262,9 @@ def compute():
         "qwencode": {
             "ranges": qwcranges,
         },
+        "deepseek_harness": {
+            "ranges": dshranges,
+        },
     }
     if errors:
         result["_errors"] = errors
@@ -5967,7 +6274,8 @@ def compute():
 
 def _recalc_costs(result):
     """只重算缺少权威账单的工具；已有日志成本的工具保留原值。"""
-    for tool_key in ("gemini", "grok", "hermes", "zcode", "mimocode", "workbuddy", "qwencode"):
+    for tool_key in ("gemini", "grok", "hermes", "zcode", "mimocode", "workbuddy",
+                     "qwencode", "deepseek_harness"):
         tool = result.get(tool_key)
         if not tool or "ranges" not in tool:
             continue
@@ -6001,7 +6309,7 @@ def _recalc_costs(result):
                     thoughts = m.get("thoughts", 0)
                     cost = (ti / 1e6 * p["in"] + (to + thoughts) / 1e6 * p["out"]
                             + cached / 1e6 * p["cache_read"])
-                elif tool_key in ("hermes", "zcode", "mimocode"):
+                elif tool_key in ("hermes", "zcode", "mimocode", "deepseek_harness"):
                     cr = m.get("cr", 0)
                     cw = m.get("cw", 0)
                     reason = m.get("reason", 0)
@@ -6514,12 +6822,14 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
     _empty = lambda: {"claude": 0.0, "codex": 0.0, "gemini": 0.0, "grok": 0.0,
                        "zcode": 0.0, "mimocode": 0.0, "pi": 0.0,
                        "workbuddy": 0.0, "opencode": 0.0, "qwencode": 0.0,
-                       "hermes": 0.0, "openclaw": 0.0,
+                       "hermes": 0.0, "openclaw": 0.0, "deepseek_harness": 0.0,
                        "c_in": 0, "c_out": 0, "c_cr": 0, "c_cw": 0,
                        "x_in": 0, "x_out": 0, "x_cached": 0, "x_reason": 0,
                        "p_in": 0, "p_out": 0, "p_cr": 0, "p_cw": 0, "p_reason": 0,
                        "w_in": 0, "w_out": 0, "w_cr": 0, "w_cw": 0,
                        "q_in": 0, "q_out": 0, "q_cr": 0, "q_reason": 0,
+                       "dsh_in": 0, "dsh_out": 0, "dsh_cr": 0, "dsh_cw": 0,
+                       "dsh_reason": 0,
                        "g_in": 0, "g_out": 0, "g_cr": 0, "g_reason": 0,
                        "tokens": 0, "sessions": 0}
 
@@ -6676,6 +6986,27 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
             for key in TOKEN_FIELDS:
                 m[key] += mv.get(key, 0)
 
+    for entry in cache.get("deepseek_harness", {}).values():
+        if not isinstance(entry, dict):
+            continue
+        for dk, day_data in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            d = days.setdefault(dk, _empty())
+            d["deepseek_harness"] += day_data.get("cost", 0)
+            d["dsh_in"] += day_data.get("in", 0); d["dsh_out"] += day_data.get("out", 0)
+            d["dsh_cr"] += day_data.get("cr", 0); d["dsh_cw"] += day_data.get("cw", 0)
+            d["dsh_reason"] += day_data.get("reason", 0)
+            _add_day_tokens(d, dk, "deepseek_harness", token_total(day_data))
+            for mn, mv in day_data.get("models", {}).items():
+                nm = f"{nice_model(mn)} (DeepSeek Harness)"
+                m = models.setdefault(nm, {"cost": 0.0, "in": 0, "out": 0, "cr": 0,
+                                           "cw": 0, "reason": 0,
+                                           "tool": "deepseek_harness"})
+                m["cost"] += mv.get("cost", 0)
+                for key in TOKEN_FIELDS:
+                    m[key] += mv.get(key, 0)
+
     for fp, entry in cache.get("hermes", {}).items():
         for dk, day in entry.get("days", {}).items():
             if cutoff and dk < cutoff:
@@ -6748,7 +7079,7 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
     # 输出结构保持完全不变(qoderwork/qoder_ide/qodercli 无成本列,只参与 token 合并)。
     _LEDGER_COST_COLUMNS = frozenset((
         "claude", "codex", "gemini", "grok", "hermes", "openclaw", "zcode",
-        "mimocode", "pi", "workbuddy", "opencode", "qwencode"))
+        "mimocode", "pi", "workbuddy", "opencode", "qwencode", "deepseek_harness"))
     for tool, tool_days in _load_ledger().get("tools", {}).items():
         if not isinstance(tool_days, dict):
             continue
@@ -6785,15 +7116,18 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
               "openclaw": round(v["openclaw"], 2),
               "zcode": round(v["zcode"], 2), "mimocode": round(v["mimocode"], 2), "pi": round(v["pi"], 2),
               "workbuddy": round(v["workbuddy"], 2), "qwencode": round(v["qwencode"], 2),
+              "deepseek_harness": round(v["deepseek_harness"], 2),
               "total": round(v["claude"] + v["codex"] + v["gemini"] + v["grok"] + v["zcode"]
                              + v["mimocode"] + v["pi"] + v["workbuddy"]
                              + v["opencode"] + v["qwencode"] + v["hermes"]
-                             + v["openclaw"], 2),
+                             + v["openclaw"] + v["deepseek_harness"], 2),
               "c_in": v["c_in"], "c_out": v["c_out"], "c_cr": v["c_cr"], "c_cw": v["c_cw"],
               "x_in": v["x_in"], "x_out": v["x_out"], "x_cached": v["x_cached"], "x_reason": v["x_reason"],
               "p_in": v["p_in"], "p_out": v["p_out"], "p_cr": v["p_cr"], "p_cw": v["p_cw"], "p_reason": v["p_reason"],
               "w_in": v["w_in"], "w_out": v["w_out"], "w_cr": v["w_cr"], "w_cw": v["w_cw"],
               "q_in": v["q_in"], "q_out": v["q_out"], "q_cr": v["q_cr"], "q_reason": v["q_reason"],
+              "dsh_in": v["dsh_in"], "dsh_out": v["dsh_out"], "dsh_cr": v["dsh_cr"],
+              "dsh_cw": v["dsh_cw"], "dsh_reason": v["dsh_reason"],
               "g_in": v["g_in"], "g_out": v["g_out"], "g_cr": v["g_cr"], "g_reason": v["g_reason"],
               "tokens": v["tokens"]}
              for dk, v in sorted(days.items())]
@@ -6989,6 +7323,27 @@ def build_wrapped(period="all", refresh=True, _cache=None):
         for model, usage in day.get("models", {}).items():
             name = f"{nice_model(model)} (OpenCode)"
             model_tok[name] = model_tok.get(name, 0) + token_total(usage)
+
+    # --- DeepSeek Harness (reason 是 output 子集，collector 已拆为互斥桶) ---
+    for entry in cache.get("deepseek_harness", {}).values():
+        if not isinstance(entry, dict):
+            continue
+        project = entry.get("project") or "?"
+        for dk, day in entry.get("days", {}).items():
+            if cutoff and dk < cutoff:
+                continue
+            tok = token_total(day)
+            day_tokens[dk] = day_tokens.get(dk, 0) + tok
+            day_cost[dk] = day_cost.get(dk, 0.0) + day.get("cost", 0)
+            weekday[date.fromisoformat(dk).weekday()] += tok
+            add_hours(dk, day.get("hours"))
+            if project != "?":
+                pt = proj_tok.setdefault(project, [0, 0.0])
+                pt[0] += tok; pt[1] += day.get("cost", 0)
+                day_projs.setdefault(dk, set()).add(project)
+            for model, usage in day.get("models", {}).items():
+                name = f"{nice_model(model)} (DeepSeek Harness)"
+                model_tok[name] = model_tok.get(name, 0) + token_total(usage)
 
     # --- ZCode / MiMoCode ---
     for tool_key, suffix in (("zcode", "ZCode"), ("mimocode", "MiMoCode")):
@@ -7349,6 +7704,26 @@ def projects():
         workbuddy_sessions.setdefault(proj_path, set()).add(record.get("session") or entry.get("sid"))
     for proj_path, session_ids in workbuddy_sessions.items():
         proj_map[proj_path]["sessions"] += len(session_ids)
+
+    # DeepSeek Harness sessions
+    for entry in cache.get("deepseek_harness", {}).values():
+        if not isinstance(entry, dict):
+            continue
+        proj_path = entry.get("proj") or ""
+        if not proj_path:
+            continue
+        p = proj_map.setdefault(proj_path, {"sessions": 0, "tokens": 0, "cost": 0.0,
+                                             "last_active": "", "model_tok": {}, "tools": set()})
+        p["sessions"] += 1
+        p["tools"].add("deepseek_harness")
+        for dk, day in entry.get("days", {}).items():
+            p["tokens"] += token_total(day)
+            p["cost"] += day.get("cost", 0)
+            if dk > p["last_active"]:
+                p["last_active"] = dk
+            for mn, mv in day.get("models", {}).items():
+                name = f"{nice_model(mn)} (DeepSeek Harness)"
+                p["model_tok"][name] = p["model_tok"].get(name, 0) + token_total(mv)
 
     # Grok Build sessions + unified 日志真实 token，直接复用主刷新缓存。
     grok_project_sessions = {}


### PR DESCRIPTION
## 背景

DeepSeek Harness 会把每个会话持久化到 `${DSH_HOME:-~/.dsh}/sessions/**/session.jsonl.zstd`。当前 Tokei 尚未识别该数据源，因此 Harness 产生的模型调用、缓存命中、推理 token、成本和项目活跃记录不会进入菜单栏、Dashboard、多设备同步或年度回顾。

本 PR 基于 DeepSeek Harness 官方仓库提交 `47f943859bef60e4160492346772ded9b24f765a` 的 session v0 定义，以及本机已有的一份真实 `~/.dsh` 会话完成接入。实现只读取统计所需的事件字段，不读取凭据，也不会把消息正文、系统提示、工具参数或工具结果写入 Tokei 输出。

## 目标

- 从 DeepSeek Harness 本地 session 日志采集真实 provider usage。
- 保持 Tokei 的 token 桶、成本、日期、模型、小时和项目统计口径一致。
- 将新工具完整接入 Python collector、Swift UI、多设备同步、Dashboard、Wrapped、项目足迹、文档和网站。
- 对当前仍处于预发布阶段的 Harness session schema 保持保守兼容，不对未知格式做猜测性解析。

## 实现范围

### Collector 与日志解析

- 默认扫描 `${DSH_HOME:-~/.dsh}/sessions/**/session.jsonl.zstd`。
- 兼容 Harness 的明文 `session.jsonl` 配置。
- 支持 `TOKEI_DSH_DIR` 覆盖，便于非默认安装和测试隔离。
- 只接受官方 session format v0；遇到未来版本时 fail closed，并保留上次成功缓存。
- 使用路径、设备号、inode、大小、`mtime_ns`、`ctime_ns` 和 parser version 组成文件签名；文件未变化时复用扫描缓存。
- 同一会话目录同时存在明文和 zstd artifact 时优先选择 zstd，避免重复计数。
- 接入现有持久账本，日志清理后仍保留逐日高水位历史。

### zstd 解压

按运行环境逐级使用：

1. Python 3.14 标准库 `compression.zstd`；
2. 可选 Python `zstandard` 模块；
3. 通过 `ctypes` 调用系统 `libzstd`，逐 frame 解码 Harness 的 concatenated zstd frames。

实现不调用外部 `zstd` 命令，避免新增 Gatekeeper 和 PATH 依赖。单个 artifact 暂时无法完整读取时会进入现有 diagnostics，并保留上一份成功快照，不影响其他采集器。

### Token 与模型口径

- Harness 会为同一模型调用先记录 `assistant/chunk` usage，再记录 `assistant/message` 最终 usage。本实现以 `(turn, step)` 为键采用 last-wins 折叠，避免双倍计数。
- `inputTokens` 已是非缓存输入；`cacheReadTokens` 与 `cacheWriteTokens` 保持独立。
- `reasoningTokens` 是 `outputTokens` 的子集。Collector 将其拆成互斥的普通输出和推理桶，使 Tokei 的总量仍为：

  ```text
  input + output_without_reasoning + cache_read + cache_write + reasoning
  ```

- 模型取当前调用前最近的 `request/context`，并用 `request/header.data.header.config.model` 作为回退。
- 未知模型保留原名，且成本保持 0；不会错误套用其他模型的兜底价格。
- 已知模型使用 Tokei 现有版本化价格表估算成本。Harness session 本身不包含权威货币成本，因此这里仍是估算值，而不是实际账单。

### Tokei 全链路

- 新增向后兼容的 `Usage.deepseek_harness` Codable 字段；旧设备快照缺少该字段时回退为空统计。
- 接入 SyncManager 多设备区间合并。
- 接入菜单栏今日 token 总计、工具卡、模型明细、显示设置和 diagnostics。
- 接入 Dashboard 的逐日成本、token 桶、模型颜色、跨设备 daily 合并、总 token 和总成本。
- 接入 Wrapped 的日期、小时、模型、项目和峰值统计。
- 接入项目足迹的 session、token、成本、最后活跃日期和工具标识。
- 增加 DeepSeek Harness 主题色，并将网站和 README 的真实支持工具数量统一为 16。

## 隐私与安全

- 不读取 `~/.dsh/.credentials.yaml`。
- 不访问 DeepSeek 远端 API，不需要新增 API key。
- 不上传或输出 user/assistant message、system prompt、tool arguments 或 tool results。
- 项目维度只使用 session header 已有的 `cwd`，沿用 Tokei 现有项目足迹和同步行为。
- zstd fallback 仅加载本机系统动态库，不执行 shell 命令。

## 兼容性

- 支持 DeepSeek Harness session format v0。
- 支持 `.jsonl.zstd` 与 `.jsonl`。
- 支持 packed chunk storage rows：这些物理布局行不会干扰最终 `assistant/message.data.usage` 统计。
- 子代理如果以独立 session artifact 持久化，会作为真实 provider usage 自然计入；不会将父会话继承的消息文本额外折算成 token。
- Harness 未来提升 session format version 时会明确报错并等待适配，不会静默产生错误统计。

## 验证

### 新增定向测试

```text
python3 -m unittest discover -s tests -p 'test_deepseek_harness.py' -v
Ran 8 tests in 0.011s
OK
```

覆盖：

- chunk/message last-wins；
- reasoning 不重复；
- request context 模型切换；
- 未知模型不产生虚假成本；
- 明文与 zstd session；
- concatenated frame 的系统 `libzstd` fallback；
- future version fail closed 并保留缓存；
- `TOKEI_DSH_DIR` 优先级；
- Daily、模型和 Wrapped 小时统计。

### 真实 `~/.dsh` 会话

本机已有 1 个 DeepSeek Harness 会话，collector 输出：

| 指标 | 结果 |
| --- | ---: |
| 会话 | 1 |
| 模型 | `deepseek-v4-flash` |
| 非缓存输入 | 21,626 |
| 非推理输出 | 3,452 |
| 缓存读 | 224,768 |
| 缓存写 | 0 |
| 推理 | 2,713 |
| 总 token | 252,559 |

结果与独立 `jq` 对最终 `assistant/message.data.usage` 的手工折叠完全一致。`/usr/bin/python3` 缺少 Python zstd 模块时，系统 `libzstd` fallback 也正确解码了全部 433 行逻辑 JSONL。

### Swift 与静态检查

```text
python3 -m py_compile usage.30s.py
git diff --check
cd Tokei && swift build -c release
bash Tokei/Tests/run-sync-integration-checks.sh
```

- Python 语法检查通过。
- diff whitespace 检查通过。
- Swift release build 通过；仅保留仓库既有的资源声明和 trailing closure warning。
- SyncManager integration checks：16/16 通过。
- 网站静态检查确认正好 16 张工具卡，标题和对比表数量一致。

### 已知上游测试基线

完整执行 `python3 -m unittest discover -s tests` 当前仍有 15 个失败，涉及 Claude、Dashboard cache、Grok、Hermes、OpenCode、Qwen Code 和 ZCode/MiMoCode。对未修改的 `upstream/main@1840fbb` 临时副本执行相同命令也得到相同的 15 个失败，根因是新持久账本状态在同一 unittest 进程内跨测试污染，并非本 PR 引入。

本 PR 没有顺带调整账本架构，以避免扩大 DeepSeek Harness 支持的交付范围。

## 实施计划与完成情况

- [x] 核对官方 session persistence、usage 与版本约束。
- [x] 使用本机真实 `~/.dsh` 会话验证日志结构和 token 语义。
- [x] 实现路径发现、zstd/明文读取、last-wins 折叠、缓存和账本。
- [x] 接入 Daily、模型、Wrapped 和项目统计。
- [x] 接入 Swift Codable、多设备同步、菜单栏、Dashboard、工具卡和设置。
- [x] 增加合成、脱敏的定向测试。
- [x] 更新 README、计算口径、collector skill 和网站支持数量。
- [x] 完成真实会话、Python、Swift、SyncManager 和网站验证。

## 延后事项

- DeepSeek Harness 当前仍使用未发布的 session format v0；未来 schema 升级需基于新的官方定义单独适配。
- 本 PR 不增加 retry 次数、step latency 或子代理树形可视化，只统计已有 provider usage。
- 本 PR 不修复上游持久账本的测试隔离问题。
