### PR TITLE
feat(qwenwork): add quota tracking

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -1,6 +1,6 @@
 # Tokei 计算逻辑
 
-Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有数据纯本地读取,不联网。
+Tokei 主要读取本地 AI 工具日志，统计 token 用量与成本。额度查询按工具使用本地日志或已有的本机登录态；需要联网的查询会明确标注并提供开关。
 
 ---
 
@@ -20,6 +20,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | DeepSeek Harness | `~/.dsh/sessions/**/session.jsonl.zstd` | 多帧 zstd JSONL，最终 `assistant/message.data.usage` |
 | OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `~/.local/share/opencode/storage/message/ses_*/msg_*.json` | SQLite/JSON, `tokens` + `cost` |
 | Qwen Code | `${QWEN_RUNTIME_DIR:-~/.qwen}/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` | JSONL,逐请求记录 + 会话汇总 |
+| 千问办公（QwenWork） | `~/.qwenworkcn/mcp-adaptor.config` + `.status.json` 文件元数据 + 官方桌面端 `127.0.0.1` MCP | JSON-RPC，`qw_query` / `qwenwork.usage`（默认关闭） |
 
 ---
 
@@ -291,6 +292,34 @@ Codex 刷新登录 Token 后立即重试。
 1. 始终优先解析本地日志
 2. 仅当用户开启实时查询时，才请求账单接口覆盖为最新值
 3. 失败时回退到本地日志或短缓存，不报错
+
+### 千问办公（QwenWork）
+
+千问办公与 Qwen Code 是两个独立产品。本功能只读取额度，不参与 Qwen Code 的 token、成本或模型统计。
+
+查询默认**关闭**，可通过设置开启，也可使用环境变量：
+
+- `~/.tokei/config.json` 中 `qwenwork_quota_enabled: true`
+- `TOKEI_QWENWORK_QUOTA=1` 开启；`TOKEI_QWENWORK_QUOTA=0` 强制关闭
+
+开启后，Tokei 读取 `~/.qwenworkcn/mcp-adaptor.config`，并向其中限定为
+`http://127.0.0.1:<port>` 的地址发送 JSON-RPC `POST`：工具固定为 `qw_query`，参数固定为
+`{"key":"qwenwork.usage"}`。千问办公必须正在运行且已登录；本机 MCP 会由千问办公自行请求
+官方额度。Tokei 不读取或解密 `auth-v2.dat`，不读取浏览器 Cookie，也不自动启动客户端。
+为防止退出或切换账号后显示旧额度，Tokei 仅把 `.status.json` 的文件 generation 元数据纳入
+缓存标识，不读取其中的姓名、邮箱等账号资料；接口明确返回不可用时会删除旧额度缓存。
+
+额度口径：
+
+- `segments` 是套餐积分和加购积分的 canonical 明细；`planCredits`、`addOnCredits` alias
+  仅用于个人积分兼容，不能与 `segments` 重复相加；`sharedAddOnCredits` 只作为共享资源包 fallback
+- `aggregateRemainingPercent` 表示**剩余百分比**，允许为 `null`；缺失时展示绝对积分，不反推已用百分比
+- `total=0` 且 `remaining>0` 是合法的未知总额状态，例如 `total=0, remaining=2100` 应显示
+  `2,100` 剩余积分
+- `sharedResourcePackage` 单独展示，不并入个人套餐/加购积分余额
+- 结果使用短缓存降低查询频率；实时查询失败时可显示标记为缓存来源的最近结果
+
+千问办公首版只有绝对积分时不加入以百分比为口径的菜单栏额度源，额度在独立卡片展示。
 
 ### Qoder(credit)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
 
 ### 支持的工具
 
@@ -35,6 +35,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 | **WorkBuddy** | Token、成本、缓存命中率、模型、项目 |
 | **OpenCode** | Token、成本、缓存命中率、模型 |
 | **Qwen Code** | Token、思考量、成本、模型 |
+| **千问办公（QwenWork）** | 套餐与加购积分余额、团队共享资源包 |
 | **Qoder** | Token、调用次数、配额 |
 | **QoderWork** | Token、调用次数、配额 |
 
@@ -83,6 +84,8 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 - Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据
 - Codex 额度使用本机 Codex 登录态读取官方接口；重置卡每天最多自动查询一次
 - Grok 实时额度默认关闭，可选择只读本地日志
+- 千问办公额度默认关闭；开启后仅调用官方桌面端的 `127.0.0.1` MCP，由已运行并登录的千问办公查询官方额度
+- Tokei 不读取或解密千问办公的 `auth-v2.dat`、浏览器 Cookie 或 `.status.json` 账号资料；仅用 `.status.json` 文件元数据使切换账号后的额度缓存失效，也不会自动启动千问办公
 - 其余联网操作仅用于检查/下载更新，以及手动更新模型价格表
 
 ## 快速开始
@@ -148,7 +151,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 ## 数据来源
 
-所有数据均来自 **本地日志文件**，无网络请求。
+Token、成本和项目统计来自 **本地日志文件**。额度查询仅使用对应工具已有的本机登录态；需联网的额度功能会在下表标明。
 
 | 工具 | 日志路径 |
 |------|----------|
@@ -163,6 +166,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | DeepSeek Harness | `~/.dsh/sessions/**/session.jsonl.zstd`（App 内置 zstd 解压） |
 | OpenCode | `~/.opencode/sessions/*.json` |
 | Qwen Code | `~/.qwen/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` |
+| 千问办公（QwenWork） | `~/.qwenworkcn/mcp-adaptor.config` + `.status.json` 文件元数据 + 官方桌面端 `127.0.0.1` MCP（默认关闭；需客户端运行且已登录） |
 | Qoder | `~/.qodo-ai/sessions/*.jsonl` |
 | QoderWork | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 
@@ -170,7 +174,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 | 功能 | Tokei | [CodexBar](https://github.com/steipete/CodexBar) |
 |------|:-----:|:---------:|
-| 支持工具 | 12 | 40+ |
+| 支持工具 | 13 | 40+ |
 | Token 级用量分析 | ✅ | — |
 | 成本估算（317 模型） | ✅ | 部分 |
 | 数据面板（图表 + 热力图） | ✅ | — |
@@ -179,7 +183,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | 多设备同步 | ✅ | — |
 | 年度回顾 | ✅ | — |
 | 防休眠 / 久坐提醒 | ✅ | — |
-| 需要联网 | 否 | 是 |
+| 需要联网 | 仅额度查询、更新等功能 | 是 |
 | 需要登录 | 否 | 是 |
 | 数据来源 | 本地日志 | 远程 API |
 
@@ -319,11 +323,11 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **12 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **13 AI tools** in real-time. Usage analytics are local-first; quota checks use each tool's existing local sign-in and may contact its official service.
 
-**Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local logs only) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
+**Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local usage logs, explicit quota controls) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 
-**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok Build, Hermes, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, Qoder, QoderWork
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI, Grok Build, Hermes, OpenClaw, Pi Coding Agent CLI, WorkBuddy, OpenCode, Qwen Code, QwenWork, Qoder, QoderWork
 
 For full documentation, visit [tokei.lanshuagent.com](https://tokei.lanshuagent.com).
 

--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -45,6 +45,7 @@ enum Theme {
     static let deepseekHarness = Color(red: 0.18, green: 0.58, blue: 0.94) // 深海蓝
     static let opencode = Color(red: 0.55, green: 0.75, blue: 0.90) // 天蓝灰
     static let qwencode = Color(red: 0.48, green: 0.55, blue: 0.95) // 靛蓝
+    static let qwenwork = Color(red: 0.24, green: 0.72, blue: 0.68) // 千问青
 
     static let panelWidth: CGFloat = 322
     static let cardRadius: CGFloat = 16

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -659,6 +659,88 @@ struct TokenUsageRanges: Codable {
 }
 struct TokenUsageStat: Codable { var ranges: TokenUsageRanges }
 
+/// A single quota bucket reported by the QwenWork desktop app.
+/// `total == 0` does not imply that the bucket is empty: some plans expose
+/// only an absolute remaining-credit balance.
+struct QwenWorkQuotaSegment: Codable, Identifiable {
+    var id = ""
+    var kind = ""
+    var total: Double?
+    var used: Double?
+    var remaining: Double?
+    var percentage_used: Double?
+    var unit: String?
+    var renews_at: Int?
+    var expires_at: Int?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id) ?? ""
+        kind = try c.decodeIfPresent(String.self, forKey: .kind) ?? ""
+        total = try? c.decodeIfPresent(Double.self, forKey: .total)
+        used = try? c.decodeIfPresent(Double.self, forKey: .used)
+        remaining = try? c.decodeIfPresent(Double.self, forKey: .remaining)
+        percentage_used = try? c.decodeIfPresent(Double.self, forKey: .percentage_used)
+        unit = try? c.decodeIfPresent(String.self, forKey: .unit)
+        renews_at = try? c.decodeIfPresent(Int.self, forKey: .renews_at)
+        expires_at = try? c.decodeIfPresent(Int.self, forKey: .expires_at)
+    }
+}
+
+/// A team/shared package is displayed separately and never added to the
+/// personal credit balance.
+struct QwenWorkSharedQuota: Codable {
+    var total: Double?
+    var used: Double?
+    var remaining: Double?
+    var percentage_used: Double?
+    var unit: String?
+    var expires_at: Int?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        total = try? c.decodeIfPresent(Double.self, forKey: .total)
+        used = try? c.decodeIfPresent(Double.self, forKey: .used)
+        remaining = try? c.decodeIfPresent(Double.self, forKey: .remaining)
+        percentage_used = try? c.decodeIfPresent(Double.self, forKey: .percentage_used)
+        unit = try? c.decodeIfPresent(String.self, forKey: .unit)
+        expires_at = try? c.decodeIfPresent(Int.self, forKey: .expires_at)
+    }
+}
+
+struct QwenWorkQuota: Codable {
+    var available = false
+    var remaining: Double?
+    var remaining_pct: Double?
+    var exceeded = false
+    var is_team = false
+    var expires_at: Int?
+    var plan_expiration: Int?
+    var segments: [QwenWorkQuotaSegment] = []
+    var shared: QwenWorkSharedQuota?
+    var source: String?
+    var updated: Int?
+    var stale = false
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        available = (try? c.decodeIfPresent(Bool.self, forKey: .available)) ?? false
+        remaining = try? c.decodeIfPresent(Double.self, forKey: .remaining)
+        remaining_pct = try? c.decodeIfPresent(Double.self, forKey: .remaining_pct)
+        exceeded = (try? c.decodeIfPresent(Bool.self, forKey: .exceeded)) ?? false
+        is_team = (try? c.decodeIfPresent(Bool.self, forKey: .is_team)) ?? false
+        expires_at = try? c.decodeIfPresent(Int.self, forKey: .expires_at)
+        plan_expiration = try? c.decodeIfPresent(Int.self, forKey: .plan_expiration)
+        segments = (try? c.decodeIfPresent([QwenWorkQuotaSegment].self, forKey: .segments)) ?? []
+        shared = try? c.decodeIfPresent(QwenWorkSharedQuota.self, forKey: .shared)
+        source = try? c.decodeIfPresent(String.self, forKey: .source)
+        updated = try? c.decodeIfPresent(Int.self, forKey: .updated)
+        stale = (try? c.decodeIfPresent(Bool.self, forKey: .stale)) ?? false
+    }
+}
+
 struct Usage: Codable {
     var claude: ClaudeStat
     var codex: CodexStat
@@ -676,10 +758,11 @@ struct Usage: Codable {
     var deepseekHarness: TokenUsageStat
     var opencode: TokenUsageStat
     var qwencode: TokenUsageStat
+    var qwenwork: QwenWorkQuota
 
     enum CodingKeys: String, CodingKey {
         case claude, codex, gemini, grok, qoder, qoderwork, qodercli, hermes, zcode, mimocode
-        case openclaw, pi, workbuddy, deepseekHarness = "deepseek_harness", opencode, qwencode
+        case openclaw, pi, workbuddy, deepseekHarness = "deepseek_harness", opencode, qwencode, qwenwork
     }
 
     init(from decoder: Decoder) throws {
@@ -704,10 +787,20 @@ struct Usage: Codable {
         deepseekHarness = try c.decodeIfPresent(TokenUsageStat.self, forKey: .deepseekHarness) ?? TokenUsageStat(ranges: .empty)
         opencode = try c.decode(TokenUsageStat.self, forKey: .opencode)
         qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)
+        qwenwork = (try? c.decodeIfPresent(QwenWorkQuota.self, forKey: .qwenwork)) ?? QwenWorkQuota()
     }
 }
 
 enum Fmt {
+    static func credits(_ n: Double) -> String {
+        if abs(n.rounded() - n) < 0.000_001 {
+            return String(format: "%.0f", n)
+        }
+        return String(format: "%.2f", n)
+            .replacingOccurrences(of: "0+$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\.$", with: "", options: .regularExpression)
+    }
+
     static func human(_ n: Int) -> String {
         let v = Double(n)
         if v >= 100_000_000 { return String(format: "%.1f亿", v / 100_000_000) }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -46,8 +46,11 @@ struct PanelView: View {
     @AppStorage("showDeepSeekHarness") private var showDeepSeekHarness = true
     @AppStorage("showOpenCode") private var showOpenCode = true
     @AppStorage("showQwenCode") private var showQwenCode = true
+    @AppStorage("showQwenWork") private var showQwenWork = true
     /// 默认关闭：Grok 额度只读本地日志；开启后才用登录凭据请求实时账单接口。
     @AppStorage("grokLiveQuotaEnabled") private var grokLiveQuotaEnabled = false
+    /// 默认关闭：开启后仅查询千问办公桌面端暴露在本机回环地址上的额度接口。
+    @AppStorage("qwenWorkQuotaEnabled") private var qwenWorkQuotaEnabled = false
     /// 菜单栏额度来源（与显示卡片独立）。Grok 默认关，避免新额度源抢占状态栏。
     @AppStorage(MenuBarQuotaSource.claude.defaultsKey) private var menuBarQuotaClaude = true
     @AppStorage(MenuBarQuotaSource.codex.defaultsKey) private var menuBarQuotaCodex = true
@@ -55,7 +58,8 @@ struct PanelView: View {
 
     private var visibleCount: Int {
         [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showQoderCli, showHermes, showZcode, showMimoCode,
-         showOpenClaw, showPi, showWorkBuddy, showDeepSeekHarness, showOpenCode, showQwenCode].filter { $0 }.count
+         showOpenClaw, showPi, showWorkBuddy, showDeepSeekHarness, showOpenCode, showQwenCode,
+         showQwenWork].filter { $0 }.count
     }
     private var hasMultipleDevices: Bool { store.syncEnabled && !store.peers.isEmpty }
     private var useWide: Bool { visibleCount > 2 }
@@ -333,6 +337,11 @@ struct PanelView: View {
                          tint: Theme.opencode, content: AnyView(tokenUsageBlock(title: "OpenCode", or, tint: Theme.opencode, modelsOpen: $openCodeModelsOpen))),
             ToolCardItem(id: "qwencode", name: "Qwen Code", visible: showQwenCode, active: qcr.sessions > 0,
                          tint: Theme.qwencode, content: AnyView(tokenUsageBlock(title: "Qwen Code", qcr, tint: Theme.qwencode, modelsOpen: $qwenCodeModelsOpen))),
+            ToolCardItem(id: "qwenwork", name: "千问办公", visible: showQwenWork,
+                         active: qwenWorkQuotaEnabled || u.qwenwork.available ||
+                             u.qwenwork.remaining != nil || !u.qwenwork.segments.isEmpty ||
+                             u.qwenwork.shared != nil,
+                         tint: Theme.qwenwork, content: AnyView(qwenWorkBlock(u.qwenwork))),
         ]
     }
 
@@ -710,6 +719,205 @@ struct PanelView: View {
             MiniBar(value: max(0, min(100, 100 - usedPct)), tint: tint.opacity(0.75))
         }
         .help(help)
+    }
+
+    // MARK: - 千问办公额度卡片
+    @ViewBuilder
+    func qwenWorkBlock(_ quota: QwenWorkQuota) -> some View {
+        VStack(alignment: .leading, spacing: 11) {
+            cardHeadPlain("千问办公", tint: Theme.qwenwork)
+
+            if quota.available || quota.remaining != nil || !quota.segments.isEmpty || quota.shared != nil {
+                if quota.exceeded {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                        Text("官方额度状态：已用尽")
+                    }
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.red.opacity(0.92))
+                }
+
+                if let remaining = quota.remaining {
+                    CostHeadline(
+                        value: Fmt.credits(remaining),
+                        caption: quota.is_team ? "团队账号个人可用积分" : "个人可用积分",
+                        tint: Theme.qwenwork
+                    )
+                }
+
+                // 有明确比例时才画进度条。部分千问办公套餐只返回绝对积分余额。
+                if let remainingPct = quota.remaining_pct {
+                    quotaRow(
+                        title: "综合剩余比例",
+                        pct: max(0, min(100, remainingPct)),
+                        reset: nil,
+                        tint: Theme.qwenwork
+                    )
+                }
+
+                if let expiresAt = quota.expires_at {
+                    qwenWorkDateRow("额度有效期", epoch: expiresAt)
+                }
+                if let planExpiration = quota.plan_expiration,
+                   planExpiration != quota.expires_at {
+                    qwenWorkDateRow("套餐有效期", epoch: planExpiration)
+                }
+
+                if !quota.segments.isEmpty {
+                    thinDivider
+                    Text("个人积分明细")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Theme.tSecondary)
+                    ForEach(Array(quota.segments.enumerated()), id: \.offset) { item in
+                        qwenWorkSegmentRow(item.element)
+                    }
+                }
+
+                if let shared = quota.shared {
+                    thinDivider
+                    qwenWorkSharedBlock(shared)
+                }
+
+                qwenWorkQuotaStatus(quota)
+            } else if qwenWorkQuotaEnabled {
+                Text("未读取到额度。请确认千问办公已登录并保持运行。")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("在设置的「隐私与额度」中开启查询后显示。")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    func qwenWorkSegmentRow(_ segment: QwenWorkQuotaSegment) -> some View {
+        let remainingPct = ((segment.total ?? 0) > 0)
+            ? segment.percentage_used.map { max(0, min(100, 100 - $0)) }
+            : nil
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(Self.qwenWorkSegmentLabel(segment))
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.tSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 6)
+                if let remaining = segment.remaining {
+                    Text("剩余 \(Fmt.credits(remaining)) \(Self.qwenWorkUnitLabel(segment.unit))")
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Theme.tPrimary)
+                }
+            }
+
+            if let total = segment.total, total > 0 {
+                let used = segment.used.map(Fmt.credits) ?? "?"
+                Text("已用 \(used) / 总量 \(Fmt.credits(total))")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(Theme.tTertiary)
+            }
+
+            if let remainingPct {
+                HStack(spacing: 6) {
+                    MiniBar(value: remainingPct, tint: remainingPct <= 15 ? .red : Theme.qwenwork)
+                    Text(String(format: "%.0f%%", remainingPct))
+                        .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(remainingPct <= 15 ? Color.red : Theme.tSecondary)
+                }
+            }
+
+            if let renewsAt = segment.renews_at {
+                qwenWorkDateRow("续期", epoch: renewsAt)
+            } else if let expiresAt = segment.expires_at {
+                qwenWorkDateRow("到期", epoch: expiresAt)
+            }
+        }
+        .padding(.vertical, 1)
+    }
+
+    func qwenWorkSharedBlock(_ shared: QwenWorkSharedQuota) -> some View {
+        let remainingPct = ((shared.total ?? 0) > 0)
+            ? shared.percentage_used.map { max(0, min(100, 100 - $0)) }
+            : nil
+        return VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("团队共享资源包")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Theme.tSecondary)
+                Spacer(minLength: 6)
+                if let remaining = shared.remaining {
+                    Text("剩余 \(Fmt.credits(remaining)) \(Self.qwenWorkUnitLabel(shared.unit))")
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Theme.tPrimary)
+                }
+            }
+            Text("共享包独立展示，不计入上方个人积分")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+            if let total = shared.total, total > 0 {
+                let used = shared.used.map(Fmt.credits) ?? "?"
+                Text("已用 \(used) / 总量 \(Fmt.credits(total))")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(Theme.tTertiary)
+            }
+            if let remainingPct {
+                HStack(spacing: 6) {
+                    MiniBar(value: remainingPct, tint: remainingPct <= 15 ? .red : Theme.qwenwork)
+                    Text(String(format: "%.0f%%", remainingPct))
+                        .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(remainingPct <= 15 ? Color.red : Theme.tSecondary)
+                }
+            }
+            if let expiresAt = shared.expires_at {
+                qwenWorkDateRow("共享包到期", epoch: expiresAt)
+            }
+        }
+    }
+
+    func qwenWorkDateRow(_ label: String, epoch: Int) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "calendar")
+                .font(.system(size: 8.5))
+            Text("\(label) · \(Fmt.reset(epoch))")
+                .font(.system(size: 9.5, design: .monospaced))
+            Spacer()
+        }
+        .foregroundStyle(Theme.tTertiary)
+    }
+
+    func qwenWorkQuotaStatus(_ quota: QwenWorkQuota) -> some View {
+        let sourceLabel: String
+        switch quota.source {
+        case "mcp", "local_mcp": sourceLabel = "本机 QwenWork 接口"
+        case "cache": sourceLabel = "本地缓存"
+        default: sourceLabel = "额度数据"
+        }
+        let updated = quota.updated.map { Fmt.reset($0) } ?? "更新时间未知"
+        return HStack(spacing: 5) {
+            Image(systemName: quota.stale ? "exclamationmark.triangle.fill" : "clock")
+                .font(.system(size: 9))
+            Text("\(quota.stale ? "缓存可能已过期" : sourceLabel) · \(updated)")
+                .font(.system(size: 9.5, design: .monospaced))
+            Spacer()
+        }
+        .foregroundStyle(quota.stale ? Color.orange.opacity(0.88) : Theme.tTertiary)
+        .help("Tokei 仅通过千问办公桌面端的本机 QwenWork 接口读取额度，不读取或保存登录凭据。")
+    }
+
+    static func qwenWorkSegmentLabel(_ segment: QwenWorkQuotaSegment) -> String {
+        let key = segment.id.isEmpty ? segment.kind : segment.id
+        switch key.lowercased().replacingOccurrences(of: "-", with: "_") {
+        case "plan", "plan_credits": return "套餐积分"
+        case "addon", "add_on", "add_on_credits": return "加购积分"
+        case "shared_addon", "shared_add_on", "shared_add_on_credits": return "共享加购积分"
+        default: return key.isEmpty ? "积分" : key
+        }
+    }
+
+    static func qwenWorkUnitLabel(_ unit: String?) -> String {
+        guard let unit, !unit.isEmpty else { return "积分" }
+        return ["credit", "credits"].contains(unit.lowercased()) ? "积分" : unit
     }
 
     // MARK: - Qoder IDE 卡片
@@ -1644,6 +1852,7 @@ struct PanelView: View {
                 settingsRow("DeepSeek Harness", tint: Theme.deepseekHarness, isOn: $showDeepSeekHarness)
                 settingsRow("OpenCode", tint: Theme.opencode, isOn: $showOpenCode)
                 settingsRow("Qwen Code", tint: Theme.qwencode, isOn: $showQwenCode)
+                settingsRow("千问办公", tint: Theme.qwenwork, isOn: $showQwenWork)
             }
         }
         .onChange(of: showQoder) { enabled in
@@ -1658,9 +1867,21 @@ struct PanelView: View {
                 .font(.system(size: 8.5))
                 .foregroundStyle(Theme.tTertiary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            thinDivider
+
+            settingsToggleRow("千问办公额度查询", isOn: $qwenWorkQuotaEnabled)
+            Text("默认关闭。开启后，Tokei 仅连接千问办公桌面端在本机 127.0.0.1 提供的受保护接口；千问办公可能随之向官方服务刷新额度。Tokei 不读取或保存登录凭据，需保持千问办公已登录并运行。")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .onChange(of: grokLiveQuotaEnabled) { enabled in
             Self.setGrokLiveQuotaEnabled(enabled)
+            store.refresh()
+        }
+        .onChange(of: qwenWorkQuotaEnabled) { enabled in
+            Self.setQwenWorkQuotaEnabled(enabled)
             store.refresh()
         }
     }
@@ -1671,6 +1892,10 @@ struct PanelView: View {
 
     private static func setGrokLiveQuotaEnabled(_ enabled: Bool) {
         SyncManager.setGrokLiveQuotaEnabled(enabled)
+    }
+
+    private static func setQwenWorkQuotaEnabled(_ enabled: Bool) {
+        SyncManager.setQwenWorkQuotaEnabled(enabled)
     }
 
     /// 启动时把 UI 开关(showQoderIde)的当前值落盘到 config.json。
@@ -1685,6 +1910,12 @@ struct PanelView: View {
     static func syncGrokLiveQuotaConfigOnLaunch() {
         let enabled = UserDefaults.standard.object(forKey: "grokLiveQuotaEnabled") as? Bool ?? false
         setGrokLiveQuotaEnabled(enabled)
+    }
+
+    /// 启动时同步千问办公额度开关（默认关）。
+    static func syncQwenWorkQuotaConfigOnLaunch() {
+        let enabled = UserDefaults.standard.object(forKey: "qwenWorkQuotaEnabled") as? Bool ?? false
+        setQwenWorkQuotaEnabled(enabled)
     }
 
     var settingsPricingSection: some View {
@@ -2309,7 +2540,7 @@ struct PanelView: View {
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             let tools = ["claude", "codex", "gemini", "grok", "qoder", "qoderwork", "hermes",
                          "zcode", "mimocode", "openclaw", "pi", "workbuddy", "deepseek_harness",
-                         "opencode", "qwencode"]
+                         "opencode", "qwencode", "qwenwork"]
                 .filter { json[$0] != nil }
                 .joined(separator: ",")
             lines.append("json: ok tools: \(tools)")

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -238,6 +238,24 @@ final class SyncManager {
         } ?? false
     }
 
+    /// 千问办公额度：默认关闭，只允许 Python 采集器查询本机 QwenWork MCP 适配器。
+    @discardableResult
+    static func setQwenWorkQuotaEnabled(_ enabled: Bool) -> Bool {
+        withConfigLock {
+            var dictionary: [String: Any] = [:]
+            if FileManager.default.fileExists(atPath: configPath.path) {
+                let data = try Data(contentsOf: configPath)
+                guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                dictionary = object
+            }
+            dictionary["qwenwork_quota_enabled"] = enabled
+            try writeConfigDictionary(dictionary)
+            return true
+        } ?? false
+    }
+
     // MARK: - Read peers
 
     func loadPeers() -> PeerLoadReport {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -249,10 +249,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior = .applicationDefined
         popover.animates = true
 
-        // 启动时先把 Qoder IDE / Grok 实时额度开关落盘到 config.json,
+        // 启动时先把 Qoder IDE / Grok / 千问办公额度开关落盘到 config.json,
         // 确保随后的 refresh() 触发的 Python 扫描能读到正确配置。
         PanelView.syncQoderIdeConfigOnLaunch()
         PanelView.syncGrokLiveQuotaConfigOnLaunch()
+        PanelView.syncQwenWorkQuotaConfigOnLaunch()
         if var syncConfig = store.syncManager.config {
             let interval = SyncManager.normalizedSyncInterval(syncConfig.sync_interval)
             if syncConfig.sync_interval != interval {

--- a/Tokei/Tests/SyncManagerIntegrationCheck.swift
+++ b/Tokei/Tests/SyncManagerIntegrationCheck.swift
@@ -53,6 +53,7 @@ private enum SyncManagerIntegrationCheck {
                 try? FileManager.default.removeItem(at: root)
             }
         }
+        try testQwenWorkAbsoluteQuotaDecoding()
         try testForeignRebaseStopsBeforeSnapshotOrCommit()
         try testDetachedHeadStopsBeforeSnapshot()
         try testSecondTransactionCannotEnterLockedRepository()
@@ -69,7 +70,38 @@ private enum SyncManagerIntegrationCheck {
         try testSaveConfigRejectsDeviceIdentityChangeInIsolatedHome()
         try testInheritedGitDirectoryCannotRedirectSync()
         try testPeerLoaderReportsBadFilesIndependently()
-        print("SyncManager integration checks passed: 16")
+        print("SyncManager integration checks passed: 17")
+    }
+
+    private static func testQwenWorkAbsoluteQuotaDecoding() throws {
+        let payload = #"""
+        {
+          "available": true,
+          "remaining": 2100,
+          "remaining_pct": null,
+          "exceeded": false,
+          "is_team": false,
+          "segments": [{
+            "id": "plan",
+            "kind": "plan_credits",
+            "total": 0,
+            "used": 0,
+            "remaining": 2100,
+            "percentage_used": null,
+            "unit": "credits"
+          }],
+          "source": "mcp",
+          "updated": 1786650000,
+          "stale": false
+        }
+        """#
+        let quota = try JSONDecoder().decode(QwenWorkQuota.self, from: Data(payload.utf8))
+        try expect(quota.available, "QwenWork absolute quota did not decode as available")
+        try expect(quota.remaining == 2100, "QwenWork remaining credits changed during decode")
+        try expect(quota.remaining_pct == nil, "missing QwenWork percentage became a value")
+        try expect(quota.segments.count == 1 && quota.segments[0].total == 0
+                       && quota.segments[0].percentage_used == nil,
+                   "QwenWork total=0 absolute-balance contract changed")
     }
 
     private static func testForeignRebaseStopsBeforeSnapshotOrCommit() throws {

--- a/tests/test_qwenwork_quota.py
+++ b/tests/test_qwenwork_quota.py
@@ -1,0 +1,372 @@
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from .test_codex_limits import USAGE
+except ImportError:
+    from test_codex_limits import USAGE
+
+
+class QwenWorkQuotaTests(unittest.TestCase):
+    def setUp(self):
+        self.old_home = USAGE.QWENWORK_HOME
+        self.old_config = USAGE.QWENWORK_MCP_CONFIG
+        self.old_status = USAGE.QWENWORK_STATUS
+        self.old_cache = USAGE.QWENWORK_QUOTA_CACHE
+        self.old_user = USAGE._USER_DIR
+        self.old_env = {
+            key: USAGE.os.environ.get(key)
+            for key in ("TOKEI_QWENWORK_QUOTA", "TOKEI_QWENWORK_HOME")
+        }
+        for key in self.old_env:
+            USAGE.os.environ.pop(key, None)
+
+    def tearDown(self):
+        USAGE.QWENWORK_HOME = self.old_home
+        USAGE.QWENWORK_MCP_CONFIG = self.old_config
+        USAGE.QWENWORK_STATUS = self.old_status
+        USAGE.QWENWORK_QUOTA_CACHE = self.old_cache
+        USAGE._USER_DIR = self.old_user
+        for key, value in self.old_env.items():
+            if value is None:
+                USAGE.os.environ.pop(key, None)
+            else:
+                USAGE.os.environ[key] = value
+
+    def configure(self, root, *, enabled=True, url="http://127.0.0.1:54365"):
+        USAGE.QWENWORK_HOME = str(root / ".qwenworkcn")
+        USAGE.QWENWORK_MCP_CONFIG = str(root / ".qwenworkcn" / "mcp-adaptor.config")
+        USAGE.QWENWORK_STATUS = str(root / ".qwenworkcn" / ".status.json")
+        USAGE.QWENWORK_QUOTA_CACHE = str(root / ".tokei" / "qwenwork_quota_cache.json")
+        USAGE._USER_DIR = str(root / ".tokei")
+        Path(USAGE.QWENWORK_HOME).mkdir(parents=True, exist_ok=True)
+        Path(USAGE._USER_DIR).mkdir(parents=True, exist_ok=True)
+        Path(USAGE._USER_DIR, "config.json").write_text(
+            json.dumps({"qwenwork_quota_enabled": enabled}), encoding="utf-8")
+        token = "a" * 64
+        config_path = Path(USAGE.QWENWORK_MCP_CONFIG)
+        config_path.write_text(json.dumps({"url": url, "token": token}), encoding="utf-8")
+        config_path.chmod(0o600)
+        status_path = Path(USAGE.QWENWORK_STATUS)
+        status_path.write_text("{}", encoding="utf-8")
+        status_path.chmod(0o600)
+        return token
+
+    @staticmethod
+    def usage_payload(data):
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "structuredContent": {
+                    "ok": True,
+                    "key": "qwenwork.usage",
+                    "data": data,
+                }
+            },
+        }
+
+    @staticmethod
+    def real_shape():
+        return {
+            "available": True,
+            "aggregateRemainingPercent": None,
+            "isQuotaExceeded": False,
+            "expiresAt": None,
+            "planExpiration": None,
+            "segments": [{
+                "id": "plan",
+                "kind": "plan_credits",
+                "total": 0,
+                "used": 0,
+                "remaining": 2100,
+                "percentageUsed": 0,
+                "unit": "credits",
+                "renewsAt": None,
+                "planExpiration": None,
+            }],
+            # These aliases mirror the segment and must not be added again.
+            "planCredits": {
+                "total": 0,
+                "used": 0,
+                "remaining": 2100,
+                "percentage": 0,
+                "unit": "credits",
+            },
+            "addOnCredits": None,
+            "sharedResourcePackage": None,
+            "sharedAddOnCredits": None,
+            "isTeamPlan": False,
+        }
+
+    def test_disabled_by_default_never_calls_local_adapter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root, enabled=False)
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc") as rpc:
+                self.assertEqual(USAGE.scan_qwenwork_quota(), {})
+                rpc.assert_not_called()
+
+    def test_environment_can_force_enable_or_disable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root, enabled=True)
+            with mock.patch.dict(USAGE.os.environ, {"TOKEI_QWENWORK_QUOTA": "0"}):
+                self.assertFalse(USAGE._qwenwork_quota_enabled())
+            Path(USAGE._USER_DIR, "config.json").write_text(
+                json.dumps({"qwenwork_quota_enabled": False}), encoding="utf-8")
+            with mock.patch.dict(USAGE.os.environ, {"TOKEI_QWENWORK_QUOTA": "1"}):
+                self.assertTrue(USAGE._qwenwork_quota_enabled())
+
+    def test_config_requires_private_regular_file_and_strict_loopback_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            token = self.configure(root)
+            config = USAGE._read_qwenwork_mcp_config()
+            self.assertEqual(config["port"], 54365)
+            self.assertEqual(config["token"], token)
+            self.assertNotIn(token, config["marker"])
+
+            path = Path(USAGE.QWENWORK_MCP_CONFIG)
+            path.chmod(0o644)
+            self.assertIsNone(USAGE._read_qwenwork_mcp_config())
+            path.chmod(0o600)
+            path.write_text(json.dumps({
+                "url": "http://localhost:54365", "token": token,
+            }), encoding="utf-8")
+            path.chmod(0o600)
+            self.assertIsNone(USAGE._read_qwenwork_mcp_config())
+
+            path.unlink()
+            target = root / "capability.json"
+            target.write_text(json.dumps({
+                "url": "http://127.0.0.1:54365", "token": token,
+            }), encoding="utf-8")
+            target.chmod(0o600)
+            path.symlink_to(target)
+            self.assertIsNone(USAGE._read_qwenwork_mcp_config())
+
+    def test_normalizes_real_shape_without_double_counting_alias(self):
+        quota = USAGE._normalize_qwenwork_usage(self.real_shape(), updated=1_786_650_000)
+        self.assertTrue(quota["available"])
+        self.assertEqual(quota["remaining"], 2100)
+        self.assertIsNone(quota["remaining_pct"])
+        self.assertEqual(len(quota["segments"]), 1)
+        self.assertEqual(quota["segments"][0]["remaining"], 2100)
+        self.assertIsNone(quota["segments"][0]["percentage_used"])
+        self.assertFalse(quota["exceeded"])
+        self.assertFalse(quota["stale"])
+
+    def test_alias_fallback_and_shared_package_stay_separate(self):
+        quota = USAGE._normalize_qwenwork_usage({
+            "available": True,
+            "aggregateRemainingPercent": "72.5",
+            "planCredits": {
+                "remaining": "100", "total": 500, "percentage": 80, "unit": "credits",
+            },
+            "addOnCredits": {
+                "remaining": 40, "total": 100, "percentage": 60, "unit": "credits",
+            },
+            "sharedResourcePackage": {
+                "cap": 10000, "used": 2500, "remaining": 7500,
+                "percentage": 25, "unit": "requests",
+            },
+            "isTeamPlan": True,
+        })
+        self.assertEqual(quota["remaining"], 140)
+        self.assertEqual(quota["remaining_pct"], 72.5)
+        self.assertEqual(quota["shared"]["remaining"], 7500)
+        self.assertEqual(quota["shared"]["unit"], "requests")
+        self.assertTrue(quota["is_team"])
+
+    def test_shared_add_on_alias_is_not_added_to_personal_balance(self):
+        quota = USAGE._normalize_qwenwork_usage({
+            "available": True,
+            "planCredits": {"remaining": 100, "total": 500, "unit": "credits"},
+            "sharedAddOnCredits": {
+                "remaining": 700, "total": 1000, "percentage": 30, "unit": "credits",
+            },
+        })
+        self.assertEqual(quota["remaining"], 100)
+        self.assertEqual(len(quota["segments"]), 1)
+        self.assertEqual(quota["shared"]["remaining"], 700)
+
+    def test_invalid_numbers_are_dropped_and_percentages_clamped(self):
+        quota = USAGE._normalize_qwenwork_usage({
+            "available": True,
+            "aggregateRemainingPercent": 140,
+            "segments": [{
+                "id": "plan", "kind": "plan_credits", "unit": "credits",
+                "remaining": float("nan"), "total": -3, "percentageUsed": -20,
+            }],
+        })
+        self.assertEqual(quota["remaining_pct"], 100)
+        self.assertIsNone(quota["remaining"])
+        self.assertEqual(quota["segments"][0]["total"], 0)
+        self.assertIsNone(quota["segments"][0]["percentage_used"])
+
+    def test_non_credit_segments_are_not_added_to_personal_balance(self):
+        quota = USAGE._normalize_qwenwork_usage({
+            "available": True,
+            "segments": [
+                {"id": "plan", "kind": "plan_credits", "remaining": 100,
+                 "unit": "credits"},
+                {"id": "requests", "kind": "plan_credits", "remaining": 7500,
+                 "unit": "requests"},
+            ],
+        })
+        self.assertEqual(quota["remaining"], 100)
+        self.assertEqual(len(quota["segments"]), 2)
+
+    def test_extracts_structured_and_text_mcp_envelopes(self):
+        data = self.real_shape()
+        self.assertEqual(
+            USAGE._qwenwork_mcp_data(self.usage_payload(data))["segments"][0]["remaining"],
+            2100,
+        )
+        text_payload = {
+            "result": {"content": [{
+                "type": "text",
+                "text": json.dumps({"ok": True, "key": "qwenwork.usage", "data": data}),
+            }]}
+        }
+        self.assertEqual(
+            USAGE._qwenwork_mcp_data(text_payload)["planCredits"]["remaining"], 2100)
+        wrong_key = self.usage_payload(data)
+        wrong_key["result"]["structuredContent"]["key"] = "qwenwork.account"
+        self.assertIsNone(USAGE._qwenwork_mcp_data(wrong_key))
+
+    def test_rpc_posts_only_fixed_read_resource_and_parses_sse(self):
+        token = "b" * 64
+        payload = self.usage_payload(self.real_shape())
+        body = ("event: message\ndata: " + json.dumps(payload) + "\n\n").encode("utf-8")
+
+        class FakeResponse:
+            status = 200
+
+            def read(self, _limit):
+                return body
+
+            def getheader(self, _name):
+                return "text/event-stream"
+
+        class FakeConnection:
+            def __init__(self, host, port, timeout):
+                self.host, self.port, self.timeout = host, port, timeout
+                self.request_args = None
+
+            def request(self, *args, **kwargs):
+                self.request_args = (args, kwargs)
+
+            def getresponse(self):
+                return FakeResponse()
+
+            def close(self):
+                pass
+
+        connection = FakeConnection("", 0, 0)
+        with mock.patch("http.client.HTTPConnection", return_value=connection):
+            result = USAGE._qwenwork_mcp_rpc({"port": 54365, "token": token})
+
+        self.assertEqual(result["result"]["structuredContent"]["key"], "qwenwork.usage")
+        args, kwargs = connection.request_args
+        self.assertEqual(args[0:2], ("POST", "/"))
+        request_json = json.loads(kwargs["body"])
+        self.assertEqual(request_json["method"], "tools/call")
+        self.assertEqual(request_json["params"], {
+            "name": "qw_query", "arguments": {"key": "qwenwork.usage"},
+        })
+        self.assertEqual(kwargs["headers"]["x-api-key"], token)
+
+    def test_scan_writes_private_token_free_cache_and_reuses_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            token = self.configure(root)
+            payload = self.usage_payload(self.real_shape())
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc", return_value=payload) as rpc:
+                quota = USAGE.scan_qwenwork_quota()
+                self.assertEqual(quota["remaining"], 2100)
+                self.assertEqual(rpc.call_count, 1)
+
+            cache_path = Path(USAGE.QWENWORK_QUOTA_CACHE)
+            cache_text = cache_path.read_text(encoding="utf-8")
+            self.assertNotIn(token, cache_text)
+            self.assertEqual(stat.S_IMODE(cache_path.stat().st_mode), 0o600)
+
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc") as rpc:
+                cached = USAGE.scan_qwenwork_quota()
+                rpc.assert_not_called()
+            self.assertEqual(cached["remaining"], 2100)
+            self.assertEqual(cached["source"], "mcp")
+            self.assertFalse(cached["stale"])
+
+    def test_failed_refresh_uses_matching_short_fallback_as_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            payload = self.usage_payload(self.real_shape())
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc", return_value=payload):
+                USAGE.scan_qwenwork_quota()
+
+            cache_path = Path(USAGE.QWENWORK_QUOTA_CACHE)
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            cached["fetched_at"] = USAGE.datetime.now().timestamp() - 400
+            cache_path.write_text(json.dumps(cached), encoding="utf-8")
+            cache_path.chmod(0o600)
+
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc", return_value=None) as rpc:
+                fallback = USAGE.scan_qwenwork_quota()
+            self.assertEqual(rpc.call_count, 2)
+            self.assertEqual(fallback["remaining"], 2100)
+            self.assertEqual(fallback["source"], "cache")
+            self.assertTrue(fallback["stale"])
+
+    def test_status_generation_change_invalidates_fresh_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            with mock.patch.object(
+                    USAGE, "_qwenwork_mcp_rpc",
+                    return_value=self.usage_payload(self.real_shape())):
+                USAGE.scan_qwenwork_quota()
+
+            Path(USAGE.QWENWORK_STATUS).write_text('{"generation":2}', encoding="utf-8")
+            Path(USAGE.QWENWORK_STATUS).chmod(0o600)
+            changed = self.real_shape()
+            changed["segments"][0]["remaining"] = 500
+            changed["planCredits"]["remaining"] = 500
+            with mock.patch.object(
+                    USAGE, "_qwenwork_mcp_rpc",
+                    return_value=self.usage_payload(changed)) as rpc:
+                quota = USAGE.scan_qwenwork_quota()
+            self.assertEqual(rpc.call_count, 1)
+            self.assertEqual(quota["remaining"], 500)
+
+    def test_unavailable_account_clears_previous_quota(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.configure(root)
+            with mock.patch.object(
+                    USAGE, "_qwenwork_mcp_rpc",
+                    return_value=self.usage_payload(self.real_shape())):
+                USAGE.scan_qwenwork_quota()
+
+            cache_path = Path(USAGE.QWENWORK_QUOTA_CACHE)
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            cached["fetched_at"] = USAGE.datetime.now().timestamp() - 400
+            cache_path.write_text(json.dumps(cached), encoding="utf-8")
+            cache_path.chmod(0o600)
+            unavailable = self.usage_payload({"available": False})
+            with mock.patch.object(USAGE, "_qwenwork_mcp_rpc", return_value=unavailable) as rpc:
+                self.assertEqual(USAGE.scan_qwenwork_quota(), {})
+            self.assertEqual(rpc.call_count, 1)
+            self.assertFalse(cache_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -8,6 +8,8 @@
 # 数据主要读自本地会话日志,不改动任何 CLI；Codex 额度会短缓存查询官方 live usage。
 # Grok 额度默认只读本地 unified.jsonl billing 日志；实时账单接口需显式开启
 # (config grok_live_quota_enabled 或 TOKEI_GROK_LIVE_QUOTA=1)。
+# 千问办公额度同样默认关闭；开启后仅访问官方桌面端的 127.0.0.1 MCP 适配器，
+# 不读取或解密账号凭据 (config qwenwork_quota_enabled 或 TOKEI_QWENWORK_QUOTA=1)。
 # 仅 --update-prices 显式联网更新价格表:
 #   Claude Code: ~/.claude/projects/<proj>/<session>.jsonl  (assistant 行 message.usage,增量)
 #   Codex:       ~/.codex/{sessions,archived_sessions}/**/rollout-*.jsonl (token_count 事件,含额度)
@@ -125,6 +127,10 @@ OMP_SESSION_DIR = os.path.expanduser(os.environ.get(
     "OMP_CODING_AGENT_SESSION_DIR", os.path.join(HOME, ".omp", "agent", "sessions")))
 QWEN_CODE_DIR = os.path.abspath(os.path.expanduser(
     os.environ.get("QWEN_HOME", os.path.join(HOME, ".qwen"))))
+QWENWORK_HOME = os.path.abspath(os.path.expanduser(
+    os.environ.get("TOKEI_QWENWORK_HOME", os.path.join(HOME, ".qwenworkcn"))))
+QWENWORK_MCP_CONFIG = os.path.join(QWENWORK_HOME, "mcp-adaptor.config")
+QWENWORK_STATUS = os.path.join(QWENWORK_HOME, ".status.json")
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _USER_DIR = os.path.join(HOME, ".tokei")
@@ -149,6 +155,7 @@ CODEX_QUOTA_CACHE = _writable_path("codex_quota_cache.json")
 CODEX_RESET_CARDS_CACHE = _writable_path("codex_reset_cards_cache.json")
 CLAUDE_QUOTA_CACHE = _writable_path("claude_quota_cache.json")
 GROK_QUOTA_CACHE = _writable_path("grok_quota_cache.json")
+QWENWORK_QUOTA_CACHE = _writable_path("qwenwork_quota_cache.json")
 
 # 每 1M token 美元单价。基准价来自 OpenRouter,外置在 pricing.json(由 --update-prices 同步);
 # pricing_overrides.json 做本地修正(write1h / 别名 / 缺漏),一键更新不覆盖它。
@@ -3354,6 +3361,409 @@ def scan_grok_quota():
     return {}
 
 
+# ---------- 千问办公额度 (官方桌面端本机 MCP；需显式开启) ----------
+# 千问办公负责登录、token 刷新和服务端额度请求。Tokei 只调用它监听在
+# 127.0.0.1 的只读 qwenwork.usage 资源，不读取 auth-v2.dat 或浏览器 Cookie。
+_QWENWORK_QUOTA_TTL = 300
+_QWENWORK_QUOTA_FALLBACK_TTL = 3600
+_QWENWORK_MCP_TIMEOUT = 3
+_QWENWORK_MCP_MAX_CONFIG_BYTES = 16 * 1024
+_QWENWORK_MCP_MAX_RESPONSE_BYTES = 1024 * 1024
+_QWENWORK_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def _qwenwork_quota_enabled():
+    """默认关闭；开启后千问办公可能通过自己的登录态访问官方额度接口。"""
+    env = os.environ.get("TOKEI_QWENWORK_QUOTA")
+    if env == "0":
+        return False
+    if env == "1":
+        return True
+    return bool(_tokei_config().get("qwenwork_quota_enabled"))
+
+
+def _read_qwenwork_mcp_config(path=None):
+    """读取千问办公本机 MCP capability，拒绝宽权限文件和非 loopback URL。"""
+    import stat
+    from urllib.parse import urlsplit
+
+    config_path = path or QWENWORK_MCP_CONFIG
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = None
+    try:
+        fd = os.open(config_path, flags)
+        info = os.fstat(fd)
+        if (not stat.S_ISREG(info.st_mode)
+                or info.st_size <= 0
+                or info.st_size > _QWENWORK_MCP_MAX_CONFIG_BYTES):
+            return None
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            return None
+        # x-api-key 可调用适配器的其他工具；只信任当前用户私有的 0600 风格文件。
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8") as fh:
+            fd = None
+            config = json.load(fh)
+    except Exception:
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    if not isinstance(config, dict):
+        return None
+    url = config.get("url")
+    token = config.get("token")
+    if not isinstance(url, str) or not isinstance(token, str):
+        return None
+    try:
+        parsed = urlsplit(url.strip())
+        port = parsed.port
+    except ValueError:
+        return None
+    if (parsed.scheme != "http" or parsed.hostname != "127.0.0.1"
+            or parsed.username is not None or parsed.password is not None
+            or port is None or not 1 <= port <= 65535
+            or parsed.path not in ("", "/") or parsed.query or parsed.fragment):
+        return None
+    token = token.strip()
+    if re.fullmatch(r"[0-9a-fA-F]{64}", token) is None:
+        return None
+    mtime_ns = getattr(info, "st_mtime_ns", int(info.st_mtime * 1_000_000_000))
+    # .status.json 内容含账号资料，Tokei 不读取；仅把其文件 generation 纳入
+    # cache marker，使登录、退出或切换账号后的快照不会沿用旧额度。
+    status_marker = _qwenwork_private_file_marker(QWENWORK_STATUS)
+    marker = f"{info.st_dev}:{info.st_ino}:{mtime_ns}:{port}:{status_marker}"
+    return {"port": port, "token": token, "marker": marker}
+
+
+def _qwenwork_private_file_marker(path):
+    """只读取私有普通文件的元数据 generation，不读取文件内容。"""
+    import stat
+
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return "missing"
+    if (not stat.S_ISREG(info.st_mode)
+            or (hasattr(os, "getuid") and info.st_uid != os.getuid())
+            or stat.S_IMODE(info.st_mode) & 0o077):
+        return "untrusted"
+    mtime_ns = getattr(info, "st_mtime_ns", int(info.st_mtime * 1_000_000_000))
+    return f"{info.st_dev}:{info.st_ino}:{mtime_ns}:{info.st_size}"
+
+
+def _qwenwork_mcp_rpc(config):
+    """固定调用 qwenwork.usage；http.client 不使用代理，也不会跟随重定向。"""
+    import http.client
+
+    request_body = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "qw_query",
+            "arguments": {"key": "qwenwork.usage"},
+        },
+    }, separators=(",", ":")).encode("utf-8")
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", config["port"], timeout=_QWENWORK_MCP_TIMEOUT)
+    try:
+        connection.request("POST", "/", body=request_body, headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "User-Agent": "Tokei",
+            "x-api-key": config["token"],
+        })
+        response = connection.getresponse()
+        if response.status != 200:
+            return None
+        payload = response.read(_QWENWORK_MCP_MAX_RESPONSE_BYTES + 1)
+        if len(payload) > _QWENWORK_MCP_MAX_RESPONSE_BYTES:
+            return None
+        text = payload.decode("utf-8")
+        content_type = (response.getheader("Content-Type") or "").lower()
+        if "text/event-stream" in content_type:
+            for line in text.splitlines():
+                if line.startswith("data:"):
+                    candidate = line[5:].strip()
+                    if candidate:
+                        return json.loads(candidate)
+            return None
+        return json.loads(text)
+    except Exception:
+        return None
+    finally:
+        connection.close()
+
+
+def _qwenwork_mcp_data(payload):
+    if not isinstance(payload, dict):
+        return None
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return None
+    envelope = result.get("structuredContent")
+    if not isinstance(envelope, dict):
+        # Older MCP clients may expose the same JSON envelope as text content.
+        for item in result.get("content") or []:
+            if not isinstance(item, dict) or not isinstance(item.get("text"), str):
+                continue
+            try:
+                candidate = json.loads(item["text"])
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(candidate, dict):
+                envelope = candidate
+                break
+    if not isinstance(envelope, dict) or envelope.get("ok") is False:
+        return None
+    if envelope.get("key") not in (None, "qwenwork.usage"):
+        return None
+    data = envelope.get("data")
+    if isinstance(data, dict):
+        return data
+    # Be tolerant if a future adapter returns the resource body directly.
+    if any(key in envelope for key in ("available", "segments", "planCredits")):
+        return envelope
+    return None
+
+
+def _qwenwork_number(value, *, percent=False):
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    upper = 100.0 if percent else 1_000_000_000_000_000.0
+    return min(upper, max(0.0, number))
+
+
+def _qwenwork_epoch(value):
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if not math.isfinite(float(value)):
+            return None
+        epoch = float(value)
+        if epoch > 1_000_000_000_000:
+            epoch /= 1000
+        return int(epoch) if 0 < epoch < 253_402_300_800 else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        try:
+            return _qwenwork_epoch(float(stripped))
+        except ValueError:
+            return _iso_to_epoch(stripped)
+    return None
+
+
+def _qwenwork_safe_name(value, default):
+    value = str(value or "").strip()
+    return value if _QWENWORK_SAFE_NAME_RE.fullmatch(value) else default
+
+
+def _normalize_qwenwork_segment(item, index, *, default_id=None, default_kind=None):
+    if not isinstance(item, dict):
+        return None
+    segment_id = _qwenwork_safe_name(
+        item.get("id"), default_id or f"segment_{index + 1}")
+    kind = _qwenwork_safe_name(
+        item.get("kind"), default_kind or segment_id)
+    unit = item.get("unit")
+    unit = _qwenwork_safe_name(unit, "") if unit is not None else None
+    if not unit:
+        unit = None
+    total = _qwenwork_number(item.get("total"))
+    percentage_used = _qwenwork_number(
+        item.get("percentageUsed", item.get("percentage")), percent=True)
+    # total=0 means the denominator is unknown in current QwenWork responses.
+    # Keep the absolute balance, but do not turn percentageUsed=0 into a fake 100% remaining bar.
+    if total is None or total <= 0:
+        percentage_used = None
+    out = {
+        "id": segment_id,
+        "kind": kind,
+        "total": total,
+        "used": _qwenwork_number(item.get("used")),
+        "remaining": _qwenwork_number(item.get("remaining")),
+        "percentage_used": percentage_used,
+        "unit": unit,
+        "renews_at": _qwenwork_epoch(item.get("renewsAt", item.get("renews_at"))),
+        "expires_at": _qwenwork_epoch(item.get(
+            "expiresAt", item.get("planExpiration", item.get("expires_at")))),
+    }
+    if all(out.get(key) is None for key in ("total", "used", "remaining", "percentage_used")):
+        return None
+    return out
+
+
+def _normalize_qwenwork_shared(item):
+    if not isinstance(item, dict):
+        return None
+    unit = item.get("unit")
+    unit = _qwenwork_safe_name(unit, "") if unit is not None else None
+    if not unit:
+        unit = None
+    total = _qwenwork_number(
+        item.get("total", item.get("cap", item.get("allowance"))))
+    percentage_used = _qwenwork_number(
+        item.get("percentageUsed", item.get("percentage")), percent=True)
+    if total is None or total <= 0:
+        percentage_used = None
+    out = {
+        "total": total,
+        "used": _qwenwork_number(item.get("used")),
+        "remaining": _qwenwork_number(item.get("remaining")),
+        "percentage_used": percentage_used,
+        "unit": unit,
+        "expires_at": _qwenwork_epoch(item.get("expiresAt", item.get("expires_at"))),
+    }
+    numeric_keys = ("total", "used", "remaining", "percentage_used", "expires_at")
+    return out if any(out.get(key) is not None for key in numeric_keys) else None
+
+
+def _normalize_qwenwork_usage(data, *, updated=None):
+    if not isinstance(data, dict) or data.get("available") is False:
+        return None
+
+    segments = []
+    raw_segments = data.get("segments")
+    if isinstance(raw_segments, list):
+        for index, item in enumerate(raw_segments[:8]):
+            segment = _normalize_qwenwork_segment(item, index)
+            if segment:
+                segments.append(segment)
+
+    # planCredits/addOnCredits are mirrors of segments, never sum both shapes.
+    if not segments:
+        aliases = (
+            ("planCredits", "plan", "plan_credits"),
+            ("addOnCredits", "add_on", "add_on_credits"),
+        )
+        for key, segment_id, kind in aliases:
+            segment = _normalize_qwenwork_segment(
+                data.get(key), len(segments), default_id=segment_id, default_kind=kind)
+            if segment:
+                segments.append(segment)
+
+    remaining_values = []
+    for segment in segments:
+        unit = (segment.get("unit") or "").lower()
+        kind = segment.get("kind") or ""
+        is_credit = (unit in ("credit", "credits")) if unit else "credit" in kind.lower()
+        if segment.get("remaining") is not None and is_credit:
+            remaining_values.append(segment["remaining"])
+    remaining = sum(remaining_values) if remaining_values else None
+    if remaining is None:
+        remaining = _qwenwork_number(data.get("remaining", data.get("balance")))
+
+    remaining_pct = _qwenwork_number(data.get("aggregateRemainingPercent"), percent=True)
+    shared_source = data.get("sharedResourcePackage")
+    if not isinstance(shared_source, dict):
+        shared_source = data.get("sharedAddOnCredits")
+    shared = _normalize_qwenwork_shared(shared_source)
+    if remaining is None and remaining_pct is None and not segments and shared is None:
+        return None
+    return {
+        "available": True,
+        "remaining": remaining,
+        "remaining_pct": remaining_pct,
+        "exceeded": data.get("isQuotaExceeded") is True,
+        "is_team": data.get("isTeamPlan") is True,
+        "expires_at": _qwenwork_epoch(data.get("expiresAt")),
+        "plan_expiration": _qwenwork_epoch(data.get("planExpiration")),
+        "segments": segments,
+        "shared": shared,
+        "source": "mcp",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def _cached_qwenwork_quota(config_marker, max_age, *, stale=False):
+    cached = _load_json(QWENWORK_QUOTA_CACHE, {})
+    if not isinstance(cached, dict) or cached.get("config_marker") != config_marker:
+        return None
+    quota = cached.get("quota")
+    fetched_at = cached.get("fetched_at")
+    if not isinstance(quota, dict) or fetched_at is None:
+        return None
+    try:
+        age = datetime.now().timestamp() - float(fetched_at)
+    except (TypeError, ValueError):
+        return None
+    if age < -60 or age > max_age:
+        return None
+    out = dict(quota)
+    if stale:
+        out["source"] = "cache"
+        out["stale"] = True
+    return out
+
+
+def _save_qwenwork_quota_cache(quota, config_marker):
+    if not isinstance(quota, dict) or not quota.get("available"):
+        return
+    try:
+        _atomic_write_json(QWENWORK_QUOTA_CACHE, {
+            "fetched_at": datetime.now().timestamp(),
+            "config_marker": config_marker,
+            "quota": quota,
+        })
+        os.chmod(QWENWORK_QUOTA_CACHE, 0o600)
+    except Exception:
+        pass
+
+
+def _clear_qwenwork_quota_cache():
+    try:
+        os.remove(QWENWORK_QUOTA_CACHE)
+    except OSError:
+        pass
+
+
+def scan_qwenwork_quota():
+    """读取千问办公官方本机额度资源；不可用时静默降级，不自动启动客户端。"""
+    if not _qwenwork_quota_enabled():
+        return {}
+    config = _read_qwenwork_mcp_config()
+    if not config:
+        return {}
+    cached = _cached_qwenwork_quota(config["marker"], _QWENWORK_QUOTA_TTL)
+    if cached:
+        return cached
+
+    latest_config = config
+    for attempt in range(2):
+        if attempt:
+            latest_config = _read_qwenwork_mcp_config()
+            if not latest_config:
+                break
+        payload = _qwenwork_mcp_rpc(latest_config)
+        data = _qwenwork_mcp_data(payload)
+        if isinstance(data, dict) and data.get("available") is False:
+            _clear_qwenwork_quota_cache()
+            return {}
+        quota = _normalize_qwenwork_usage(data)
+        if quota:
+            _save_qwenwork_quota_cache(quota, latest_config["marker"])
+            return quota
+
+    fallback = _cached_qwenwork_quota(
+        latest_config["marker"], _QWENWORK_QUOTA_FALLBACK_TTL, stale=True)
+    return fallback or {}
+
+
 def scan_grok(bounds, cache=None):
     ledger_touch("grok")
     cache = cache if cache is not None else {"v": _SCAN_CACHE_VERSION}
@@ -6127,6 +6537,8 @@ def compute():
 
     plan = _safe_scan("claude_plan", scan_claude_plan, lambda: {}, errors) or {}
     grok_quota = _safe_scan("grok_quota", scan_grok_quota, lambda: {}, errors) or {}
+    qwenwork_quota = _safe_scan(
+        "qwenwork_quota", scan_qwenwork_quota, lambda: {}, errors) or {}
     codex_reset_cards = _safe_scan(
         "codex_reset_cards", fetch_codex_reset_cards, lambda: {}, errors) or {}
 
@@ -6162,6 +6574,7 @@ def compute():
             "q_updated": grok_quota.get("updated"),
             "stale": grok_quota.get("stale"),
         },
+        "qwenwork": qwenwork_quota,
         "qoderwork": {
             "ranges": qwranges,
             "model": qd.get("model"),


### PR DESCRIPTION
## Summary

- add opt-in quota tracking for QwenWork / 千问办公 as a product separate from Qwen Code
- query the official desktop app's loopback MCP adapter with the fixed `qw_query({key: "qwenwork.usage"})` resource
- normalize personal plan, add-on, and shared quota data, then show absolute credits in a dedicated card
- document the data source, calculation semantics, privacy boundary, cache behavior, and failure modes

## Why

QwenWork exposes quota data through its desktop client, but its shape does not fit Tokei's existing percentage-only providers. A real response can legitimately report `total=0`, `remaining=2100`, and `aggregateRemainingPercent=null`. This change preserves the absolute remaining credits without inventing a percentage or mixing QwenWork into the existing Qwen Code model.

## Data source and behavior

The collector reads `~/.qwenworkcn/mcp-adaptor.config` on every refresh and calls the desktop app's local adapter only when QwenWork is installed, running, and logged in. The query is disabled by default and can be enabled through Tokei settings or `TOKEI_QWENWORK_QUOTA=1`.

The collector:

- never starts QwenWork automatically
- never reads browser cookies or decrypts Electron `safeStorage`
- uses only `http://127.0.0.1:<port>` and bypasses system proxies
- hard-codes the JSON-RPC method, tool name, and resource key
- does not follow redirects and applies a 3-second timeout plus a 1 MiB response limit
- treats missing, stale, logged-out, or incompatible responses as unavailable without blocking other collectors

Invoking the local adapter may cause QwenWork itself to contact its official quota service, which is why the feature remains opt-in.

## Privacy and cache

- the adapter config must be a current-user-owned regular file with private permissions; symlinks and group/other access are rejected
- the local API key is used only for the loopback request and is never logged, returned, or cached
- cached quota metadata is written with mode `0600`; explicit unavailable/logout state clears older cache
- account-state invalidation uses only private `.status.json` file metadata and never reads that file's contents
- fresh cache is valid for 5 minutes, with a bounded 1-hour stale fallback when the local adapter is temporarily unavailable

## Quota semantics and UI

- `segments` is canonical; `planCredits` and `addOnCredits` are compatibility fallbacks only
- shared resource packages are displayed separately and are never added to personal remaining credits
- `total=0` keeps absolute remaining credits but suppresses percentage rendering
- the card uses `aggregateRemainingPercent` only when the desktop app provides it
- QwenWork is not used as a percentage source for the menu-bar quota ranking when that percentage is unknown

## Validation

- QwenWork Python tests: 14/14 passed
- `python3 -m py_compile usage.30s.py`: passed
- Swift package build: passed
- SyncManager integration checks: 17/17 passed
- isolated live collector check: available, 2100 remaining credits, null aggregate/segment percentage, no shared package
- `git diff --check`: passed
- full Python discovery: 145 tests with 16 failures; pristine upstream runs 131 tests with the same 16 failures, so this change adds no new full-suite failures

## Risk and compatibility

The loopback MCP resource belongs to the official QwenWork desktop app, but it is not a public or versioned API. A future desktop release may change the config or response shape. Parsing is intentionally defensive, failures degrade to unavailable, and the integration is disabled by default.
