### PR TITLE
feat: support Antigravity CLI usage tracking via SQLite protobuf parsing

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -9,8 +9,7 @@ Tokei 读取本地 AI CLI 工具的日志,统计 token 用量与成本。所有�
 | 工具 | 日志路径 | 格式 |
 |------|---------|------|
 | Claude Code | `~/.claude/*/*.jsonl` | JSONL, `type=assistant` 行含 `message.usage` |
-| Codex | `~/.codex/**/rollout-*.jsonl` | JSONL, `payload.info.last_token_usage` |
-| Gemini CLI | `~/.gemini/*/chats/session-*.json` | JSON, `messages[].tokens` |
+| Gemini / Antigravity CLI | `~/.gemini/antigravity-cli/conversations/*.db` / `~/.gemini/*/chats/session-*.json` | SQLite (`gen_metadata` protobuf) / JSON (`messages[].tokens`) |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl` + `sessions/*/*/{summary,signals}.json` | JSONL, `shell.turn.inference_done` + 会话指标 |
 | Qoder | `~/Library/Application Support/QoderWork/data/agents.db` | SQLite, `messages.metadata` |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `session_model_usage*` 用量表，回退 `sessions` 表 |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **12 款 AI 编�
 |------|----------|
 | **Claude Code** | Token（输入/输出/缓存）、成本、配额、模型 |
 | **Codex CLI** | Token、成本、配额、会话 |
-| **Gemini CLI** | Token、思考量、成本、模型 |
+| **Gemini / Antigravity CLI** | Token、思考量、成本、模型 |
 | **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟、配额（本地日志；可选实时） |
 | **Hermes** | Token、成本、缓存命中率、模型 |
 | **OpenClaw** | Token、成本、任务、模型 |
@@ -154,7 +154,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 |------|----------|
 | Claude Code | `~/.claude/projects/<proj>/<session>.jsonl` |
 | Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
-| Gemini CLI | `~/.gemini/gemini-cli/conversations/*.json` |
+| Gemini / Antigravity CLI | `~/.gemini/antigravity-cli/conversations/*.db` + `~/.gemini/gemini-cli/conversations/*.json` |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl`（含真实 token + billing 额度）+ `sessions/*/*/{summary,signals}.json`；可选实时账单接口（设置里默认关闭） |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -516,11 +516,11 @@ struct PanelView: View {
         }
     }
 
-    // MARK: - Gemini 卡片
+    // MARK: - Gemini / Antigravity 卡片
     @ViewBuilder
     func geminiBlock(_ r: GeminiRange) -> some View {
         VStack(alignment: .leading, spacing: 11) {
-            cardHead("Gemini CLI", tint: Theme.gemini, sessions: r.sessions)
+            cardHead("Gemini / Antigravity", tint: Theme.gemini, sessions: r.sessions)
             if r.sessions > 0 {
                 CostHeadline(value: Fmt.human(r.in + r.cached + r.out + r.thoughts), caption: "\(sel.label) 总量", tint: Theme.gemini)
                 metricGrid([.init("dollarsign.circle", "≈成本", String(format: "$%.2f", r.cost))],
@@ -1630,7 +1630,7 @@ struct PanelView: View {
                                 GridItem(.flexible(), spacing: 7)], spacing: 7) {
                 settingsRow("Claude", tint: Theme.claude, isOn: $showClaude)
                 settingsRow("Codex", tint: Theme.codex, isOn: $showCodex)
-                settingsRow("Gemini", tint: Theme.gemini, isOn: $showGemini)
+                settingsRow("Gemini / Antigravity", tint: Theme.gemini, isOn: $showGemini)
                 settingsRow("Grok", tint: Theme.grok, isOn: $showGrok)
                 settingsRow("Qoder Desktop", tint: Theme.qoder, isOn: $showQoder)
                 settingsRow("QoderWork", tint: Theme.qoderwork, isOn: $showQoderWork)

--- a/tests/test_gemini_usage.py
+++ b/tests/test_gemini_usage.py
@@ -5,7 +5,19 @@ from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
-from test_codex_limits import USAGE
+try:
+    from .test_codex_limits import USAGE
+except ImportError:
+    from test_codex_limits import USAGE
+
+
+def isolate_ledger(testcase):
+    USAGE._LEDGER_CACHE.update({"data": None, "dirty": False})
+    patcher = mock.patch.object(
+        USAGE, "_load_ledger_from_disk",
+        return_value={"v": USAGE._LEDGER_VERSION, "tools": {}})
+    patcher.start()
+    testcase.addCleanup(patcher.stop)
 
 
 def gemini_message(message_id, input_tokens, timestamp, model="gemini-3.5-flash"):
@@ -19,6 +31,15 @@ def gemini_message(message_id, input_tokens, timestamp, model="gemini-3.5-flash"
 
 
 class GeminiUsageTests(unittest.TestCase):
+    def setUp(self):
+        isolate_ledger(self)
+        self.old_dir = USAGE.GEMINI_DIR
+        self.old_dirs = USAGE.GEMINI_DIRS
+
+    def tearDown(self):
+        USAGE.GEMINI_DIR = self.old_dir
+        USAGE.GEMINI_DIRS = self.old_dirs
+
     def test_jsonl_updates_nested_subagents_and_migration_dedup(self):
         with tempfile.TemporaryDirectory() as tmp:
             chats = Path(tmp) / "project" / "chats"
@@ -49,18 +70,15 @@ class GeminiUsageTests(unittest.TestCase):
             (nested / "sub-session.jsonl").write_text(
                 "\n".join(json.dumps(item) for item in sub_records) + "\n", encoding="utf-8")
 
-            old_dir = USAGE.GEMINI_DIR
             USAGE.GEMINI_DIR = tmp
-            try:
-                cache = {"v": USAGE._SCAN_CACHE_VERSION}
-                result = USAGE.scan_gemini(USAGE.range_bounds(), cache)
-                with mock.patch.object(
-                    USAGE, "_load_gemini_usage_file",
-                    side_effect=AssertionError("unchanged Gemini files were reparsed"),
-                ):
-                    cached = USAGE.scan_gemini(USAGE.range_bounds(), cache)
-            finally:
-                USAGE.GEMINI_DIR = old_dir
+            USAGE.GEMINI_DIRS = [tmp]
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            result = USAGE.scan_gemini(USAGE.range_bounds(), cache)
+            with mock.patch.object(
+                USAGE, "_load_gemini_usage_file",
+                side_effect=AssertionError("unchanged Gemini files were reparsed"),
+            ):
+                cached = USAGE.scan_gemini(USAGE.range_bounds(), cache)
 
         usage = result["ranges"]["all"]
         self.assertEqual(usage["in"], 1150)
@@ -91,6 +109,88 @@ class GeminiUsageTests(unittest.TestCase):
         self.assertEqual(len(parsed["events"]), 1)
         self.assertEqual(parsed["events"][0]["id"], "three")
         self.assertEqual(parsed["events"][0]["tokens"]["input"], 40)
+
+    def test_antigravity_sqlite_protobuf_parsing_and_scan(self):
+        def encode_varint(val):
+            res = bytearray()
+            while True:
+                b = val & 0x7F
+                val >>= 7
+                if val:
+                    res.append(b | 0x80)
+                else:
+                    res.append(b)
+                    break
+            return bytes(res)
+
+        def encode_proto_field(field_num, wire_type, val):
+            key = (field_num << 3) | wire_type
+            if wire_type == 0:
+                return encode_varint(key) + encode_varint(val)
+            elif wire_type == 2:
+                if isinstance(val, str):
+                    val = val.encode("utf-8")
+                return encode_varint(key) + encode_varint(len(val)) + val
+            raise NotImplementedError
+
+        def make_gen_step(model, inp, out, cached, thoughts, ts_sec):
+            tok_sub = (encode_proto_field(2, 0, inp) +
+                       encode_proto_field(3, 0, out) +
+                       encode_proto_field(5, 0, cached) +
+                       encode_proto_field(9, 0, thoughts))
+            time_sub = encode_proto_field(4, 2, encode_proto_field(1, 0, ts_sec))
+            sub1 = (encode_proto_field(19, 2, model) +
+                    encode_proto_field(4, 2, tok_sub) +
+                    encode_proto_field(9, 2, time_sub))
+            return encode_proto_field(1, 2, sub1)
+
+        import sqlite3
+        with tempfile.TemporaryDirectory() as tmp:
+            conv_dir = Path(tmp) / "antigravity-cli" / "conversations"
+            conv_dir.mkdir(parents=True)
+            db_path = conv_dir / "session-12345.db"
+
+            now_sec = int(datetime.now().astimezone().timestamp())
+            step0 = make_gen_step("gemini-3.7-flash", inp=200, out=50, cached=800, thoughts=20, ts_sec=now_sec)
+            step1 = make_gen_step("gemini-3.7-flash", inp=500, out=100, cached=1200, thoughts=40, ts_sec=now_sec + 10)
+
+            conn = sqlite3.connect(str(db_path))
+            conn.execute("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER)")
+            conn.execute("INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)", (step0, len(step0)))
+            conn.execute("INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)", (step1, len(step1)))
+            conn.commit()
+            conn.close()
+
+            # Test _load_antigravity_db directly
+            parsed = USAGE._load_antigravity_db(str(db_path))
+            self.assertIsNotNone(parsed)
+            self.assertEqual(parsed["sid"], "session-12345")
+            self.assertEqual(len(parsed["events"]), 2)
+            self.assertEqual(parsed["events"][0]["tokens"]["input"], 1000)  # 200 + 800 cached
+            self.assertEqual(parsed["events"][0]["tokens"]["cached"], 800)
+            self.assertEqual(parsed["events"][0]["tokens"]["output"], 50)
+            self.assertEqual(parsed["events"][0]["tokens"]["thoughts"], 20)
+            self.assertEqual(parsed["events"][1]["tokens"]["input"], 1700)  # 500 + 1200 cached
+
+            # Test full scan_gemini integration and cache
+            USAGE.GEMINI_DIR = str(conv_dir)
+            USAGE.GEMINI_DIRS = [str(conv_dir)]
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            result = USAGE.scan_gemini(USAGE.range_bounds(), cache)
+            with mock.patch.object(
+                USAGE, "_load_antigravity_db",
+                side_effect=AssertionError("unchanged Antigravity DB was reparsed"),
+            ):
+                cached_res = USAGE.scan_gemini(USAGE.range_bounds(), cache)
+
+            usage = result["ranges"]["all"]
+            self.assertEqual(usage["in"], 2700)  # total prompt tokens = 1000 + 1700
+            self.assertEqual(usage["cached"], 2000)  # 800 + 1200
+            self.assertEqual(usage["out"], 150)  # 50 + 100
+            self.assertEqual(usage["thoughts"], 60)  # 20 + 40
+            self.assertEqual(usage["sessions"], {"session-12345"})
+            self.assertEqual(cached_res["ranges"]["all"]["in"], 2700)
+            self.assertTrue(cache["_dirty"])
 
 
 if __name__ == "__main__":

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -23,7 +23,8 @@ import hashlib
 import json
 import math
 import re
-from datetime import datetime, timedelta, date
+import sqlite3
+from datetime import datetime, timedelta, date, timezone
 from pathlib import Path
 
 HOME = os.path.expanduser("~")
@@ -80,9 +81,14 @@ CODEX_DIR = os.path.join(HOME, ".codex", "sessions")
 CODEX_ARCHIVED_DIR = os.path.join(HOME, ".codex", "archived_sessions")
 CODEX_AUTH = os.path.join(HOME, ".codex", "auth.json")
 GEMINI_DIR = os.path.join(HOME, ".gemini", "tmp")
+ANTIGRAVITY_DIR = os.path.join(HOME, ".gemini", "antigravity-cli", "conversations")
 GEMINI_DIRS = _path_candidates(
     "TOKEI_GEMINI_DIR", GEMINI_DIR,
-    os.path.join(HOME, ".gemini", "gemini-cli", "conversations"))
+    ANTIGRAVITY_DIR,
+    os.path.join(HOME, ".gemini", "antigravity", "conversations"),
+    os.path.join(HOME, ".gemini", "antigravity-ide", "conversations"),
+    os.path.join(HOME, ".gemini", "gemini-cli", "conversations"),
+    *([os.environ["TOKEI_ANTIGRAVITY_DIR"]] if "TOKEI_ANTIGRAVITY_DIR" in os.environ else []))
 GROK_HOME = os.path.abspath(os.path.expanduser(
     os.environ.get("GROK_HOME", os.path.join(HOME, ".grok"))))
 GROK_DIR = os.path.join(GROK_HOME, "sessions")
@@ -2679,16 +2685,20 @@ def _codex_quota_values(limits, now_epoch=None):
     return values
 
 
-# ---------- Gemini CLI ----------
-# 日志:~/.gemini/tmp/<projectHash>/chats/{session-*.json,session-*.jsonl,<parent>/*.jsonl}
-# assistant 行 type=="gemini",tokens={input,output,cached,thoughts,total}
-# (total=input+output+thoughts,cached⊂input)。JSONL 是追加日志，同消息 ID 以后写入的记录覆盖之前记录。
+# ---------- Gemini / Antigravity CLI ----------
+# 日志:
+# - Gemini CLI: ~/.gemini/tmp/<projectHash>/chats/{session-*.json,session-*.jsonl,<parent>/*.jsonl}
+#   assistant 行 type=="gemini",tokens={input,output,cached,thoughts,total}
+# - Antigravity CLI: ~/.gemini/antigravity-cli/conversations/<uuid>.db
+#   gen_metadata 表存储 protobuf 逐步生成指标(包含 input, output, cached, thoughts, model, start_time)
 def _gemini_session_files():
     files = []
     roots = _path_candidates("TOKEI_GEMINI_DIR", GEMINI_DIR, *GEMINI_DIRS)
     patterns = []
     for root in roots:
         patterns.extend((
+            os.path.join(root, "*.db"),
+            os.path.join(root, "**", "*.db"),
             os.path.join(root, "*", "chats", "session-*.json"),
             os.path.join(root, "*", "chats", "**", "*.jsonl"),
             os.path.join(root, "**", "session-*.json"),
@@ -2696,7 +2706,128 @@ def _gemini_session_files():
         ))
     for pattern in patterns:
         files.extend(glob.glob(pattern, recursive=True))
-    return sorted(set(os.path.realpath(path) for path in files if os.path.isfile(path)))
+    return sorted(set(os.path.realpath(path) for path in files
+                      if os.path.isfile(path) and not path.endswith("conversation_summaries.db")))
+
+
+def _decode_proto_varint(data, offset):
+    val = 0
+    shift = 0
+    while offset < len(data):
+        b = data[offset]
+        offset += 1
+        val |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            break
+        shift += 7
+    return val, offset
+
+
+def _parse_proto_fields(data):
+    i = 0
+    fields = []
+    while i < len(data):
+        try:
+            key, i = _decode_proto_varint(data, i)
+        except Exception:
+            break
+        field_num = key >> 3
+        wire_type = key & 0x7
+        if wire_type == 0:
+            val, i = _decode_proto_varint(data, i)
+            fields.append((field_num, 0, val))
+        elif wire_type == 1:
+            val = data[i:i + 8]
+            i += 8
+            fields.append((field_num, 1, val))
+        elif wire_type == 2:
+            length, i = _decode_proto_varint(data, i)
+            val = data[i:i + length]
+            i += length
+            fields.append((field_num, 2, val))
+        elif wire_type == 5:
+            val = data[i:i + 4]
+            i += 4
+            fields.append((field_num, 5, val))
+        else:
+            break
+    return fields
+
+
+def _load_antigravity_db(path):
+    """从 Antigravity conversations/*.db 的 gen_metadata 表解析逐步 token 用量"""
+    events = []
+    max_ts = ""
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        cursor = conn.cursor()
+        cursor.execute("SELECT idx, data FROM gen_metadata ORDER BY idx ASC")
+        for idx, data in cursor.fetchall():
+            if not data:
+                continue
+            top = _parse_proto_fields(data)
+            for fn, wt, val in top:
+                if fn == 1 and wt == 2:
+                    sub1 = _parse_proto_fields(val)
+                    model = "unknown"
+                    inp = 0
+                    out = 0
+                    cached = 0
+                    thoughts = 0
+                    ts_sec = None
+                    for sfn, swt, sval in sub1:
+                        if sfn == 19 and swt == 2:
+                            try:
+                                model = sval.decode("utf-8")
+                            except Exception:
+                                pass
+                        elif sfn == 4 and swt == 2:
+                            for tfn, twt, tval in _parse_proto_fields(sval):
+                                if twt == 0:
+                                    if tfn == 2:
+                                        inp = tval
+                                    elif tfn == 3:
+                                        out = tval
+                                    elif tfn == 5:
+                                        cached = tval
+                                    elif tfn == 9:
+                                        thoughts = tval
+                        elif sfn == 9 and swt == 2:
+                            for tfn, twt, tval in _parse_proto_fields(sval):
+                                if tfn == 4 and twt == 2:
+                                    for stfn, stwt, stval in _parse_proto_fields(tval):
+                                        if stfn == 1 and stwt == 0:
+                                            ts_sec = stval
+                    if ts_sec:
+                        iso_ts = datetime.fromtimestamp(ts_sec, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                        if iso_ts > max_ts:
+                            max_ts = iso_ts
+                        events.append({
+                            "id": f"{os.path.basename(path)}:{idx}",
+                            "timestamp": iso_ts,
+                            "model": model,
+                            "tokens": {
+                                "input": inp + cached,
+                                "output": out,
+                                "cached": cached,
+                                "thoughts": thoughts,
+                            },
+                        })
+        conn.close()
+    except Exception:
+        return None
+
+    if not events:
+        return None
+    sid = os.path.basename(path)
+    if sid.endswith(".db"):
+        sid = sid[:-3]
+    return {
+        "sid": sid,
+        "updated": max_ts,
+        "rank": 3,
+        "events": events,
+    }
 
 
 def _gemini_apply_messages(message_map, messages, replace=False):
@@ -2715,6 +2846,8 @@ def _gemini_apply_messages(message_map, messages, replace=False):
 
 
 def _load_gemini_usage_file(path):
+    if path.endswith(".db"):
+        return _load_antigravity_db(path)
     metadata = {}
     messages = {}
     rank = 2 if path.endswith(".jsonl") else 1
@@ -6498,10 +6631,10 @@ def main():
     if x["plan"]:
         print(f"plan: {x['plan']} {F}")
     print("---")
-    # Gemini 块
+    # Gemini / Antigravity 块
     g = d["gemini"]
     gt = g["ranges"]["today"]
-    print(f"Gemini CLI {HEAD}")
+    print(f"Gemini / Antigravity {HEAD}")
     print(f"命中率   {gt['hit']:5.1f}% {F}")
     print(f"今日 输入   {human(gt['in']):>6} {F}")
     print(f"今日 输出   {human(gt['out']):>6} {F}")


### PR DESCRIPTION
## Summary
- Resolves #47
- Resolves #59

支持 Google **Antigravity CLI**（以及 Antigravity IDE / 2.0 架构）的本地 token 用量采集与展示。

### 背景与问题
1. 原有的 Gemini 扫描逻辑依赖早期 `gemini-cli` 的会话日志（`~/.gemini/tmp/<hash>/chats/session-*.json`），并且要求 `type == "gemini"`。
2. Antigravity 全面升级后，数据存放于 `~/.gemini/antigravity-cli/conversations/<uuid>.db`（SQLite），每次生成的 token 指标以二进制 Protobuf 格式存储在 `gen_metadata` 表中。
3. 导致 Antigravity CLI 的实际使用量在 Tokei 中无法被读取和统计（Issue #47, Issue #59）。

### 实现方案
1. **多目录与 DB 发现**：
   - 扩充 `_gemini_session_files()`，支持扫描 `~/.gemini/antigravity-cli/conversations/*.db`、`~/.gemini/antigravity/conversations/*.db` 及 `~/.gemini/antigravity-ide/conversations/*.db`，并保留 `TOKEI_ANTIGRAVITY_DIR` / `TOKEI_GEMINI_DIR` 自定义环境变量覆盖。
2. **轻量级 Protobuf 变长字节解析**：
   - 编写纯 Python 的 Protobuf wire-format 解码（零外部依赖），安全以只读模式（`mode=ro`）查询 SQLite `gen_metadata` 表。
   - 解析模型名称（`gemini-3.7-flash`、`gemini-3.6-flash`、`gemini-3-flash-a`、`gemini-3.7-pro` 等）、输入 tokens、缓存 tokens、输出 tokens、思考量 tokens 及生成时间戳。
3. **缓存与性能**：
   - 沿用 Tokei 的 `mtime_ns` + `size` 文件签名机制，避免重复解析已处理的数据库。
4. **UI 与文案**：
   - 卡片与设置文案平滑升级为 `Gemini / Antigravity`，向下兼容现有数据模型。
5. **测试覆盖**：
   - 在 `tests/test_gemini_usage.py` 中增加 SQLite + Protobuf 逐步指标解析及端到端 `scan_gemini` 增量缓存测试，测试全部通过。

Closes #47
Closes #59