### PR TITLE
fix(ui): 收紧订阅状态卡片并补充异常提示

### DIFF
--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -22,12 +22,17 @@ struct PanelView: View {
     @State private var mode: PanelMode = .cards
     @State private var trailProjects: [TrailProject]?
     enum PanelMode { case cards, quotaHistory, dashboard, projects, settings }
+    private enum ToolCardPresentation: Equatable {
+        case standard
+        case compactStatus
+    }
     private struct ToolCardItem: Identifiable {
         let id: String
         let name: String
         let visible: Bool
         let active: Bool
         let tint: Color
+        var presentation: ToolCardPresentation = .standard
         let content: AnyView
     }
     @AppStorage("showClaude") private var showClaude = true
@@ -290,11 +295,22 @@ struct PanelView: View {
         let wr = u.workbuddy.ranges.get(sel), or = u.opencode.ranges.get(sel)
         let dshr = u.deepseekHarness.ranges.get(sel)
         let qcr = u.qwencode.ranges.get(sel)
+        let claudeQuotaState = SubscriptionQuotaState.resolve([
+            (value: u.claude.q5, stale: u.claude.q5_stale),
+            (value: u.claude.q7, stale: u.claude.q7_stale),
+            (value: u.claude.qf, stale: u.claude.qf_stale),
+        ])
+        let grokQuotaState = SubscriptionQuotaState.resolve([
+            (value: u.grok.pct, stale: u.grok.stale),
+        ])
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude,
                          active: cr.sessions > 0 || u.claude.q5 != nil ||
                              u.claude.q7 != nil || u.claude.qf != nil,
-                         tint: Theme.claude, content: AnyView(claudeBlock(u.claude, cr))),
+                         tint: Theme.claude,
+                         presentation: claudeQuotaState.shouldUseCompactCard(hasUsage: cr.sessions > 0)
+                             ? .compactStatus : .standard,
+                         content: AnyView(claudeBlock(u.claude, cr))),
             ToolCardItem(id: "codex", name: "Codex", visible: showCodex,
                          active: xr.sessions > 0 || u.codex.p5 != nil || u.codex.pw != nil ||
                              (u.codex.reset_cards?.count ?? 0) > 0,
@@ -303,7 +319,11 @@ struct PanelView: View {
                          tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
             ToolCardItem(id: "grok", name: "Grok", visible: showGrok,
                          active: kr.sessions > 0 || kr.usage_calls > 0 || u.grok.pct != nil,
-                         tint: Theme.grok, content: AnyView(grokBlock(u.grok, kr))),
+                         tint: Theme.grok,
+                         presentation: grokQuotaState.shouldUseCompactCard(
+                            hasUsage: kr.sessions > 0 || kr.usage_calls > 0
+                         ) ? .compactStatus : .standard,
+                         content: AnyView(grokBlock(u.grok, kr))),
             ToolCardItem(id: "qoder", name: "Qoder Desktop", visible: showQoder, active: qr.calls > 0,
                          tint: Theme.qoder, content: AnyView(qoderIdeBlock(u.qoder, qr))),
             ToolCardItem(id: "qoderwork", name: "QoderWork", visible: showQoderWork, active: qwr.calls > 0,
@@ -338,28 +358,51 @@ struct PanelView: View {
 
     @ViewBuilder
     private func toolCardsLayout(_ cards: [ToolCardItem]) -> some View {
+        let compactCards = cards.filter { $0.presentation == .compactStatus }
+        let standardCards = cards.filter { $0.presentation == .standard }
         if useWide {
-            EqualHeightGrid() {
-                ForEach(cards) { item in
-                    Card(tint: item.tint) { item.content }
-                        .id(cardContentIdentity(for: item))
+            VStack(spacing: 13) {
+                if !compactCards.isEmpty {
+                    EqualHeightGrid(columns: compactCards.count == 1 ? 1 : 2) {
+                        ForEach(compactCards) { item in
+                            Card(tint: item.tint) { item.content }
+                                .id(cardContentIdentity(for: item))
+                        }
+                    }
+                }
+                if !standardCards.isEmpty {
+                    EqualHeightGrid() {
+                        ForEach(standardCards) { item in
+                            Card(tint: item.tint) { item.content }
+                                .id(cardContentIdentity(for: item))
+                        }
+                    }
                 }
             }
         } else {
-            ForEach(cards) { item in
-                Card(tint: item.tint) { item.content }
-                    .id(cardContentIdentity(for: item))
+            VStack(spacing: 13) {
+                ForEach(compactCards + standardCards) { item in
+                    Card(tint: item.tint) { item.content }
+                        .id(cardContentIdentity(for: item))
+                }
             }
         }
     }
 
     private func cardContentIdentity(for item: ToolCardItem) -> String {
-        "\(item.id):\(sel.rawValue):\(store.syncEnabled):\(store.showAllDevices)"
+        let presentation = item.presentation == .compactStatus ? "compact" : "standard"
+        return "\(item.id):\(presentation):\(sel.rawValue):\(store.syncEnabled):\(store.showAllDevices)"
     }
 
     // MARK: - Claude 卡片
     @ViewBuilder
     func claudeBlock(_ c: ClaudeStat, _ r: ClaudeRange) -> some View {
+        let quotaState = SubscriptionQuotaState.resolve([
+            (value: c.q5, stale: c.q5_stale),
+            (value: c.q7, stale: c.q7_stale),
+            (value: c.qf, stale: c.qf_stale),
+        ])
+        let compactExpired = quotaState.shouldUseCompactCard(hasUsage: r.sessions > 0)
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Claude Code", tint: Theme.claude, sessions: r.sessions)
             if r.sessions > 0 {
@@ -381,10 +424,20 @@ struct PanelView: View {
                 if !claudeRows.isEmpty {
                     modelDisclosure(claudeRows, open: $claudeModelsOpen, tint: Theme.claude)
                 }
-            } else {
-                emptyHint
+            } else if !compactExpired && quotaState != .unavailable {
+                usageEmptyHint
             }
-            if c.q5 != nil || c.q7 != nil || c.qf != nil {
+
+            if compactExpired {
+                quotaStateNotice(
+                    title: "额度数据已过期",
+                    detail: "等待 Claude Code 写入新的额度缓存，恢复后将自动展示。",
+                    source: "Claude Code 本地缓存",
+                    updated: c.q_updated,
+                    tint: Theme.claude,
+                    warning: true
+                )
+            } else if quotaState != .unavailable {
                 thinDivider
                 if let q5 = c.q5, c.q5_stale != true {
                     quotaRow(title: "5h 剩余", pct: 100 - q5, reset: c.q5_reset, tint: Theme.claude)
@@ -395,7 +448,27 @@ struct PanelView: View {
                 if let qf = c.qf, c.qf_stale != true {
                     quotaRow(title: "周 · Fable 剩余", pct: 100 - qf, reset: c.qf_reset, tint: .orange)
                 }
-                claudeQuotaStatus(c)
+                if quotaState == .expired {
+                    quotaStateNotice(
+                        title: "额度数据已过期",
+                        detail: "当前用量仍可查看；新额度缓存写入后会自动恢复。",
+                        source: "Claude Code 本地缓存",
+                        updated: c.q_updated,
+                        tint: Theme.claude,
+                        warning: true
+                    )
+                } else {
+                    claudeQuotaStatus(c)
+                }
+            } else if r.sessions > 0 {
+                thinDivider
+                quotaStateNotice(
+                    title: "暂未获取到额度数据",
+                    detail: "用量统计不受影响；检测到订阅额度后会自动展示。",
+                    source: "Claude Code 本地缓存",
+                    updated: c.q_updated,
+                    tint: Theme.claude
+                )
             }
         }
     }
@@ -403,6 +476,7 @@ struct PanelView: View {
     // MARK: - Codex 卡片
     @ViewBuilder
     func codexBlock(_ x: CodexStat, _ r: CodexRange) -> some View {
+        let hasQuotaData = x.p5 != nil || x.pw != nil || (x.reset_cards?.count ?? 0) > 0
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Codex", tint: Theme.codex, sessions: r.sessions)
             if r.sessions > 0 {
@@ -421,11 +495,14 @@ struct PanelView: View {
                     tokenModelDisclosure(r.models, open: $codexModelsOpen, tint: Theme.codex,
                                          reasonIncludedInOutput: true)
                 }
-            } else {
-                emptyHint
+            } else if hasQuotaData {
+                usageEmptyHint
             }
-            if x.pw != nil || (x.reset_cards?.count ?? 0) > 0 {
+            if hasQuotaData {
                 thinDivider
+            }
+            if let p5 = x.p5 {
+                quotaRow(title: "5h 剩余", pct: 100 - p5, reset: x.r5, tint: Theme.codex)
             }
             if let pw = x.pw {
                 quotaRow(title: "周剩余", pct: 100 - pw, reset: x.rw, tint: Theme.codex)
@@ -443,6 +520,16 @@ struct PanelView: View {
                         .padding(.horizontal, 7).padding(.vertical, 2)
                         .background(Capsule().fill(Theme.codex.opacity(0.16)))
                 }
+            }
+            if r.sessions > 0 && !hasQuotaData {
+                thinDivider
+                quotaStateNotice(
+                    title: "暂未获取到额度数据",
+                    detail: "用量统计不受影响；检测到订阅周期后会自动展示。",
+                    source: "Codex 本地状态",
+                    updated: nil,
+                    tint: Theme.codex
+                )
             }
         }
     }
@@ -552,9 +639,14 @@ struct PanelView: View {
     // MARK: - Grok 卡片
     @ViewBuilder
     func grokBlock(_ g: GrokStat, _ r: GrokRange) -> some View {
+        let hasUsage = r.sessions > 0 || r.usage_calls > 0
+        let quotaState = SubscriptionQuotaState.resolve([
+            (value: g.pct, stale: g.stale),
+        ])
+        let compactExpired = quotaState.shouldUseCompactCard(hasUsage: hasUsage)
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Grok", tint: Theme.grok, sessions: r.sessions)
-            if r.sessions > 0 || r.usage_calls > 0 {
+            if hasUsage {
                 CostHeadline(value: Fmt.human(r.tokens),
                              caption: r.usage_available ? "\(sel.label) 真实用量" : "\(sel.label) 上下文快照",
                              tint: Theme.grok)
@@ -609,11 +701,21 @@ struct PanelView: View {
                     .font(.system(size: 8.5))
                     .foregroundStyle(Theme.tTertiary)
                     .fixedSize(horizontal: false, vertical: true)
-            } else if g.pct == nil {
-                emptyHint
+            } else if !compactExpired && quotaState != .unavailable {
+                usageEmptyHint
             }
-            if let pct = g.pct, g.stale != true {
-                if r.sessions > 0 || r.usage_calls > 0 { thinDivider }
+
+            if compactExpired {
+                quotaStateNotice(
+                    title: "额度周期已结束",
+                    detail: "Grok 写入新周期日志后，将自动恢复额度展示。",
+                    source: grokQuotaSourceLabel(g.source),
+                    updated: g.q_updated,
+                    tint: Theme.grok,
+                    warning: true
+                )
+            } else if let pct = g.pct, g.stale != true {
+                if hasUsage { thinDivider }
                 let title = (g.window == "month") ? "月剩余" : "周剩余"
                 // 总剩余：同一周额度池。分产品 usagePercent 是该产品在池内的占用占比，不是独立额度剩余。
                 quotaRow(title: title, pct: 100 - pct, reset: g.reset, tint: Theme.grok)
@@ -639,22 +741,31 @@ struct PanelView: View {
                     }
                 }
                 grokQuotaStatus(g)
-            } else if g.stale == true {
-                if r.sessions > 0 || r.usage_calls > 0 { thinDivider }
-                Text("额度周期已结束，等待 Grok 写入新日志")
-                    .font(.system(size: 9.5, design: .monospaced))
-                    .foregroundStyle(Color.orange.opacity(0.88))
+            } else if quotaState == .expired {
+                if hasUsage { thinDivider }
+                quotaStateNotice(
+                    title: "额度周期已结束",
+                    detail: "当前用量仍可查看；新周期日志写入后会自动恢复。",
+                    source: grokQuotaSourceLabel(g.source),
+                    updated: g.q_updated,
+                    tint: Theme.grok,
+                    warning: true
+                )
+            } else if hasUsage {
+                thinDivider
+                quotaStateNotice(
+                    title: "暂未获取到额度数据",
+                    detail: "用量统计不受影响；检测到订阅周期后会自动展示。",
+                    source: grokQuotaSourceLabel(g.source),
+                    updated: g.q_updated,
+                    tint: Theme.grok
+                )
             }
         }
     }
 
     func grokQuotaStatus(_ stat: GrokStat) -> some View {
-        let sourceLabel: String
-        switch stat.source {
-        case "live": sourceLabel = "实时接口"
-        case "cache": sourceLabel = "本地缓存"
-        default: sourceLabel = "本地日志"
-        }
+        let sourceLabel = grokQuotaSourceLabel(stat.source)
         let updated = stat.q_updated.map { Fmt.reset($0) } ?? "更新时间未知"
         return HStack(spacing: 5) {
             Image(systemName: "clock")
@@ -667,6 +778,14 @@ struct PanelView: View {
         .help(stat.source == "live"
               ? "已开启 Grok 实时额度查询。Grok Build / API 等为同一周额度池内的占用拆分，共享上方重置时间。"
               : "默认只读 ~/.grok 本地日志，不访问网络")
+    }
+
+    private func grokQuotaSourceLabel(_ source: String?) -> String {
+        switch source {
+        case "live": return "Grok 实时接口"
+        case "cache": return "Grok 本地缓存"
+        default: return "Grok 本地日志"
+        }
     }
 
     /// 账单 product 字段 → 更可读的名称。
@@ -949,6 +1068,57 @@ struct PanelView: View {
         Text("暂无数据")
             .font(.system(size: 10))
             .foregroundStyle(Theme.tTertiary)
+    }
+
+    var usageEmptyHint: some View {
+        Text("\(sel.label)暂无用量，额度状态如下")
+            .font(.system(size: 10))
+            .foregroundStyle(Theme.tTertiary)
+    }
+
+    func quotaStateNotice(
+        title: String,
+        detail: String,
+        source: String,
+        updated: Int?,
+        tint: Color,
+        warning: Bool = false
+    ) -> some View {
+        let statusTint = warning ? Color.orange : tint
+        let updatedLabel = updated.map { "上次更新 \(Fmt.reset($0))" } ?? "尚无更新时间"
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: warning ? "exclamationmark.triangle.fill" : "info.circle.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer(minLength: 4)
+            }
+            .foregroundStyle(statusTint.opacity(0.95))
+
+            Text(detail)
+                .font(.system(size: 9.5))
+                .foregroundStyle(Theme.tSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 5) {
+                Image(systemName: "clock")
+                    .font(.system(size: 8.5))
+                Text("\(source) · \(updatedLabel)")
+                    .font(.system(size: 9, design: .monospaced))
+                Spacer(minLength: 4)
+            }
+            .foregroundStyle(Theme.tTertiary)
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(statusTint.opacity(0.07))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .strokeBorder(statusTint.opacity(0.16), lineWidth: 0.5)
+                )
+        )
     }
 
     func modelBadge(_ model: String, tint: Color) -> some View {
@@ -1332,7 +1502,7 @@ struct PanelView: View {
                         .foregroundStyle(Theme.tTertiary)
                 }
                 Spacer()
-                Text(String(format: "%.0f%%", pct))
+                Text(SubscriptionQuotaPresentation.remainingLabel(pct))
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
                     .foregroundStyle(pct <= 15 ? AnyShapeStyle(.red) : AnyShapeStyle(Theme.tPrimary))
                 // 无重置时间时不显示「· ?」，避免分产品行误导。

--- a/Tokei/Sources/Tokei/SubscriptionQuotaState.swift
+++ b/Tokei/Sources/Tokei/SubscriptionQuotaState.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum SubscriptionQuotaState: Equatable {
+    case unavailable
+    case available
+    case partiallyStale
+    case expired
+
+    static func resolve(_ windows: [(value: Double?, stale: Bool?)]) -> Self {
+        let availableWindows = windows.filter { $0.value != nil }
+        guard !availableWindows.isEmpty else { return .unavailable }
+
+        let staleCount = availableWindows.filter { $0.stale == true }.count
+        if staleCount == 0 { return .available }
+        if staleCount == availableWindows.count { return .expired }
+        return .partiallyStale
+    }
+
+    func shouldUseCompactCard(hasUsage: Bool) -> Bool {
+        self == .expired && !hasUsage
+    }
+}
+
+enum SubscriptionQuotaPresentation {
+    static func remainingLabel(_ remaining: Double) -> String {
+        let clamped = min(100, max(0, remaining))
+        return clamped < 0.5 ? "已用尽" : String(format: "%.0f%%", clamped)
+    }
+}

--- a/tests/swift/SubscriptionQuotaStateCheck.swift
+++ b/tests/swift/SubscriptionQuotaStateCheck.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+@main
+struct SubscriptionQuotaStateCheck {
+    static func main() throws {
+        try expect(
+            SubscriptionQuotaState.resolve([
+                (value: nil, stale: nil),
+                (value: nil, stale: true),
+            ]) == .unavailable,
+            "missing quota windows should be unavailable"
+        )
+        try expect(
+            SubscriptionQuotaState.resolve([
+                (value: 42, stale: false),
+                (value: 73, stale: nil),
+            ]) == .available,
+            "fresh quota windows should be available"
+        )
+        try expect(
+            SubscriptionQuotaState.resolve([
+                (value: 42, stale: false),
+                (value: 73, stale: true),
+            ]) == .partiallyStale,
+            "mixed freshness should be partially stale"
+        )
+
+        let expired = SubscriptionQuotaState.resolve([
+            (value: 100, stale: true),
+            (value: 73, stale: true),
+        ])
+        try expect(expired == .expired, "all stale quota windows should be expired")
+        try expect(expired.shouldUseCompactCard(hasUsage: false),
+                   "expired quota-only cards should be compact")
+        try expect(!expired.shouldUseCompactCard(hasUsage: true),
+                   "cards with usage should keep their full presentation")
+
+        try expect(SubscriptionQuotaPresentation.remainingLabel(0) == "已用尽",
+                   "zero remaining should use an explicit exhausted label")
+        try expect(SubscriptionQuotaPresentation.remainingLabel(-4) == "已用尽",
+                   "negative remaining should be clamped")
+        try expect(SubscriptionQuotaPresentation.remainingLabel(42.4) == "42%",
+                   "positive remaining should stay numeric")
+        try expect(SubscriptionQuotaPresentation.remainingLabel(120) == "100%",
+                   "remaining percentage should not exceed 100 percent")
+
+        print("subscription quota state checks passed")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        guard condition() else {
+            throw NSError(domain: "SubscriptionQuotaStateCheck", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: message])
+        }
+    }
+}

--- a/tests/test_subscription_quota_state.py
+++ b/tests/test_subscription_quota_state.py
@@ -1,0 +1,33 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SubscriptionQuotaStateTests(unittest.TestCase):
+    def test_swift_state_checks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "subscription-quota-state-check"
+            result = subprocess.run(
+                [
+                    "swiftc",
+                    str(ROOT / "Tokei/Sources/Tokei/SubscriptionQuotaState.swift"),
+                    str(ROOT / "tests/swift/SubscriptionQuotaStateCheck.swift"),
+                    "-o",
+                    str(binary),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            result = subprocess.run([str(binary)], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("subscription quota state checks passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

主界面宽版使用双列等高布局。当某个支持订阅周期展示的工具只有一小段状态提示，而同排另一张卡片包含完整用量统计时，前者仍会被拉伸到相同高度，形成大片无效空白。原有提示也偏向单行技术状态，缺少恢复条件、来源与更新时间等上下文。

本 PR 仅优化卡片的展示密度与状态文案，不改变采集器、网络请求、同步格式或历史数据口径。

## 实现

### 紧凑状态卡布局

- 为工具卡片增加 `standard` / `compactStatus` 两种展示类型。
- 宽版面板将紧凑状态卡与完整用量卡分组布局，避免两类内容互相拉高。
- 两张紧凑卡并排展示；只有一张时自动横跨整行，不留下半行空白。
- 卡片从紧凑状态恢复为标准状态时更新视图 identity，确保 SwiftUI 正确迁移布局。

### 统一订阅状态表达

- 新增纯 Swift 状态模型，统一识别 unavailable、available、partiallyStale、expired 四种状态。
- 无当前用量但仍有周期状态时，使用更明确的“本时段暂无用量”提示。
- 状态提示统一展示标题、恢复条件、数据来源与最后更新时间。
- 正常用量仍可展示但周期状态暂不可用时，保留完整用量卡，并在底部提供非阻断说明。
- 剩余比例归零时直接显示“已用尽”，并对异常百分比做 0–100 范围约束。

### 覆盖范围

- Claude Code
- Codex
- Grok

## 用户影响

- 轻量状态卡不再占用完整统计卡的高度，主界面首屏信息密度更合理。
- 状态原因与后续恢复方式更容易理解。
- 正常用量卡的指标、模型明细、费用与周期展示保持原有交互。
- 窄版单列布局继续按阅读顺序展示，不引入横向滚动。

## 隐私与兼容性

- 不增加网络访问。
- 不读取新的本地文件或用户信息。
- 不修改 `Usage` Codable 数据结构和多设备快照格式。
- 不修改 Python collector 或持久化账本。
- 兼容现有 macOS 13 最低系统版本。

## 验证

- `PYTHONPATH=tests python3 -m unittest test_subscription_quota_state test_quota_history test_claude_quota_cache test_grok_quota test_codex_limits`：28 项通过。
- `bash Tokei/Tests/run-sync-integration-checks.sh`：16 项通过。
- `swift build --package-path Tokei`：通过。
- `git diff --check`：通过。
- 使用本机真实数据完成离屏渲染检查：紧凑状态卡并排且高度收敛，标准卡片继续展示完整内容，文案无截断。

全量 Python discovery 在当前开发机上会读取已有持久账本，因此未作为本次纯 SwiftUI 变更的验收口径；本 PR 未修改相关 Python 采集路径。
