### PR TITLE
fix(kimi): 接入持久账本并防止 wire 重复统计

### DIFF
--- a/tests/test_kimicode.py
+++ b/tests/test_kimicode.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from datetime import datetime
@@ -187,6 +188,50 @@ class KimiCodeScanTests(unittest.TestCase):
             self.assertEqual(entry["parser_version"], USAGE._KIMI_PARSER_VERSION)
             self.assertEqual(entry["days"][now.date().isoformat()]["hours"][now.hour],
                              USAGE.token_total(entry["days"][now.date().isoformat()]))
+
+    def test_agent_wires_exclude_root_usage_mirror(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wires, _, _ = self.create_modern_session(tmp)
+            session_dir = wires[0].parents[2]
+            root_wire = session_dir / "wire.jsonl"
+            root_wire.write_text("\n".join(json.dumps(record) for record in [
+                {"type": "metadata", "protocol_version": "1.5"},
+                {
+                    "type": "usage.record",
+                    "time": int(datetime.now().timestamp() * 1000),
+                    "usageScope": "turn",
+                    "model": "moonshot/kimi-k3",
+                    "usage": {"inputOther": 9999, "output": 9999},
+                },
+            ]) + "\n", encoding="utf-8")
+
+            result, cache = self.scan(tmp)
+
+        self.assertEqual(set(cache["kimicode"]), {str(wire) for wire in wires})
+        self.assertEqual(USAGE.token_total(result["ranges"]["all"]), 230)
+
+    def test_ledger_preserves_usage_sessions_and_projects_after_wire_cleanup(self):
+        ledger = {"v": USAGE._LEDGER_VERSION, "tools": {}}
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(USAGE, "_load_ledger_from_disk", return_value=ledger):
+            _, _, project = self.create_modern_session(tmp)
+            first, cache = self.scan(tmp)
+            first_usage = first["ranges"]["all"]
+
+            stored = USAGE._load_ledger()["tools"]["kimicode"]
+            self.assertEqual(len(stored), 1)
+            stored_day = next(iter(stored.values()))
+            self.assertEqual(stored_day["sessions"], ["session-modern"])
+            self.assertEqual(stored_day["projects"], [project])
+
+            shutil.rmtree(Path(tmp) / "sessions")
+            second, cache = self.scan(tmp, cache=cache)
+
+        second_usage = second["ranges"]["all"]
+        self.assertEqual(USAGE.token_total(second_usage), USAGE.token_total(first_usage))
+        self.assertEqual(second_usage["sessions"], {"session-modern"})
+        self.assertEqual(cache["kimicode"], {})
+        self.assertIn("kimicode", ledger["tools"])
 
     def test_parser_upgrade_rescans_unchanged_modern_wires(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -6524,9 +6524,20 @@ def _kimi_wire_files():
     files = set()
     for root in _kimi_roots():
         sessions_dir = os.path.join(root, "sessions")
-        files.update(glob.glob(os.path.join(sessions_dir, "*", "*", "wire.jsonl")))
-        files.update(glob.glob(os.path.join(
-            sessions_dir, "*", "*", "agents", "*", "wire.jsonl")))
+        for session_dir in glob.glob(os.path.join(sessions_dir, "*", "*")):
+            if not os.path.isdir(session_dir):
+                continue
+            # protocol 1.5 writes authoritative per-Agent usage.record files. Some
+            # transitional versions may also leave a root wire mirror; selecting
+            # both would count the same call twice. Root wire is protocol 1 fallback.
+            agent_wires = glob.glob(os.path.join(
+                session_dir, "agents", "*", "wire.jsonl"))
+            if agent_wires:
+                files.update(agent_wires)
+                continue
+            root_wire = os.path.join(session_dir, "wire.jsonl")
+            if os.path.isfile(root_wire):
+                files.add(root_wire)
     return sorted(os.path.abspath(path) for path in files)
 
 
@@ -6672,6 +6683,7 @@ def _scan_kimi_wire(path):
 
 
 def scan_kimicode(bounds, cache):
+    ledger_touch("kimicode")
     fc = cache.setdefault("kimicode", {})
     B = _empty_token_ranges()
     files = _kimi_wire_files()
@@ -6679,7 +6691,6 @@ def scan_kimicode(bounds, cache):
         if fc:
             fc.clear()
             cache["_dirty"] = True
-        return {"ranges": B}
 
     projects = _kimi_project_map()
     stale = set(fc)
@@ -6712,16 +6723,36 @@ def scan_kimicode(bounds, cache):
         fc.pop(path, None)
         changed = True
 
+    live_days = {}
+    live_sessions = {}
+    live_projects = {}
     for path, entry in fc.items():
         if not isinstance(entry, dict):
             continue
         for day_key, day in entry.get("days", {}).items():
             try:
-                local_day = date.fromisoformat(day_key)
+                date.fromisoformat(day_key)
             except (TypeError, ValueError):
                 continue
-            for range_key in classify_date(local_day, bounds):
-                _merge_token_day(B[range_key], day, entry.get("sid") or path)
+            _merge_live_token_day(live_days.setdefault(day_key, _empty_token_day()), day)
+            session = entry.get("sid") or path
+            live_sessions.setdefault(day_key, set()).add(session)
+            project = entry.get("proj")
+            if isinstance(project, str) and project:
+                live_projects.setdefault(day_key, set()).add(project)
+
+    for day_key, day in live_days.items():
+        day["sessions"] = sorted(live_sessions.get(day_key, set()))
+        day["projects"] = sorted(live_projects.get(day_key, set()))
+
+    for day_key, day in ledger_reconcile("kimicode", live_days).items():
+        try:
+            local_day = date.fromisoformat(day_key)
+        except (TypeError, ValueError):
+            continue
+        for range_key in classify_date(local_day, bounds):
+            _merge_token_day(B[range_key], day)
+            B[range_key]["sessions"].update(day.get("sessions", []))
     if changed:
         cache["_dirty"] = True
     return {"ranges": B}


### PR DESCRIPTION
## 背景

这是 [Kimi Code 支持 PR #56](https://github.com/cclank/tokei/pull/56) 合并后的 follow-up，落实维护者在[合并评论](https://github.com/cclank/tokei/pull/56#issuecomment-5386935658)中指出的两点：

1. `scan_kimicode` 尚未接入 `ledger_touch` / `ledger_reconcile`，Kimi 历史只存在于临时 scan cache；
2. 如果未来同一会话的根 `wire.jsonl` 与 `agents/*/wire.jsonl` 同时携带 `usage.record`，现有固定深度 glob 会重复累计。

## 问题

### Kimi 历史没有进入持久账本

原实现逐个 wire 文件直接合并到 range bucket。wire 日志轮转、清理或整个会话目录消失后，对应日期会从卡片和历史统计中消失；同时 `write_sync_snapshot()` 无法在 `_ledger.tools` 中发布 Kimi 数据，多设备节点也得不到这部分高水位历史。

### 根 wire 与 Agent wire 缺少互斥规则

Kimi protocol 1 使用会话根 `wire.jsonl`；protocol 1.5 使用 `agents/<agent>/wire.jsonl`。原来的 `_kimi_wire_files()` 会无条件选择两类文件。当前 0.36.1 数据只有 Agent wire，尚未产生重复，但如果迁移版本保留根 wire 镜像，同一笔 `usage.record` 会被统计两次。

## 实现

### 1. 接入持久高水位账本

- 在 `scan_kimicode` 开始时调用 `ledger_touch("kimicode")`，即使当前没有数据也标记该 scanner 已接入账本；
- 先把所有现存 wire 的每日 Token、模型和小时桶汇总成 `live_days`；
- 每日会话 ID 去重后保存为 JSON-compatible `sessions` 列表；
- 每日项目路径去重后保存为 `projects` 列表，使日志清理后 Wrapped 仍能保留当天项目信息；
- 通过 `ledger_reconcile("kimicode", live_days)` 获得完整高水位视图；
- range bucket 从 reconciled days 构建，并恢复账本中的会话集合；
- 即使所有 Kimi wire 都消失，也不提前返回空结果，而是允许账本兜底。

### 2. 按会话互斥选择 wire

- 仍保持固定深度、有界遍历；
- 同一会话只要存在 `agents/*/wire.jsonl`，就只选择 Agent wire；
- 仅当 Agent wire 不存在时，才选择根 `wire.jsonl` 作为 protocol 1 / root-only 回退；
- 不扫描 `server/events` 等镜像目录。

这样既保留 protocol 1 和 protocol 1.5 支持，又从文件选择层消除根/Agent 镜像双算风险。

## 测试

`tests/test_kimicode.py` 新增两项回归：

- `test_agent_wires_exclude_root_usage_mirror`
  - 构造 Agent wire 与含重复 `usage.record` 的根 wire；
  - 确认 cache 只包含 Agent wire；
  - 总量仍为 230 Token，没有把根镜像的 19,998 Token 计入。
- `test_ledger_preserves_usage_sessions_and_projects_after_wire_cleanup`
  - 首次扫描把每日用量、会话和项目写入账本；
  - 删除整个 `sessions/`；
  - 再次扫描仍恢复相同 Token 和会话，scan cache 同时正确清空。

验证结果：

```text
python3 -m unittest discover -s tests -p 'test_kimicode.py' -v
Ran 8 tests
OK

HOME=<temporary-home> TMPDIR=<temporary-dir> python3 -m unittest discover -s tests -q
Ran 200 tests in 25.771s
OK

cd Tokei && swift build
Build complete

python3 -m py_compile usage.30s.py
git diff --check
```

Swift 构建仍会输出 `DashboardView.swift:646` 的既有 trailing-closure warning，与本 PR 无关。

## 真实 Kimi 0.36.1 验证

使用本机真实 Kimi Code 0.36.1 数据进行只读验证：

- 6 个会话目录；
- 13 个 protocol 1.5 Agent wire；
- wire 总大小约 22.3 MB；
- 1,718 条 `usage.record`；
- 8 个有用量的日期；
- 真实总量 `168,735,794` Token；
- 3 个有用量的会话；
- 3 个模型桶。

验证流程把 `_LEDGER_FILE`、scan cache 和同步目录全部指向临时目录，不读取或修改真实 `~/.tokei/ledger.json`：

1. 扫描真实 wire 并写入临时账本；
2. 将 Kimi 来源切换为空目录，模拟日志被全部清理；
3. 再次扫描，从账本恢复的 Token 为 `168,735,794`，与实时扫描完全一致；
4. scan cache 中 Kimi 文件条目归零；
5. 调用真实 `write_sync_snapshot()` 路径，生成的设备快照包含 `_ledger.tools.kimicode`，其 8 天合计仍为 `168,735,794` Token。

## 安全与兼容性

- 仍然只读 Kimi 本地结构化用量字段，不读取对话正文；
- 不新增网络请求、子进程、凭据读取或依赖；
- 不改变 Token 字段口径、模型展示或成本策略；
- protocol 1 根 wire、protocol 1.5 Agent wire 和 root-only protocol 1.5 都保留支持；
- 账本保存的集合均转换为排序列表，可安全写入 JSON 和同步快照。
