### PR TITLE
fix(ui): 设置页构建日期改为打包时真实注入

### DIFF
--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -2845,7 +2845,9 @@ struct PanelView: View {
         return lines.joined(separator: "\n")
     }
 
-    static let buildVersion = "2026.0615"
+    static var buildVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "TokeiBuildDate") as? String ?? "未打包"
+    }
 
     static var skillPath: String {
         return "https://raw.githubusercontent.com/cclank/tokei/main/skills/tokei-setup.md"

--- a/Tokei/package.sh
+++ b/Tokei/package.sh
@@ -9,6 +9,14 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
+# 只记录本次打包日期，不把它混入正式版本号或 CFBundleVersion。
+# 允许测试和可复现打包显式指定日期。
+BUILD_DATE="${TOKEI_BUILD_DATE:-$(date '+%Y.%m.%d')}"
+if [[ ! "$BUILD_DATE" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+    echo "构建日期格式无效，应为 YYYY.MM.DD: $BUILD_DATE" >&2
+    exit 1
+fi
+
 swift build -c release
 
 APP="Tokei.app"
@@ -40,6 +48,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleIdentifier</key><string>com.tokei.app</string>
     <key>CFBundleVersion</key><string>${VERSION}</string>
     <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>TokeiBuildDate</key><string>${BUILD_DATE}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>CFBundleExecutable</key><string>Tokei</string>
     <key>CFBundleIconFile</key><string>AppIcon</string>


### PR DESCRIPTION
## 背景

本 PR 无关联 Issue，处理设置页版本信息中已过期的硬编码构建日期。

设置页原先将两个来源拼成 `正式版本 · 构建版本`：

- `Updater.releaseTag` 是更新检查使用的正式版本，例如 `v1.0.33`。
- `PanelView.buildVersion` 是写死的 `2026.0615`。

通过 Git 历史确认，`2026.0615` 在 2026-06-15 为 v1.0.3 增加“构建日期”时写入，此后正式版本持续升级但日期没有同步，因此它已经不能代表实际构建。

## 本次实现

- `Tokei/package.sh` 在打包时生成 `YYYY.MM.DD` 格式的构建日期。
- 将日期写入 App `Info.plist` 的专用 `TokeiBuildDate` 键。
- 设置页从 `Bundle.main` 读取 `TokeiBuildDate`，不再保留源码中的日期字面量。
- 支持通过 `TOKEI_BUILD_DATE` 显式指定日期，用于确定性测试和可复现打包。
- 未打包运行 SwiftPM 可执行文件时显示 `未打包`，避免把启动时间误当作构建日期。

## 关键设计

本次选择“打包时注入真实构建日期”的方案，而不是运行时使用当前时间或展示 Git commit SHA：

1. 运行时当前时间代表启动时间，不代表构建时间。
2. Git commit SHA 适合定位源码，但对普通用户不可读；日期对人类可读性更高，也足以表达“这份安装包是什么时候构建的”。
3. 正式版本继续由 `Updater.releaseTag` 和现有的 `CFBundleShortVersionString` 管理，构建日期放在独立的 `TokeiBuildDate` 中，避免误用 Apple 的版本号字段。
4. `TOKEI_BUILD_DATE` 覆盖入口让测试可以固定日期，同时保留默认情况下由打包时刻生成真实日期的行为。

安装包最终会显示类似 `v1.0.33 · 2026.08.24`，其中日期来自该安装包的 `Info.plist`，不是源码里的过期常量。

## 用户体验

设置页展示的正式版本格式不变；右侧构建日期会反映实际打包日期。没有新增交互、网络请求或布局变化，因此未附交互录屏。

## 安全与隐私

- 只在本地打包时写入日期元数据。
- 不增加网络请求、外部进程、文件权限或日志输出。
- 不写入 Git commit、用户名、机器路径或其他环境信息。

## 兼容性与影响

- macOS 13+ 和现有 SwiftPM 打包流程保持不变。
- 更新包仍按 `Updater.releaseTag` 比较版本，升级逻辑不受影响。
- 旧安装包没有 `TokeiBuildDate`，不会被本次代码修改；从新版本开始由新的打包脚本写入该键。

## 验证

- `bash -n Tokei/package.sh`：通过。
- `swift build -c release`：通过；仅有仓库原有的未声明资源和 `DashboardView.swift` trailing-closure 警告。
- `swift test`：SwiftPM 报告仓库当前没有 test target（`no tests found`），不是本次改动引入的测试失败。
- `TOKEI_BUILD_DATE=2030.01.02 ./package.sh`：通过；生成 App 的 `Info.plist` 读取到 `TokeiBuildDate = 2030.01.02`，正式版本仍为 `1.0.33`。
- `./package.sh`：通过；默认生成的日期为当前打包日期 `2026.08.24`。
- `TOKEI_BUILD_DATE=2026.0615 ./package.sh`：按预期拒绝旧的非 `YYYY.MM.DD` 格式。
- `git diff --check`：通过。

## 已知限制

- 当前仓库没有 SwiftPM 测试目标，因此 `swift test` 无可执行测试。
- DMG 打包流程仍会输出已有的 `.background` 文件缺失提示，但本次打包和 DMG 生成成功；该提示与版本日期注入无关。

## 检查清单

- [x] 版本日期不再硬编码
- [x] 构建时注入并从 App 包读取
- [x] 正式版本号和更新逻辑保持不变
- [x] 支持确定性测试日期
- [x] 无敏感信息或无关改动
- [x] Release 构建通过
- [ ] GitHub Actions 通过
