### PR TITLE
fix(ui): 平衡设置页分栏并稳定同步操作行

### DIFF
--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -1971,17 +1971,18 @@ struct PanelView: View {
         VStack(alignment: .leading, spacing: 12) {
             settingsHeader
 
+            settingsAgentsSection
+
             HStack(alignment: .top, spacing: 11) {
                 VStack(alignment: .leading, spacing: 11) {
-                    settingsAgentsSection
                     settingsMenuBarSection
-                    settingsPrivacySection
+                    settingsDiagnosticsSection
+                    settingsPricingSection
                 }
                 .frame(width: settingsColumnWidth, alignment: .top)
 
                 VStack(alignment: .leading, spacing: 11) {
-                    settingsDiagnosticsSection
-                    settingsPricingSection
+                    settingsPrivacySection
                     settingsSystemSection
                     settingsReminderSection
                     settingsSyncSection
@@ -2167,6 +2168,7 @@ struct PanelView: View {
     var settingsAgentsSection: some View {
         settingsSection("square.grid.2x2", "显示卡片") {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 7),
+                                GridItem(.flexible(), spacing: 7),
                                 GridItem(.flexible(), spacing: 7)], spacing: 7) {
                 settingsRow("Claude", tint: Theme.claude, isOn: $showClaude)
                 settingsRow("Codex", tint: Theme.codex, isOn: $showCodex)

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -1959,14 +1959,14 @@ struct PanelView: View {
             HStack(alignment: .top, spacing: 11) {
                 VStack(alignment: .leading, spacing: 11) {
                     settingsAgentsSection
-                    settingsDiagnosticsSection
-                    settingsPricingSection
+                    settingsMenuBarSection
+                    settingsPrivacySection
                 }
                 .frame(width: settingsColumnWidth, alignment: .top)
 
                 VStack(alignment: .leading, spacing: 11) {
-                    settingsMenuBarSection
-                    settingsPrivacySection
+                    settingsDiagnosticsSection
+                    settingsPricingSection
                     settingsSystemSection
                     settingsReminderSection
                     settingsSyncSection
@@ -2375,14 +2375,21 @@ struct PanelView: View {
                         .disabled(store.syncing)
                 }
 
-                HStack(spacing: 8) {
-                    settingsActionButton(icon: "arrow.triangle.2.circlepath", title: store.syncing ? "同步中" : "同步") {
+                HStack(spacing: 6) {
+                    settingsActionButton(
+                        icon: "arrow.triangle.2.circlepath",
+                        title: store.syncing ? "同步中" : "同步",
+                        width: 86
+                    ) {
                         if saveSync() { store.doSync() }
                     }
                     .disabled(store.syncing || syncDir.isEmpty)
 
-                    Spacer()
-                    Text("自动").font(.system(size: 10)).foregroundStyle(Theme.tTertiary)
+                    Spacer(minLength: 6)
+                    Text("自动")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Theme.tTertiary)
+                        .fixedSize(horizontal: true, vertical: false)
                     Toggle("", isOn: $autoSync)
                         .toggleStyle(.switch).controlSize(.mini).labelsHidden()
                         .disabled(store.syncing)
@@ -2398,7 +2405,7 @@ struct PanelView: View {
                             }
                         }
                         .pickerStyle(.segmented)
-                        .frame(width: 112)
+                        .frame(width: 104)
                         .controlSize(.mini)
                         .disabled(store.syncing)
                         .onChange(of: syncInterval) { v in
@@ -2614,7 +2621,12 @@ struct PanelView: View {
         )
     }
 
-    func settingsActionButton(icon: String, title: String, action: @escaping () -> Void) -> some View {
+    func settingsActionButton(
+        icon: String,
+        title: String,
+        width: CGFloat? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             HStack(spacing: 4) {
                 Image(systemName: icon).font(.system(size: 9))
@@ -2623,6 +2635,7 @@ struct PanelView: View {
             .foregroundStyle(Theme.tPrimary)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
+            .frame(width: width)
             .background(RoundedRectangle(cornerRadius: 6, style: .continuous)
                 .fill(Color.primary.opacity(0.08)))
         }


### PR DESCRIPTION
## 背景

设置页原本按两栏组织内容，但每个区块的高度会随模块数量和开关状态变化。主线新增显示模块后，原来的分组让左栏明显高于右栏，右侧提前结束，页面下方留下较大的空白。

## 这个 PR 的演变

### 第一版：调整区块分组

最初的改动把设置页分成两栏：左侧放显示卡片、菜单栏和隐私设置，右侧放诊断、价格表、系统、久坐提醒和多设备同步。

当时这样安排是为了让设置内容更紧凑，同时处理同步状态文字变化时操作行被挤压的问题。

### 主线增加设置内容后

后续主线增加了更多显示模块，也扩充了菜单栏设置。显示卡片列表从原来的规模继续增长，菜单栏区块还加入了更多额度来源和说明文字。

原来的两栏分配因此失去平衡：显示卡片和菜单栏叠在左侧，左栏变得越来越长。问题不在某个单独区块，而在于一个会持续增长的列表被固定放进了半宽栏。

### 当前方案

这次保留同步操作行的稳定性修复，同时重新安排整体布局：

- 显示卡片移到顶部，独占全宽区域；
- 显示卡片开关从两列改为三列，减少模块数量增长带来的行数；
- 下方左栏放菜单栏、诊断和价格表；
- 下方右栏放隐私与额度、系统、久坐提醒和多设备同步。

这样处理后，最容易增长的内容不再拉长某一侧。下方两栏仍然保留清晰的功能分组，也没有引入复杂的动态瀑布流布局。

## 具体改动

- 调整 `settingsContent` 的外层排布；
- 将 `settingsAgentsSection` 改为全宽三列网格；
- 保留同步按钮固定宽度；
- 保留自动同步开关和时间间隔控件的稳定布局；
- 不改变设置项状态、持久化、同步和诊断逻辑。

## 为什么不是直接撤回原分栏改动

直接撤回后，菜单栏和多设备同步区块会集中到另一侧，随着内容继续增加，左右高度差仍然可能出现，只是方向相反。

因此这次只调整区块的摆放方式，保留已经解决同步操作行问题的部分。

## 数据和行为影响

本次只调整设置页布局，不改变用量采集、数据同步、设置持久化或菜单栏状态计算。

三列布局使用现有的 SwiftUI `LazyVGrid`，设置窗口宽度和其他卡片样式保持不变。

## 验证

- `swift build -c debug`
- `python3 -m unittest discover -s tests`
  - 210 tests passed
- `bash Tokei/Tests/run-sync-integration-checks.sh`
  - 17 checks passed
- `git diff --check`

Release 构建和本机安装验证已完成。
