### PR TITLE
wip(codex): 调查官方订阅额度缺失的 provider 边界

### DIFF
--- a/tests/test_codex_limits.py
+++ b/tests/test_codex_limits.py
@@ -58,7 +58,7 @@ class _Response:
 class CodexQuotaValuesTests(unittest.TestCase):
     def setUp(self):
         self.patchers = [
-            mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=False),
+            mock.patch.object(USAGE, "_codex_uses_non_openai_provider", return_value=False),
         ]
         for patcher in self.patchers:
             patcher.start()
@@ -434,22 +434,22 @@ class CodexCustomProviderTests(unittest.TestCase):
     def _write_config(self, text):
         self.config_path.write_text(text)
 
-    def test_is_custom_provider_with_explicit_custom(self):
+    def test_uses_non_openai_provider_with_explicit_custom(self):
         self._write_config('model_provider = "custom"\nmodel = "deepseek-v4-flash"\n')
-        self.assertTrue(USAGE._codex_is_custom_provider())
+        self.assertTrue(USAGE._codex_uses_non_openai_provider())
 
-    def test_is_not_custom_provider_with_openai(self):
+    def test_does_not_use_non_openai_provider_with_openai(self):
         self._write_config('model_provider = "openai"\nmodel = "gpt-5.5"\n')
-        self.assertFalse(USAGE._codex_is_custom_provider())
+        self.assertFalse(USAGE._codex_uses_non_openai_provider())
 
-    def test_is_not_custom_provider_without_config(self):
-        self.assertFalse(USAGE._codex_is_custom_provider())
+    def test_does_not_use_non_openai_provider_without_config(self):
+        self.assertFalse(USAGE._codex_uses_non_openai_provider())
 
     def test_declared_but_unused_provider_block_stays_official(self):
         # 只准备了 provider 段、没把 model_provider 指过去的人还在用官方额度，
         # 误判成第三方会把他们的额度卡整块藏掉。
         self._write_config('[model_providers.packycode]\nbase_url = "https://x"\n')
-        self.assertFalse(USAGE._codex_is_custom_provider())
+        self.assertFalse(USAGE._codex_uses_non_openai_provider())
 
     def test_custom_provider_detected_without_tomllib(self):
         # macOS 自带的 /usr/bin/python3 是 3.9，没有 tomllib；模块级 import 会让
@@ -465,10 +465,17 @@ class CodexCustomProviderTests(unittest.TestCase):
 
         with mock.patch.object(builtins, "__import__", side_effect=no_tomllib):
             self.assertEqual(USAGE._codex_config()["model_provider"], "packycode")
-            self.assertTrue(USAGE._codex_is_custom_provider())
+            self.assertTrue(USAGE._codex_uses_non_openai_provider())
 
     def test_live_quota_remains_available_for_custom_provider(self):
-        self._write_config('model_provider = "custom"\n')
+        self._write_config(
+            'model_provider = "custom"\n'
+            '[model_providers.custom]\n'
+            'name = "OpenAI"\n'
+            'requires_openai_auth = true\n'
+            'supports_websockets = true\n'
+            'wire_api = "responses"\n'
+        )
         payload = {
             "rate_limit": {
                 "primary_window": {
@@ -534,7 +541,7 @@ class CodexCustomProviderTests(unittest.TestCase):
         with mock.patch.object(USAGE, "CODEX_DIR", self.tmp.name), \
                 mock.patch.object(USAGE, "CODEX_ARCHIVED_DIR",
                                   str(Path(self.tmp.name) / "archived_sessions")), \
-                mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=True), \
+                mock.patch.object(USAGE, "_codex_uses_non_openai_provider", return_value=True), \
                 mock.patch.object(
                     USAGE, "fetch_codex_live_limits",
                     return_value=(live_limits, "plus", datetime.now().timestamp())):

--- a/tests/test_codex_limits.py
+++ b/tests/test_codex_limits.py
@@ -467,18 +467,81 @@ class CodexCustomProviderTests(unittest.TestCase):
             self.assertEqual(USAGE._codex_config()["model_provider"], "packycode")
             self.assertTrue(USAGE._codex_is_custom_provider())
 
-    def test_live_quota_skipped_for_custom_provider(self):
+    def test_live_quota_remains_available_for_custom_provider(self):
         self._write_config('model_provider = "custom"\n')
-        # Pre-populate a stale official cache to prove it gets cleared.
-        self.quota_cache_path.write_text(json.dumps({
-            "fetched_at": 1_785_000_000,
-            "limits": {"primary": {"used_percent": 80.0}},
-            "plan": "pro",
-        }))
-        opener = mock.Mock(side_effect=AssertionError("should not call API"))
+        payload = {
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 7,
+                    "limit_window_seconds": 604800,
+                    "reset_at": 200,
+                },
+            },
+            "plan_type": "plus",
+        }
+        opener = mock.Mock(return_value=_Response(payload))
         with mock.patch("urllib.request.urlopen", opener):
-            self.assertIsNone(USAGE.fetch_codex_live_limits())
-        self.assertFalse(self.quota_cache_path.exists())
+            limits, plan, _ = USAGE.fetch_codex_live_limits()
+        self.assertEqual(limits["primary"]["used_percent"], 7.0)
+        self.assertEqual(limits["primary"]["window_minutes"], 10080)
+        self.assertEqual(plan, "plus")
+        opener.assert_called_once()
+        self.assertTrue(self.quota_cache_path.exists())
+
+    def test_scan_uses_live_quota_but_not_custom_provider_usage(self):
+        path = Path(self.tmp.name) / "rollout-custom.jsonl"
+        path.write_text("\n".join([
+            json.dumps({
+                "timestamp": "2026-08-25T00:00:00Z",
+                "type": "session_meta",
+                "payload": {"id": "custom-provider", "cwd": "/tmp/project"},
+            }),
+            json.dumps({
+                "timestamp": "2026-08-25T00:01:00Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 100,
+                            "cached_input_tokens": 20,
+                            "output_tokens": 10,
+                            "reasoning_output_tokens": 2,
+                        },
+                    },
+                },
+            }),
+        ]) + "\n")
+        live_limits = {
+            "limit_id": "codex",
+            "plan_type": "plus",
+            "primary": {
+                "used_percent": 7.0,
+                "window_minutes": 10080,
+                "resets_at": 200,
+            },
+            "secondary": None,
+        }
+        bounds = {
+            "today": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "yesterday": datetime(2026, 8, 24, tzinfo=timezone.utc),
+            "week": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "last_week": datetime(2026, 8, 18, tzinfo=timezone.utc),
+            "last_week_end": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "month": datetime(2026, 8, 1, tzinfo=timezone.utc),
+            "year": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        }
+        with mock.patch.object(USAGE, "CODEX_DIR", self.tmp.name), \
+                mock.patch.object(USAGE, "CODEX_ARCHIVED_DIR",
+                                  str(Path(self.tmp.name) / "archived_sessions")), \
+                mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=True), \
+                mock.patch.object(
+                    USAGE, "fetch_codex_live_limits",
+                    return_value=(live_limits, "plus", datetime.now().timestamp())):
+            result = USAGE.scan_codex(bounds, {"v": USAGE._SCAN_CACHE_VERSION})
+        self.assertEqual(result["limits"], live_limits)
+        self.assertEqual(result["plan"], "plus")
+        self.assertIsNone(result["limits_consumed"])
 
     def test_reset_cards_survive_for_custom_provider(self):
         # 重置卡挂在 OpenAI 账号上，临时切到第三方中转不会让卡消失；

--- a/tests/test_codex_reset_cards.py
+++ b/tests/test_codex_reset_cards.py
@@ -48,7 +48,7 @@ class CodexResetCardsTests(unittest.TestCase):
         self.patchers = [
             mock.patch.object(USAGE, "CODEX_AUTH", str(self.auth_path)),
             mock.patch.object(USAGE, "CODEX_RESET_CARDS_CACHE", str(self.cache_path)),
-            mock.patch.object(USAGE, "_codex_is_custom_provider", return_value=False),
+            mock.patch.object(USAGE, "_codex_uses_non_openai_provider", return_value=False),
         ]
         for patcher in self.patchers:
             patcher.start()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -1429,11 +1429,11 @@ def _codex_config():
     }
 
 
-def _codex_is_custom_provider():
-    """True 表示 Codex 已切到非 OpenAI 的 provider(cc Switch 之类)。
+def _codex_uses_non_openai_provider():
+    """True 表示当前 rollout 用量走非 openai provider。
 
-    只认显式声明:光有 [model_providers.x] 段、但没把 model_provider 指过去的用户
-    仍在用官方额度,误判会把他们的额度卡整块藏掉。
+    这里只描述当前请求路由,不代表 ChatGPT 账号是否有官方订阅额度。
+    账号级额度必须由 auth.json + live quota 接口独立决定。
     """
     provider = _codex_config().get("model_provider")
     return bool(provider) and provider != "openai"
@@ -2719,18 +2719,18 @@ def scan_codex(bounds, cache):
                 g_ts = entry["g_ts"]
                 g_limits = entry["g_limits"]
 
-    custom_provider = _codex_is_custom_provider()
+    non_openai_provider = _codex_uses_non_openai_provider()
     # Historical rollout events can contain an official rate-limit snapshot
     # from before the user switched providers. It is not a valid fallback for
     # the current account-level quota, so custom-provider mode starts with no
     # local quota and may only be populated by the live account query below.
-    if custom_provider:
+    if non_openai_provider:
         latest_limits = None
         plan_type = None
         selected_limits_ts = None
     else:
         selected_limits_ts = latest_ts
-    if not custom_provider and latest_limits is None and g_limits is not None:
+    if not non_openai_provider and latest_limits is None and g_limits is not None:
         latest_limits = g_limits
         plan_type = (g_limits or {}).get("plan_type")
         selected_limits_ts = g_ts
@@ -2749,7 +2749,7 @@ def scan_codex(bounds, cache):
     # 窗口翻篇后本机又消耗了多少 —— 用来区分「确实回满了」和「读数已经失真」。
     # now_epoch=0 让映射函数只做槽位归类,不触发过期处理。
     slots = _codex_quota_values(latest_limits, now_epoch=0)
-    limits_consumed = None if custom_provider else {
+    limits_consumed = None if non_openai_provider else {
         "p5": _codex_used_since(merged_days, slots["r5"]),
         "pw": _codex_used_since(merged_days, slots["rw"]),
     }

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -1478,17 +1478,10 @@ def _codex_auth_context(auth):
 def fetch_codex_live_limits():
     if os.environ.get("TOKEI_CODEX_LIVE_QUOTA") == "0":
         return None
-    # When the user has switched to a third-party provider (cc Switch, etc.),
-    # the official OpenAI quota endpoint is no longer relevant. Skip it and
-    # clear any stale cached official quota so the dashboard falls back to
-    # showing only token usage/cost.
-    if _codex_is_custom_provider():
-        try:
-            if os.path.exists(CODEX_QUOTA_CACHE):
-                os.remove(CODEX_QUOTA_CACHE)
-        except Exception:
-            pass
-        return None
+    # The subscription quota belongs to the ChatGPT account, not to the
+    # provider currently selected for model requests. A third-party provider
+    # must not hide this account-level data; scan_codex keeps its token usage
+    # separate and only accepts a fresh live snapshot in that mode.
     cached = _cached_codex_live_limits(_CODEX_QUOTA_TTL)
     if cached:
         return cached
@@ -2726,8 +2719,18 @@ def scan_codex(bounds, cache):
                 g_ts = entry["g_ts"]
                 g_limits = entry["g_limits"]
 
-    selected_limits_ts = latest_ts
-    if latest_limits is None and g_limits is not None:
+    custom_provider = _codex_is_custom_provider()
+    # Historical rollout events can contain an official rate-limit snapshot
+    # from before the user switched providers. It is not a valid fallback for
+    # the current account-level quota, so custom-provider mode starts with no
+    # local quota and may only be populated by the live account query below.
+    if custom_provider:
+        latest_limits = None
+        plan_type = None
+        selected_limits_ts = None
+    else:
+        selected_limits_ts = latest_ts
+    if not custom_provider and latest_limits is None and g_limits is not None:
         latest_limits = g_limits
         plan_type = (g_limits or {}).get("plan_type")
         selected_limits_ts = g_ts
@@ -2746,16 +2749,10 @@ def scan_codex(bounds, cache):
     # 窗口翻篇后本机又消耗了多少 —— 用来区分「确实回满了」和「读数已经失真」。
     # now_epoch=0 让映射函数只做槽位归类,不触发过期处理。
     slots = _codex_quota_values(latest_limits, now_epoch=0)
-    limits_consumed = {
+    limits_consumed = None if custom_provider else {
         "p5": _codex_used_since(merged_days, slots["r5"]),
         "pw": _codex_used_since(merged_days, slots["rw"]),
     }
-
-    # For third-party providers the official OpenAI quota is not meaningful,
-    # and stale limits from older sessions must not be shown.
-    if _codex_is_custom_provider():
-        latest_limits = None
-        plan_type = None
 
     cur_total = None
     if cur_file:


### PR DESCRIPTION
## 背景

关联 #68

Issue #68 反馈：升级 Tokei 后，Codex 面板不再显示订阅额度，但重置卡信息仍然可以显示。

本 PR 原本尝试修复该问题，但进一步核对仓库设计和 Codex 官方配置语义后，确认当前仓库有意将两类信息分开处理：

- 订阅额度：跟随当前 Codex provider；
- 重置卡：跟随本机登录的 ChatGPT 账号。

本 PR 不建议合并，完成调查记录后关闭。

## 调查结论

当前仓库的行为来自已合入的 PR #55 及后续修正：

1. PR #55 引入 provider 判断，在当前 provider 不是 `openai` 时隐藏官方额度。
2. 后续提交恢复了 reset cards 的账号级查询，但保留了额度随 provider 屏蔽的设计。
3. 因此，当用户使用自定义 provider 时，即使背后仍然使用 ChatGPT 登录认证，也可能出现：
   - reset cards 可以显示；
   - 7 天订阅额度不显示。

这不是认证失败，也不是 reset cards 和 quota 使用了不同的登录账号。

## 官方文档确认的配置方式

### 直接使用官方 OAuth

Codex 官方配置文档确认：

- `model_provider` 的默认 provider ID 是 `openai`；
- 使用 ChatGPT 登录时，Codex 会缓存登录信息；
- 文件存储模式下，登录缓存位于 `~/.codex/auth.json`；
- 因此没有显式 provider 配置时，默认使用内置 `openai` provider，并可以使用 ChatGPT OAuth 账号。

### 用自定义 provider 配置 OpenAI 认证

官方认证文档确认，自定义 provider 可以配置：

```toml
[model_providers.custom]
name = "OpenAI"
requires_openai_auth = true
supports_websockets = true
wire_api = "responses"
```

`requires_openai_auth = true` 表示该 provider 使用 OpenAI 认证。官方文档说明，这种 provider 可以使用 ChatGPT 登录或 API key，常见用途是通过 LLM proxy server 访问 OpenAI 模型。

因此，这种配置可以复用 ChatGPT 登录态，但配置本身不能证明账号一定拥有官方 Codex 订阅；也可能只是 API key 或代理场景。

## 为什么无法仅靠配置准确判断“是否官方订阅”

官方文档对这些字段的定义是：

- `model_provider`：当前使用的 provider ID，默认是 `openai`；
- `model_providers.<id>.name`：自定义 provider 的显示名称，不是官方订阅标识；
- `requires_openai_auth`：使用 OpenAI 认证的开关，不区分 ChatGPT OAuth 和 API key，也不直接表示订阅权益；
- `wire_api`：通信协议；
- `supports_websockets`：是否支持 Responses API WebSocket 传输。

所以 Tokei 无法仅凭 `name`、`requires_openai_auth`、`wire_api` 或 provider ID，可靠地区分：

- 直接使用官方 `openai` provider 的 ChatGPT 订阅；
- 使用 ChatGPT OAuth 的自定义 provider；
- 使用 API key 的自定义 provider；
- 指向代理或中转服务但复用 OpenAI 认证的 provider。

官方文档：

- [Codex 配置参考](https://developers.openai.com/codex/config-reference/)
- [Codex 认证](https://developers.openai.com/codex/auth/)

## 本 PR 的实现与结论

本 PR 曾尝试：

- 恢复自定义 provider 下的账号级 live quota；
- 保留第三方 provider 的 token 用量隔离；
- 防止旧 provider 的本地 quota 快照回退；
- 增加自定义 provider 配置和 live quota 的回归测试。

本机验证确认该实现可以恢复以下配置下的额度：

```toml
model_provider = "custom"

[model_providers.custom]
name = "OpenAI"
requires_openai_auth = true
supports_websockets = true
wire_api = "responses"
```

但该行为会改变仓库当前“额度随 provider、重置卡随账号”的既有产品设计。由于 Tokei 无法仅凭本地配置准确判断自定义 provider 背后的订阅归属，本 PR 不应直接合并。

## 验证

- v1.0.31：同一份本机 auth/config 可以返回 `plus / 8% / 10080 分钟`。
- v1.0.32 及 v1.0.33：provider 判断会隐藏 live quota。
- 当前本机额度接口和 reset cards 接口均返回成功。
- 当前实现可以恢复自定义 provider 包装官方认证时的额度显示。
- Python 全量测试：210 个通过。

## 最终决定

本 PR 作为调查和实现尝试保留，结论是不合并，后续关闭。

如果未来要支持“自定义 provider 但背后使用官方订阅”的额度展示，需要先由仓库维护者明确新的产品契约，例如：

- 是否所有能使用 ChatGPT OAuth 的 provider 都展示官方账号额度；
- 是否引入显式配置开关；
- 是否接受 provider 请求实际不消耗官方额度时，面板同时展示官方额度；
- quota 查询失败时是否允许使用历史快照回退。

在这些产品语义确认前，不应继续扩大 provider 推断逻辑。
