### PR TITLE
fix(sync): 修复 Prime Agent 导致快照同步失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **18 款 AI 工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **19 款 AI 工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
 
 ### 支持的工具
 
@@ -44,8 +43,6 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编�
 | **OpenCode** | Token、成本、缓存命中率、模型 |
 | **Qwen Code** | Token、思考量、成本、模型 |
 | **千问办公（QwenWork）** | 套餐与加购积分余额、团队共享资源包 |
-| **Qoder** | Token、调用次数、配额 |
-| **QoderWork** | Token、调用次数、配额 |
 | **Kimi Code** | Token（输入/输出/缓存）、会话、模型、项目 |
 
 ## 功能一览
@@ -177,8 +174,6 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 | OpenCode | `~/.local/share/opencode/opencode.db`，旧版回退 `storage/message/` |
 | Qwen Code | `~/.qwen/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` |
 | 千问办公（QwenWork） | `~/.qwenworkcn/mcp-adaptor.config` + `.status.json` 文件元数据 + 官方桌面端 `127.0.0.1` MCP（默认关闭；需客户端运行且已登录） |
-| Qoder | `~/.qodo-ai/sessions/*.jsonl` |
-| QoderWork | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/*/wire.jsonl`；兼容旧版 `${KIMI_SHARE_DIR:-~/.kimi}/sessions/*/*/wire.jsonl` |
 | Qoder Desktop | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 | QoderWork | `~/Library/Application Support/QoderWork/data/agents.db` |
@@ -190,7 +185,7 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 
 | 功能 | Tokei | [CodexBar](https://github.com/steipete/CodexBar) |
 |------|:-----:|:---------:|
-| 支持工具 | 18 | 40+ |
+| 支持工具 | 19 | 40+ |
 | Token 级用量分析 | ✅ | — |
 | 成本估算（317 模型） | ✅ | 部分 |
 | 数据面板（图表 + 热力图） | ✅ | — |
@@ -339,8 +334,7 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **18 AI tools** in real-time. Usage analytics are local-first; quota checks use each tool's existing local sign-in and may contact its official service.
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **13 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **19 AI tools** in real-time. Usage analytics are local-first; quota checks use each tool's existing local sign-in and may contact its official service.
 
 **Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local usage logs, explicit quota controls) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 

--- a/tests/test_prime_agent_usage.py
+++ b/tests/test_prime_agent_usage.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from datetime import datetime
@@ -27,13 +28,14 @@ class PrimeAgentUsageTests(unittest.TestCase):
                                  "cacheRead": usage.get("cache_read", 0), "cacheWrite": usage.get("cache_write", 0),
                                  "cost": usage.get("cost", {})}}}
 
-    def scan(self, agent_dir):
+    def scan(self, agent_dir, cache=None):
         with mock.patch.object(USAGE, "PRIME_AGENT_DIR", str(agent_dir)), \
              mock.patch.dict(os.environ, {}, clear=False):
             for key in ("TOKEI_PRIME_AGENT_SESSION_DIR", "PRIME_AGENT_SESSION_DIR",
                         "PRIME_AGENT_CODING_AGENT_SESSION_DIR", "PRIME_AGENT_CODING_AGENT_DIR"):
                 os.environ.pop(key, None)
-            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            if cache is None:
+                cache = {"v": USAGE._SCAN_CACHE_VERSION}
             return USAGE.scan_prime_agent(USAGE.range_bounds(), cache), cache
 
     def test_root_and_nested_children_are_counted_without_attribution_double_count(self):
@@ -101,6 +103,69 @@ class PrimeAgentUsageTests(unittest.TestCase):
                 result = USAGE.scan_prime_agent(USAGE.range_bounds(), {"v": USAGE._SCAN_CACHE_VERSION})
         self.assertEqual(result["ranges"]["all"]["in"], 7)
         self.assertEqual(result["ranges"]["all"]["sessions"], {"custom"})
+
+    def test_ledger_preserves_usage_after_session_cleanup(self):
+        ledger = {"v": USAGE._LEDGER_VERSION, "tools": {}}
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(USAGE, "_load_ledger_from_disk", return_value=ledger):
+            agent_dir = Path(tmp) / "agent"
+            now = datetime.now().astimezone().replace(microsecond=0).isoformat()
+            self.write_session(
+                agent_dir / "sessions" / "session.jsonl",
+                "session-id",
+                "/tmp/prime-project",
+                [self.assistant(now, input=10, output=2, cost={"total": 0.12})],
+            )
+            first, cache = self.scan(agent_dir)
+            first_usage = first["ranges"]["all"]
+
+            stored = ledger["tools"]["prime_agent"]
+            self.assertEqual(len(stored), 1)
+            stored_day = next(iter(stored.values()))
+            self.assertEqual(stored_day["sessions"], ["session-id"])
+            self.assertEqual(stored_day["projects"], ["prime-project"])
+
+            shutil.rmtree(agent_dir / "sessions")
+            second, cache = self.scan(agent_dir, cache=cache)
+
+        second_usage = second["ranges"]["all"]
+        self.assertEqual(USAGE.token_total(second_usage), USAGE.token_total(first_usage))
+        self.assertEqual(second_usage["sessions"], {"session-id"})
+        self.assertEqual(cache["prime_agent"], {})
+
+    def test_wrapped_with_prime_agent_usage_includes_tokens_and_cost(self):
+        today = datetime.now().astimezone().date().isoformat()
+        day = {
+            "in": 10, "out": 2, "cr": 3, "cw": 4, "reason": 1,
+            "cost": 0.12, "hours": [20] + [0] * 23,
+            "models": {
+                "metarouter/gpt-5.6-sol": {
+                    "in": 10, "out": 2, "cr": 3, "cw": 4, "reason": 1,
+                    "cost": 0.12,
+                },
+            },
+        }
+        cache = {
+            "v": USAGE._SCAN_CACHE_VERSION,
+            "_dirty": False,
+            "prime_agent": {
+                "/tmp/prime-session.jsonl": {
+                    "days": {today: day},
+                    "proj": "/tmp/prime-project",
+                    "sid": "session-id",
+                },
+            },
+        }
+        with mock.patch.object(
+            USAGE,
+            "_load_ledger",
+            return_value={"v": USAGE._LEDGER_VERSION, "tools": {}},
+        ):
+            wrapped = USAGE.build_wrapped("1d", refresh=False, _cache=cache)
+
+        self.assertEqual(wrapped["total_tokens"], 20)
+        self.assertEqual(wrapped["total_cost"], 0.12)
+        self.assertEqual(sum(wrapped["hours"]), 20)
 
 
 if __name__ == "__main__":

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -5477,6 +5477,7 @@ def _parse_prime_session_file(path):
 
 
 def scan_prime_agent(bounds, cache):
+    ledger_touch("prime_agent")
     fc = cache.setdefault("prime_agent", {})
     B = _empty_token_ranges()
     roots = _prime_agent_session_dirs()
@@ -5515,23 +5516,45 @@ def scan_prime_agent(bounds, cache):
             fc.pop(path, None)
             changed = True
     used = set()
+    live_days = {}
+    live_sessions = {}
+    live_projects = {}
     for path, entry in canonical.values():
+        session = entry.get("sid") or path
+        project = entry.get("proj") or ""
+        project_name = os.path.basename(project.rstrip("/"))
         for event in entry.get("events", []):
             if event.get("key") in used:
                 continue
             used.add(event.get("key"))
-            day = B["all"]
+            day_key = event.get("date")
+            try:
+                date.fromisoformat(day_key)
+            except (TypeError, ValueError):
+                continue
+            day = live_days.setdefault(day_key, _empty_token_day())
             _add_token_usage(day, event.get("in", 0), event.get("out", 0),
                              event.get("cr", 0), event.get("cw", 0), event.get("reason", 0),
                              event.get("cost", 0), event.get("model"))
-            for key in classify_date(date.fromisoformat(event["date"]), bounds):
-                if key == "all":
-                    continue
-                _add_token_usage(B[key], event.get("in", 0), event.get("out", 0),
-                                 event.get("cr", 0), event.get("cw", 0), event.get("reason", 0),
-                                 event.get("cost", 0), event.get("model"))
-                B[key]["sessions"].add(entry.get("sid") or path)
-        B["all"]["sessions"].add(entry.get("sid") or path)
+            hour = event.get("hour")
+            if isinstance(hour, int) and 0 <= hour < 24:
+                day["hours"][hour] += token_total(event)
+            live_sessions.setdefault(day_key, set()).add(session)
+            if project_name:
+                live_projects.setdefault(day_key, set()).add(project_name)
+
+    for day_key, day in live_days.items():
+        day["sessions"] = sorted(live_sessions.get(day_key, set()))
+        day["projects"] = sorted(live_projects.get(day_key, set()))
+
+    for day_key, day in ledger_reconcile("prime_agent", live_days).items():
+        try:
+            day_date = date.fromisoformat(day_key)
+        except (TypeError, ValueError):
+            continue
+        for range_key in classify_date(day_date, bounds):
+            _merge_token_day(B[range_key], day)
+            B[range_key]["sessions"].update(day.get("sessions", []))
     if changed:
         cache["_dirty"] = True
     return {"ranges": B}
@@ -8703,8 +8726,7 @@ def build_wrapped(period="all", refresh=True, _cache=None):
                 continue
             tok = token_total(day)
             day_tokens[dk] = day_tokens.get(dk, 0) + tok
-            total_tokens += tok
-            total_cost += day.get("cost", 0)
+            day_cost[dk] = day_cost.get(dk, 0.0) + day.get("cost", 0)
             weekday[date.fromisoformat(dk).weekday()] += tok
             add_hours(dk, day.get("hours"))
             for mn, mv in day.get("models", {}).items():


### PR DESCRIPTION
## 背景

PR #52 合入 Prime Agent 后，只要本机出现 Prime Agent 用量，`usage.30s.py --json` 就可能出现“JSON 已输出，但进程退出码为 1”的情况。

原因在同步快照的 Wrapped 汇总路径：Prime Agent 汇总块先执行 `total_tokens += tok` 和 `total_cost += ...`，而这两个变量要到所有工具汇总、账本合并完成后才初始化。普通用量计算因此看起来正常，但写同步快照时会触发 `UnboundLocalError`，快照写入根本还没开始。

这个问题在没有 Prime Agent 日志时不会出现，所以直到实际产生 Prime Agent 用量才暴露出来。它会让本机同步任务失败，并且让日志里的 `json: ok` 变得容易误导排查。

## 本次改动

- 移除 Wrapped 汇总中初始化之前的总量累加。
- 将 Prime Agent 成本写入逐日成本桶，避免总成本在统一汇总时丢失。
- 为 `scan_prime_agent` 接入 `ledger_touch("prime_agent")` 和 `ledger_reconcile("prime_agent", live_days)`。
- 按日期构建 Prime Agent 的实时账本数据，保留模型、小时、session 和项目字段。
- 日志被清理后，从账本恢复 Prime Agent 的历史 token、成本、session 和项目数据。
- 清理 PR #52 合并 README 时留下的重复介绍、重复 Qoder 条目和错误日志路径。
- 增加 Prime Agent 账本恢复与 Wrapped 汇总回归测试。

## 关键设计

Prime Agent 仍然沿用原来的物理 session 去重和 `child_usage_attributed` 排除规则。这次只是把已经去重后的每日结果接到账本，不重新扫描或重复累计数据。

账本按天保存高水位。现存日志的当天数据与账本对账时取较新的完整日结果，日志整天消失后才使用账本回退；不会把实时值和账本值相加。这样既能保留日志清理前的历史，也能让账本随已有的 `_ledger` 快照机制参与多设备同步。

## 用户影响

修复后，有 Prime Agent 用量的设备可以正常完成同步快照写入。没有 Prime Agent 用量的设备行为不变。

本 PR 不包含 DMG 打包、安装包发布或本机 App 更新。

## 安全与隐私

- 仍然只读取本地 Prime Agent JSONL。
- 没有新增网络请求、凭据读取或外部进程。
- 账本只保存已有的每日统计字段，不保存对话正文。
- 测试使用临时目录和合成 JSONL，不包含真实用户日志。

## 兼容性

- Prime Agent 的 usage 数据结构没有改变。
- 账本沿用现有版本和同步快照格式。
- 没有改变旧设备快照的读取方式。
- README 文案与当前 19 个工具的代码和数据路径保持一致。

## 验证

以下命令均在 macOS 本地执行：

```text
python3 -m py_compile usage.30s.py
python3 -m unittest discover -s tests
swift build
```

结果：

- Python 全量测试 211/211 通过。
- `py_compile` 通过。
- `swift build` 通过。
- `git diff --check` 通过。
- 使用当前本机真实 Prime Agent 缓存做了不落盘探针：扫描到 64,512 tokens，账本生成 1 个日期，`all`、`today`、`week` 汇总均正常。

Swift 构建仍会报告仓库原有的未声明资源 warning；没有新增编译错误。

## 已知限制

- 当前 PR 没有重新生成 DMG，也没有更新任何已安装的 Tokei.app。
- 项目足迹页面仍主要依赖现存 session 缓存；本次 follow-up 的持久化范围是每日统计和同步快照。

## 检查清单

- [x] 修复 Prime Agent 导致同步快照失败的问题
- [x] 接入 Prime Agent 持久账本
- [x] 增加日志清理后的恢复测试
- [x] 清理 PR #52 合并留下的 README 重复文案
- [x] Python 测试通过
- [x] Swift 构建通过
- [x] 未修改 DMG 或已安装 App
- [x] 未包含真实日志、凭据或对话内容
