### PR TITLE
fix(usage): 统一模型身份解析并修正 OpenClaw 模型归类

### DIFF
--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -507,6 +507,7 @@ struct HermesRange: Codable {
     var models: [TokenModelStat] = []
 }
 struct TokenModelStat: Codable, Identifiable {
+    var modelId: String?
     var name: String
     var `in`: Int
     var out: Int
@@ -516,10 +517,11 @@ struct TokenModelStat: Codable, Identifiable {
     var cost: Double
     var pin: Double = 0
     var pout: Double = 0
-    var id: String { name }
+    var id: String { modelId ?? name }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelId = try c.decodeIfPresent(String.self, forKey: .modelId)
         name = try c.decode(String.self, forKey: .name)
         `in` = try c.decodeIfPresent(Int.self, forKey: .in) ?? 0
         out = try c.decodeIfPresent(Int.self, forKey: .out) ?? 0
@@ -529,6 +531,11 @@ struct TokenModelStat: Codable, Identifiable {
         cost = try c.decodeIfPresent(Double.self, forKey: .cost) ?? 0
         pin = try c.decodeIfPresent(Double.self, forKey: .pin) ?? 0
         pout = try c.decodeIfPresent(Double.self, forKey: .pout) ?? 0
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case modelId = "model_id"
+        case name, `in`, out, cr, cw, reason, cost, pin, pout
     }
 }
 struct HermesRanges: Codable {

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -11,6 +11,7 @@ struct PanelView: View {
     @State private var codexResetCardsOpen = false
     @State private var geminiModelsOpen = false
     @State private var grokModelsOpen = false
+    @State private var hermesModelsOpen = false
     @State private var zcodeModelsOpen = false
     @State private var mimocodeModelsOpen = false
     @State private var piModelsOpen = false
@@ -20,6 +21,7 @@ struct PanelView: View {
     @State private var openCodeModelsOpen = false
     @State private var qwenCodeModelsOpen = false
     @State private var kimiCodeModelsOpen = false
+    @State private var openClawModelsOpen = false
     @State private var expandedModels: Set<String> = []
     @State private var mode: PanelMode = .cards
     @State private var trailProjects: [TrailProject]?
@@ -360,14 +362,14 @@ struct PanelView: View {
             ToolCardItem(id: "qodercli", name: "Qoder CLI", visible: showQoderCli, active: qclir.calls > 0,
                          tint: Theme.qodercli, content: AnyView(qodercliBlock(u.qodercli, qclir))),
             ToolCardItem(id: "hermes", name: "Hermes", visible: showHermes, active: hr.sessions > 0,
-                         tint: Theme.hermes, content: AnyView(hermesBlock(hr))),
+                         tint: Theme.hermes, content: AnyView(hermesBlock(hr, modelsOpen: $hermesModelsOpen))),
             ToolCardItem(id: "zcode", name: "ZCode", visible: showZcode, active: zr.sessions > 0,
                          tint: Theme.zcode, content: AnyView(tokenUsageBlock(title: "ZCode", zr, tint: Theme.zcode, modelsOpen: $zcodeModelsOpen, toolID: "zcode"))),
             ToolCardItem(id: "mimocode", name: "MiMoCode", visible: showMimoCode, active: mr.sessions > 0,
                          tint: Theme.mimocode, content: AnyView(tokenUsageBlock(title: "MiMoCode", mr, tint: Theme.mimocode, modelsOpen: $mimocodeModelsOpen, toolID: "mimocode"))),
             ToolCardItem(id: "openclaw", name: "OpenClaw", visible: showOpenClaw,
                          active: lr.tasks > 0 || lr.in + lr.out + lr.cr + lr.cw > 0,
-                         tint: Theme.openclaw, content: AnyView(openclawBlock(lr))),
+                         tint: Theme.openclaw, content: AnyView(openclawBlock(lr, modelsOpen: $openClawModelsOpen))),
             ToolCardItem(id: "pi", name: "Pi", visible: showPi, active: pr.sessions > 0,
                          tint: Theme.pi, content: AnyView(tokenUsageBlock(title: "Pi Coding Agent", pr, tint: Theme.pi, modelsOpen: $piModelsOpen, toolID: "pi"))),
             ToolCardItem(id: "prime_agent", name: "Prime Agent", visible: showPrimeAgent, active: par.sessions > 0,
@@ -1183,7 +1185,7 @@ struct PanelView: View {
 
     // MARK: - Hermes 卡片
     @ViewBuilder
-    func hermesBlock(_ r: HermesRange) -> some View {
+    func hermesBlock(_ r: HermesRange, modelsOpen: Binding<Bool>) -> some View {
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Hermes", tint: Theme.hermes, sessions: r.sessions, toolID: "hermes")
             if r.sessions > 0 {
@@ -1198,6 +1200,9 @@ struct PanelView: View {
                     if r.reason > 0 { items.append(.init("brain", "推理", Fmt.human(r.reason))) }
                     return items
                 }(), tint: Theme.hermes)
+                if !r.models.isEmpty {
+                    tokenModelDisclosure(r.models, open: modelsOpen, tint: Theme.hermes)
+                }
             } else {
                 emptyHint
             }
@@ -1206,7 +1211,7 @@ struct PanelView: View {
 
     // MARK: - OpenClaw 卡片
     @ViewBuilder
-    func openclawBlock(_ r: OpenClawRange) -> some View {
+    func openclawBlock(_ r: OpenClawRange, modelsOpen: Binding<Bool>) -> some View {
         VStack(alignment: .leading, spacing: 11) {
             cardHead("OpenClaw", tint: Theme.openclaw, sessions: r.sessions, toolID: "openclaw")
             if r.in + r.out + r.cr + r.cw > 0 {
@@ -1221,6 +1226,9 @@ struct PanelView: View {
                     if r.tasks > 0 { items.append(.init("checklist", "任务", "\(r.tasks)")) }
                     return items
                 }(), tint: Theme.openclaw)
+                if !r.models.isEmpty {
+                    tokenModelDisclosure(r.models, open: modelsOpen, tint: Theme.openclaw)
+                }
             } else if r.tasks > 0 {
                 HStack(spacing: 16) {
                     VStack(alignment: .leading, spacing: 2) {

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -632,13 +632,22 @@ final class SyncManager {
 
     private static func mergeTokenModels(_ dst: inout [TokenModelStat], _ src: [TokenModelStat]) {
         for m in src {
-            if let idx = dst.firstIndex(where: { $0.name == m.name }) {
+            let index: Int?
+            if let modelId = m.modelId {
+                index = dst.firstIndex { $0.modelId == modelId }
+            } else {
+                index = dst.firstIndex { $0.modelId == nil && $0.name == m.name }
+            }
+            if let idx = index {
                 dst[idx].in += m.in
                 dst[idx].out += m.out
                 dst[idx].cr += m.cr
                 dst[idx].cw += m.cw
                 dst[idx].reason += m.reason
                 dst[idx].cost += m.cost
+                if dst[idx].name == "未知" && m.name != "未知" {
+                    dst[idx].name = m.name
+                }
             } else {
                 dst.append(m)
             }

--- a/tests/test_model_names.py
+++ b/tests/test_model_names.py
@@ -26,7 +26,43 @@ class ModelNameTests(unittest.TestCase):
         names = [model["name"] for model in formatted]
 
         self.assertEqual(names, ["GPT-5.6 Sol", "GPT-5.6 Luna"])
+        self.assertEqual(
+            [model["model_id"] for model in formatted],
+            ["openai/gpt-5.6-sol", "openai/gpt-5.6-luna"],
+        )
         self.assertEqual(len(names), len(set(names)))
+
+    def test_catalog_canonical_slug_resolves_without_family_guessing(self):
+        old_pricing = USAGE._PRICING_DB
+        try:
+            USAGE._PRICING_DB = {
+                "provider/model": {
+                    "canonical_slug": "provider/model-2026",
+                    "in": 1.0,
+                    "out": 2.0,
+                },
+            }
+            model_id = USAGE._model_identity_id("provider/model-2026")
+            self.assertEqual(model_id, "provider/model")
+            self.assertEqual(
+                USAGE._exact_pricing_id(model_id),
+                "provider/model",
+            )
+        finally:
+            USAGE._PRICING_DB = old_pricing
+
+    def test_unknown_model_identity_is_preserved(self):
+        old_pricing = USAGE._PRICING_DB
+        old_override_models = USAGE._OV_MODELS
+        try:
+            USAGE._PRICING_DB = {}
+            USAGE._OV_MODELS = {}
+            model = "private-provider/model-variant"
+            self.assertEqual(USAGE._model_identity_id(model), model)
+            self.assertIsNone(USAGE._exact_pricing_id(model))
+        finally:
+            USAGE._PRICING_DB = old_pricing
+            USAGE._OV_MODELS = old_override_models
 
 
 if __name__ == "__main__":

--- a/tests/test_pricing_cache.py
+++ b/tests/test_pricing_cache.py
@@ -18,6 +18,9 @@ class PricingCacheTests(unittest.TestCase):
         return io.BytesIO(json.dumps({
             "data": [{
                 "id": "test/model",
+                "name": "Test Model",
+                "canonical_slug": "test/model-2026",
+                "owned_by": "test-owner",
                 "pricing": {
                     "prompt": prompt,
                     "completion": "0.000002",
@@ -34,6 +37,9 @@ class PricingCacheTests(unittest.TestCase):
                 "out": 2.0,
                 "cache_read": 0.5,
                 "cache_write": 0.8,
+                "name": "Test Model",
+                "canonical_slug": "test/model-2026",
+                "owned_by": "test-owner",
             },
         }
 
@@ -54,7 +60,10 @@ class PricingCacheTests(unittest.TestCase):
 
             self.assertTrue(scan_cache.exists())
             self.assertTrue(json.loads(scan_cache.read_text(encoding="utf-8"))["sentinel"])
-            self.assertIn("test/model", json.loads(pricing.read_text(encoding="utf-8"))["models"])
+            saved = json.loads(pricing.read_text(encoding="utf-8"))["models"]["test/model"]
+            self.assertEqual(saved["name"], "Test Model")
+            self.assertEqual(saved["canonical_slug"], "test/model-2026")
+            self.assertEqual(saved["owned_by"], "test-owner")
 
     def test_changed_price_update_invalidates_cost_cache(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -313,6 +313,32 @@ def _known_id_or_raw(model: str):
     return s
 
 
+def _model_identity_id(model: str):
+    """Resolve only exact catalog identities; never guess an unknown model family."""
+    s = (model or "").strip()
+    if not s or s.lower() == "<synthetic>":
+        return None
+    if s in _OV_ALIASES:
+        return _OV_ALIASES[s]
+    norm = _normalize(s)
+    if norm and (norm in _OV_MODELS or norm in _PRICING_DB or norm in _DEFAULT_PRICES):
+        return norm
+    for model_id, entry in _PRICING_DB.items():
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("canonical_slug")
+        if isinstance(slug, str) and _normalize(slug) == norm:
+            return model_id
+    return s
+
+
+def _exact_pricing_id(model: str):
+    """Return a catalog pricing ID without family-based fallback."""
+    if model and (model in _OV_MODELS or model in _PRICING_DB or model in _DEFAULT_PRICES):
+        return model
+    return None
+
+
 def _has_known_price(model: str):
     return _pricing_id(model) is not None
 
@@ -479,7 +505,7 @@ _SCAN_CACHE_DIR = os.environ.get("TOKEI_CACHE_DIR") or os.path.join(
 _DEFAULT_SCAN_CACHE_FILE = os.path.join(
     _SCAN_CACHE_DIR, "scan_cache.json")
 _SCAN_CACHE_FILE = _DEFAULT_SCAN_CACHE_FILE
-_SCAN_CACHE_VERSION = 20
+_SCAN_CACHE_VERSION = 21
 _SCAN_CACHE_MIGRATABLE_VERSION = 19
 _CODEX_EVENT_CACHE_SUFFIX = ".codex-events"
 _CODEX_PARSER_VERSION = 3
@@ -975,10 +1001,12 @@ def _format_token_models(models, include_prices=True):
     sort_key = (lambda kv: -kv[1].get("cost", 0)) if include_prices else (
         lambda kv: -token_total(kv[1]))
     for n, v in sorted(models.items(), key=sort_key):
-        price_id = _pricing_id(n) if include_prices else None
+        model_id = _model_identity_id(n)
+        price_id = _exact_pricing_id(model_id) if include_prices else None
         p = _raw_price(price_id) if price_id else {
             "in": 0.0, "out": 0.0, "cache_read": 0.0, "cache_write": 0.0}
-        result.append({"name": nice_model(n), "in": v.get("in", 0), "out": v.get("out", 0),
+        result.append({"model_id": model_id, "name": nice_model(model_id),
+                       "in": v.get("in", 0), "out": v.get("out", 0),
                         "cr": v.get("cr", 0), "cw": v.get("cw", 0), "reason": v.get("reason", 0),
                         "cost": v.get("cost", 0), "pin": p["in"], "pout": p["out"]})
     return result
@@ -4737,7 +4765,8 @@ def _scan_hermes_db(db_path, _sq):
             cr = int(row.get("cache_read_tokens") or 0)
             cw = int(row.get("cache_write_tokens") or 0)
             reason = int(row.get("reasoning_tokens") or 0)
-            _add_token_usage(day, inp, out, cr, cw, reason, row_cost(row), row.get("model"))
+            _add_token_usage(day, inp, out, cr, cw, reason, row_cost(row),
+                             _model_identity_id(row.get("model")))
             day["hours"][local_dt.hour] += inp + out + cr + cw + reason
             if session_id in sessions:
                 day_sessions.setdefault(dk, set()).add(session_id)
@@ -5163,13 +5192,14 @@ def scan_openclaw(bounds, cache):
                             if inp == 0 and out == 0:
                                 continue
                             model = msg.get("model", "")
-                            cid = _resolve_id(model)
+                            model_id = _model_identity_id(model)
+                            pricing_id = _exact_pricing_id(model_id)
                             cost_obj = u.get("cost")
                             raw_cost = float((cost_obj or {}).get("total", 0) or 0)
                             if raw_cost > 0:
                                 cost = raw_cost
-                            elif cid:
-                                p = _raw_price(model)
+                            elif pricing_id:
+                                p = _raw_price(pricing_id)
                                 cost = inp / 1e6 * p["in"] + out / 1e6 * p["out"] + cr / 1e6 * p["cache_read"] + cw / 1e6 * p["cache_write"]
                             else:
                                 cost = 0.0
@@ -5180,7 +5210,7 @@ def scan_openclaw(bounds, cache):
                             day["in"] += inp; day["out"] += out
                             day["cr"] += cr; day["cw"] += cw; day["cost"] += cost
                             day["hours"][dt.hour] += inp + out + cr + cw
-                            mn = cid or model or "unknown"
+                            mn = model_id or model or "unknown"
                             mm = day["models"].setdefault(
                                 mn, {"in": 0, "out": 0, "cr": 0, "cw": 0,
                                      "reason": 0, "cost": 0.0})
@@ -7510,7 +7540,10 @@ def _recalc_costs(result):
             total_cost = 0.0
             for m in r["models"]:
                 name = m.get("name", "")
-                price_id = _pricing_id(name)
+                model_id = m.get("model_id")
+                price_id = (_exact_pricing_id(model_id) if isinstance(model_id, str) else None)
+                if not price_id:
+                    price_id = _pricing_id(name)
                 authoritative_cost = float(m.get("cost", 0) or 0)
                 if tool_key == "hermes" and authoritative_cost:
                     total_cost += authoritative_cost
@@ -7844,9 +7877,14 @@ def update_prices():
         pr = m.get("pricing") or {}
         if not mtok(pr, "prompt") and not mtok(pr, "completion"):
             continue                              # 跳过无价(免费/路由占位)条目
-        models[m["id"]] = {"in": mtok(pr, "prompt"), "out": mtok(pr, "completion"),
-                           "cache_read": mtok(pr, "input_cache_read"),
-                           "cache_write": mtok(pr, "input_cache_write")}
+        entry = {"in": mtok(pr, "prompt"), "out": mtok(pr, "completion"),
+                 "cache_read": mtok(pr, "input_cache_read"),
+                 "cache_write": mtok(pr, "input_cache_write")}
+        for field in ("name", "canonical_slug", "owned_by"):
+            value = m.get(field)
+            if isinstance(value, str) and value.strip():
+                entry[field] = value.strip()
+        models[m["id"]] = entry
     payload = {"_meta": {"source": "openrouter/api/v1/models",
                          "updated_at": datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S%z"),
                          "count": len(models)},


### PR DESCRIPTION
## 为什么改

OpenClaw 和 Hermes 对模型 ID 的处理方式不一致。

同一个模型在 Hermes 中显示为原始模型名，但 OpenClaw 在找不到匹配项时会回退到代表性模型。这样会造成两个问题：模型名称显示不准，价格也可能按错误的模型计算。

## 改了什么

### 统一模型身份

模型 ID 现在按以下顺序处理：

1. 已有 alias；
2. 标准模型 ID；
3. 公开模型目录中的 `canonical_slug`；
4. 没有匹配结果时，保留原始 ID。

无法确认的模型不会再被猜成 Opus 或其他模型。

模型展示和价格计算使用同一个模型身份，避免两边各自处理后产生不同结果。

### 保存模型目录信息

价格更新仍然使用 OpenRouter 的公开模型目录，同时保存模型的 `name`、`canonical_slug`、`owned_by` 以及输入、输出和缓存价格。

这些信息用于后续的精确匹配和价格查询。

### 修正 OpenClaw 与 Hermes

OpenClaw 和 Hermes 现在使用同一套模型身份逻辑。模型明细中会保留 `model_id`，这样后续重新计算成本或合并多设备数据时，不需要再从显示名称反推模型。

### 补齐模型明细 UI

Hermes 和 OpenClaw 卡片接入现有的“按模型”展开区，与其他 token Agent 保持一致。

模型展开区支持查看各模型的 token 总量、输入、输出、缓存和估算成本。没有 token/model 明细的任务记录仍然只显示任务状态。

## 数据示例

对于能在公开目录中精确匹配的模型：

```text
raw model ID       provider/model-v2026
canonical model ID provider/model
display name       Model
pricing source     public catalog
```

没有匹配结果时：

```text
raw model ID       vendor/model-variant
canonical model ID vendor/model-variant
display name       Vendor Model Variant
pricing source     unavailable
```

这种情况下保留原始模型名称，不使用其他模型的名称或价格。

## 数据影响

Token 数量、会话数、任务数和日期归属不会改变。

重新扫描后，模型分组名称、模型明细行、无权威账单时的估算成本，以及多设备合并后的模型列表可能发生变化。原始日志仍然存在时，旧数据可以按新的模型身份重新归类。

## 验证

- `python3 -m unittest discover -s tests`
  - 212 tests passed
- `swift build -c debug`
  - passed
- `git diff --check`
  - passed
- Release `.app` 和 `.dmg`
  - 构建成功
  - 签名验证通过
- OpenClaw 与 Hermes 数据检查
  - 模型身份统一
  - Token 数量与原始 usage 一致
  - 模型展开区可以正常显示
  - 多设备模型合并保持稳定
