### PR TITLE
feat: 添加 Cursor、Zed、Sub2API、z.ai 与 Antigravity 额度/用量

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪 20+ 款 AI 编程工具
 | **Claude Code** | Token（输入/输出/缓存）、成本、配额、模型 |
 | **Codex CLI** | Token、成本、配额、会话 |
 | **Gemini / Antigravity CLI** | Token、思考量、成本、模型 |
-| **Cursor** | 套餐额度、Cursor/第三方模型占比、按量预算、Grok Bot 周额度 |
+| **Cursor** | 账号 Token、请求、API 价成本、按模型统计、套餐额度与 Grok Bot 周额度 |
 | **Zed** | Edit Predictions、订阅周期、账号与套餐 |
 | **Sub2API** | 日/周/月额度、限流窗口、余额、请求与 Token 摘要 |
-| **z.ai / GLM** | 会话/周期/MCP 额度、套餐、BigModel CN 余额 |
+| **z.ai / GLM** | 近 30 天账号 Token、按模型统计、会话/周期/MCP 额度、BigModel CN 余额 |
 | **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟、配额（本地日志；可选实时） |
 | **Qoder Desktop** | Token、缓存、会话、调用次数、模型 |
 | **QoderWork** | Token、调用次数、子 Agent、时长、上下文 |
@@ -93,13 +93,14 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪 20+ 款 AI 编程工具
 - 可自定义间隔时间
 
 ### 隐私优先
-- 核心 Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据；外部额度卡只读取对应 Provider 返回的账号额度摘要
+- 核心 Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据；Cursor 与 z.ai 还可读取对应 Provider 返回的账号级 Token/模型摘要
 - Codex 额度使用本机 Codex 登录态读取官方接口；重置卡每天最多自动查询一次
 - Grok 实时额度默认关闭，可选择只读本地日志
 - 千问办公额度默认关闭；开启后仅调用官方桌面端的 `127.0.0.1` MCP，由已运行并登录的千问办公查询官方额度
 - Tokei 不读取或解密千问办公的 `auth-v2.dat`、浏览器 Cookie 或 `.status.json` 账号资料；仅用 `.status.json` 文件元数据使切换账号后的额度缓存失效，也不会自动启动千问办公
 - Cursor、Zed、Sub2API、z.ai 卡片默认关闭；开启后才查询额度。Sub2API 与 z.ai API Key 保存于 macOS Keychain，不写入 `config.json` 或额度缓存
 - Cursor 只读取 Cursor.app 的本地登录态数据库；Zed 以禁止交互的方式读取现有 Keychain 登录态，不会弹出授权框
+- Cursor 与 z.ai 的账号级统计在 Dashboard 中单独展示，不并入本地工具总计，避免与 Claude Code 等本地日志重复计算
 - Antigravity 额度只连接已运行客户端的 `127.0.0.1` language server，不会自动启动客户端
 - 这 5 个 Provider 的额度与账号标签只保存在本机缓存，不写入多设备 Git 同步快照
 - 其他联网操作包括检查/下载更新，以及手动更新模型价格表
@@ -174,10 +175,10 @@ chmod +x ~/.tokei/tokei-sync.sh
 | Claude Code | `~/.claude/projects/<proj>/<session>.jsonl` |
 | Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
 | Gemini / Antigravity CLI | `~/.gemini/antigravity-cli/conversations/*.db` + `~/.gemini/gemini-cli/conversations/*.json` |
-| Cursor | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` 登录态 + `cursor.com/api/usage-summary`（卡片默认关闭） |
+| Cursor | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` 登录态 + Cursor usage summary / usage-events API（卡片默认关闭） |
 | Zed | `~/.config/zed/settings.json` + Zed Keychain 登录态 + Cloud API（卡片默认关闭） |
 | Sub2API | macOS Keychain API Key + 自定义 Base URL 的 `/v1/usage`（卡片默认关闭） |
-| z.ai / GLM | macOS Keychain API Key + Global/BigModel CN quota API（卡片默认关闭） |
+| z.ai / GLM | macOS Keychain API Key + Global/BigModel CN quota / model-usage API（卡片默认关闭） |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl`（含真实 token + billing 额度）+ `sessions/*/*/{summary,signals}.json`；可选实时账单接口（设置里默认关闭） |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
@@ -222,6 +223,8 @@ chmod +x ~/.tokei/tokei-sync.sh
 ### Unreleased
 
 - feat(provider): 新增 Cursor、Zed、Sub2API、z.ai / GLM 额度卡
+- feat(provider-usage): Cursor 与 z.ai 新增账号 Token、按模型统计及 Dashboard 独立账号模型区
+- fix(antigravity): 兼容新版会话库把生成时间迁移到 `steps.metadata` 后的 Token 解析
 - feat(antigravity): 在现有 Gemini / Antigravity 卡片中读取本机 language server 额度
 - privacy: 外部 Provider 默认关闭，API Key 存入 macOS Keychain，账号额度不进入 Git 同步快照
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@
 
 ## 什么是 Tokei？
 
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **18 款 AI 工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
-Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编程工具** 上的用量、成本和性能。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态。
+Tokei 是一款 **macOS 菜单栏应用**，实时追踪 20+ 款 AI 编程工具的用量、成本和额度。Token 统计以本地日志为主，额度查询使用对应工具已有的本机登录态或用户明确保存的 API Key。
 
 ### 支持的工具
 
@@ -29,6 +28,10 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编�
 | **Claude Code** | Token（输入/输出/缓存）、成本、配额、模型 |
 | **Codex CLI** | Token、成本、配额、会话 |
 | **Gemini / Antigravity CLI** | Token、思考量、成本、模型 |
+| **Cursor** | 套餐额度、Cursor/第三方模型占比、按量预算、Grok Bot 周额度 |
+| **Zed** | Edit Predictions、订阅周期、账号与套餐 |
+| **Sub2API** | 日/周/月额度、限流窗口、余额、请求与 Token 摘要 |
+| **z.ai / GLM** | 会话/周期/MCP 额度、套餐、BigModel CN 余额 |
 | **Grok Build** | Token（输入/输出/缓存/推理）、会话、上下文、延迟、配额（本地日志；可选实时） |
 | **Qoder Desktop** | Token、缓存、会话、调用次数、模型 |
 | **QoderWork** | Token、调用次数、子 Agent、时长、上下文 |
@@ -90,12 +93,16 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪你在 **13 款 AI 编�
 - 可自定义间隔时间
 
 ### 隐私优先
-- Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据
+- 核心 Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据；外部额度卡只读取对应 Provider 返回的账号额度摘要
 - Codex 额度使用本机 Codex 登录态读取官方接口；重置卡每天最多自动查询一次
 - Grok 实时额度默认关闭，可选择只读本地日志
 - 千问办公额度默认关闭；开启后仅调用官方桌面端的 `127.0.0.1` MCP，由已运行并登录的千问办公查询官方额度
 - Tokei 不读取或解密千问办公的 `auth-v2.dat`、浏览器 Cookie 或 `.status.json` 账号资料；仅用 `.status.json` 文件元数据使切换账号后的额度缓存失效，也不会自动启动千问办公
-- 其余联网操作仅用于检查/下载更新，以及手动更新模型价格表
+- Cursor、Zed、Sub2API、z.ai 卡片默认关闭；开启后才查询额度。Sub2API 与 z.ai API Key 保存于 macOS Keychain，不写入 `config.json` 或额度缓存
+- Cursor 只读取 Cursor.app 的本地登录态数据库；Zed 以禁止交互的方式读取现有 Keychain 登录态，不会弹出授权框
+- Antigravity 额度只连接已运行客户端的 `127.0.0.1` language server，不会自动启动客户端
+- 这 5 个 Provider 的额度与账号标签只保存在本机缓存，不写入多设备 Git 同步快照
+- 其他联网操作包括检查/下载更新，以及手动更新模型价格表
 
 ## 快速开始
 
@@ -160,13 +167,17 @@ chmod +x ~/.tokei/tokei-sync.sh
 
 ## 数据来源
 
-Token、成本和项目统计来自 **本地日志文件**。额度查询仅使用对应工具已有的本机登录态；需联网的额度功能会在下表标明。
+核心 Token、成本和项目统计来自 **本地日志文件**。额度查询使用对应工具已有的本机登录态或 Keychain API Key；需联网的额度功能会在下表标明。
 
 | 工具 | 日志路径 |
 |------|----------|
 | Claude Code | `~/.claude/projects/<proj>/<session>.jsonl` |
 | Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
 | Gemini / Antigravity CLI | `~/.gemini/antigravity-cli/conversations/*.db` + `~/.gemini/gemini-cli/conversations/*.json` |
+| Cursor | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` 登录态 + `cursor.com/api/usage-summary`（卡片默认关闭） |
+| Zed | `~/.config/zed/settings.json` + Zed Keychain 登录态 + Cloud API（卡片默认关闭） |
+| Sub2API | macOS Keychain API Key + 自定义 Base URL 的 `/v1/usage`（卡片默认关闭） |
+| z.ai / GLM | macOS Keychain API Key + Global/BigModel CN quota API（卡片默认关闭） |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl`（含真实 token + billing 额度）+ `sessions/*/*/{summary,signals}.json`；可选实时账单接口（设置里默认关闭） |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
 | OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
@@ -190,7 +201,7 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 
 | 功能 | Tokei | [CodexBar](https://github.com/steipete/CodexBar) |
 |------|:-----:|:---------:|
-| 支持工具 | 18 | 40+ |
+| 支持工具 | 20+ | 40+ |
 | Token 级用量分析 | ✅ | — |
 | 成本估算（317 模型） | ✅ | 部分 |
 | 数据面板（图表 + 热力图） | ✅ | — |
@@ -200,12 +211,19 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 | 年度回顾 | ✅ | — |
 | 防休眠 / 久坐提醒 | ✅ | — |
 | 需要联网 | 仅额度查询、更新等功能 | 是 |
-| 需要登录 | 否 | 是 |
-| 数据来源 | 本地日志 | 远程 API |
+| 需要登录 | 核心统计否；外部额度卡复用已有登录态/API Key | 是 |
+| 数据来源 | 本地日志为主；可选额度 API | 远程 API |
 
-> CodexBar 在提供商覆盖和配额可见性上表现出色。Tokei 更深入——Token 级分析、成本趋势、项目维度拆分、跨设备同步——全部无需登录。
+> CodexBar 在提供商覆盖和配额可见性上表现出色。Tokei 更深入——核心 Token 分析、成本趋势、项目维度拆分与跨设备同步仍以本地日志为主；外部额度卡按需复用现有登录态。
+> Cursor、Zed、Sub2API、z.ai 与 Antigravity 额度协议的实现参考了 CodexBar 对应 provider，并按 Tokei 的本地优先、显式开关和统一缓存模型重新实现。
 
 ## 更新日志
+
+### Unreleased
+
+- feat(provider): 新增 Cursor、Zed、Sub2API、z.ai / GLM 额度卡
+- feat(antigravity): 在现有 Gemini / Antigravity 卡片中读取本机 language server 额度
+- privacy: 外部 Provider 默认关闭，API Key 存入 macOS Keychain，账号额度不进入 Git 同步快照
 
 ### v1.0.19
 
@@ -339,12 +357,11 @@ Token、成本和项目统计来自 **本地日志文件**。额度查询仅使�
 
 ## English
 
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **18 AI tools** in real-time. Usage analytics are local-first; quota checks use each tool's existing local sign-in and may contact its official service.
-Tokei is a **macOS menu bar app** that tracks usage, cost, and performance across **13 AI coding tools** in real-time — all from local log files, with zero network traffic.
+Tokei is a **macOS menu bar app** that tracks usage, cost, and quotas across **20+ AI coding tools** in real-time. Usage analytics are local-first; optional quota cards reuse an existing local sign-in or an API key explicitly stored in macOS Keychain.
 
 **Features:** Real-time monitoring (30s refresh, seven menu bar styles, three density modes) · Cost estimation (317 models, OpenRouter pricing) · Dashboard (daily chart, weekly heatmap) · Time ranges (today/week/month/year) · Project-level tracking · Multi-device sync (Git-based, Mac + Linux) · Annual Wrapped · Keep awake · Sit reminder · Privacy-first (local usage logs, explicit quota controls) · [Compare with CodexBar](https://tokei.lanshuagent.com#compare)
 
-**Supported tools:** Claude Code, Codex CLI, Gemini CLI / Antigravity, Grok Build, Qoder Desktop, QoderWork, Qoder CLI, Hermes, ZCode, MiMoCode, OpenClaw, Pi Coding Agent CLI, WorkBuddy, DeepSeek Harness, OpenCode, Qwen Code, Kimi Code, QwenWork
+**Supported tools:** Claude Code, Codex CLI, Gemini CLI / Antigravity, Cursor, Zed, Sub2API, z.ai / GLM, Grok Build, Qoder Desktop, QoderWork, Qoder CLI, Hermes, ZCode, MiMoCode, OpenClaw, Pi Coding Agent CLI, Prime Agent, WorkBuddy, DeepSeek Harness, OpenCode, Qwen Code, Kimi Code, QwenWork
 
 For full documentation, visit [tokei.lanshuagent.com](https://tokei.lanshuagent.com).
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ cd tokei/Tokei
 bash package.sh
 open Tokei.app
 ```
+
+`package.sh` 会优先使用本机可用的 Developer ID / Apple Development
+证书，让 Keychain 中的 Provider 密钥在重复构建后仍可访问；没有证书时会回退到
+ad-hoc 签名。可用 `TOKEI_CODESIGN_IDENTITY=- bash package.sh` 强制 ad-hoc，或用
+`TOKEI_CODESIGN_IDENTITY="证书名称" bash package.sh` 指定签名身份。
+
 </details>
 
 ## 多设备同步配置

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -94,6 +94,14 @@ struct DashboardPayload: Codable {
     var wrapped: WrappedData
 }
 
+private struct DashboardProviderQuotaItem: Identifiable {
+    var id: String
+    var title: String
+    var quota: ProviderQuotaStat
+    var usage: TokenUsageRange?
+    var tint: Color
+}
+
 final class DashboardRepository: ObservableObject {
     static let shared = DashboardRepository()
 
@@ -155,6 +163,42 @@ struct DashboardView: View {
     @State private var wrappedPeriod: WrappedPeriod = .all
     @AppStorage("hideProjects") private var hideProjects = false
 
+    private var providerRangeKey: RangeKey {
+        switch wrappedPeriod {
+        case .day: return .today
+        case .week: return .week
+        case .month: return .month
+        case .year: return .year
+        case .all: return .all
+        }
+    }
+
+    private var providerQuotaItems: [DashboardProviderQuotaItem] {
+        guard let usage = store.usage else { return [] }
+        let range = providerRangeKey
+        let candidates: [(id: String, title: String, quota: ProviderQuotaStat,
+                         usage: TokenUsageRange?, tint: Color)] = [
+            ("antigravity", "Gemini / Antigravity", usage.antigravity, nil, Theme.gemini),
+            ("cursor", "Cursor", usage.cursor,
+             usage.cursor.usage?.ranges.get(range), Theme.cursor),
+            ("zed", "Zed", usage.zed, nil, Theme.zed),
+            ("sub2api", "Sub2API", usage.sub2api,
+             usage.sub2api.usage?.ranges.get(range), Theme.sub2api),
+            ("zai", "z.ai / GLM", usage.zai,
+             usage.zai.usage?.ranges.get(range), Theme.zai),
+        ]
+        return candidates.compactMap { candidate in
+            guard candidate.quota.available else { return nil }
+            return DashboardProviderQuotaItem(
+                id: candidate.id,
+                title: candidate.title,
+                quota: candidate.quota,
+                usage: candidate.usage,
+                tint: candidate.tint
+            )
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             if loading {
@@ -163,6 +207,10 @@ struct DashboardView: View {
             } else {
                 if let w = wrapped, w.total_tokens > 0 {
                     WrappedView(data: w, period: $wrappedPeriod) { p in loadWrapped(p) }
+                }
+                if !providerQuotaItems.isEmpty {
+                    Divider().opacity(0.15)
+                    providerQuotaSection(providerQuotaItems)
                 }
                 if !models.isEmpty {
                     Divider().opacity(0.15)
@@ -185,10 +233,158 @@ struct DashboardView: View {
         .onAppear { loadData(showLoading: true) }
         .onChange(of: store.showAllDevices) { _ in applyCachedScope(animated: true) }
         .onChange(of: store.syncEnabled) { _ in applyCachedScope(animated: true) }
-        .onReceive(store.$usage) { _ in applyCachedScope(animated: false) }
+        .onReceive(store.$usage) { _ in
+            applyCachedScope(animated: false)
+            // Provider model days are written by the main refresh. Reload the
+            // lightweight dashboard aggregation after that refresh completes so
+            // z.ai/Cursor model rows stay in sync with the quota cards.
+            dashboardRepository.load(wrappedPeriod, force: true)
+        }
         .onReceive(dashboardRepository.$payloads) { payloads in
             guard let payload = payloads[wrappedPeriod.rawValue] else { return }
             apply(payload, animated: false)
+        }
+    }
+
+    @ViewBuilder
+    private func providerQuotaSection(_ items: [DashboardProviderQuotaItem]) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("账号额度")
+                .font(.system(size: 13, weight: .bold))
+            Text("额度来自本机账号登录态；账号用量单独展示，不并入本地工具总计")
+                .font(.system(size: 9))
+                .foregroundStyle(Theme.tTertiary)
+            ForEach(items) { item in
+                providerQuotaCard(item)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func providerQuotaCard(_ item: DashboardProviderQuotaItem) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Circle().fill(item.tint.gradient).frame(width: 7, height: 7)
+                Text(item.title)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(Theme.tPrimary)
+                if let plan = item.quota.plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.system(size: 8.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Theme.tSecondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(item.tint.opacity(0.14)))
+                }
+                Spacer(minLength: 6)
+                if let account = item.quota.account, !account.isEmpty {
+                    Text(account)
+                        .font(.system(size: 8.5, design: .monospaced))
+                        .foregroundStyle(Theme.tTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            if let usage = item.usage, usage.totalTokens > 0 {
+                HStack(spacing: 6) {
+                    Text("\(wrappedPeriod.label)账号 Token")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(Theme.tTertiary)
+                    Spacer()
+                    Text("\(Fmt.human(usage.totalTokens)) · \(usage.models.count) 个模型")
+                        .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(item.tint)
+                }
+            }
+
+            ForEach(item.quota.windows) { window in
+                dashboardQuotaWindow(window, tint: item.tint)
+            }
+
+            if !item.quota.details.isEmpty {
+                VStack(spacing: 4) {
+                    ForEach(Array(item.quota.details.prefix(6).enumerated()), id: \.offset) { entry in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(entry.element.label)
+                                .font(.system(size: 9))
+                                .foregroundStyle(Theme.tTertiary)
+                            Spacer(minLength: 6)
+                            Text(entry.element.value)
+                                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(Theme.tSecondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+
+            HStack(spacing: 5) {
+                Image(systemName: item.quota.stale ? "exclamationmark.triangle" : "clock")
+                    .font(.system(size: 8.5))
+                Text(item.quota.stale
+                     ? "额度数据已过期"
+                     : (item.quota.updated.map { "更新于 \(Fmt.reset($0))" } ?? "尚无更新时间"))
+                    .font(.system(size: 8.5, design: .monospaced))
+                Spacer()
+            }
+            .foregroundStyle(item.quota.stale ? Color.orange : Theme.tTertiary)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(item.tint.opacity(0.16), lineWidth: 0.5)
+                )
+        )
+    }
+
+    @ViewBuilder
+    private func dashboardQuotaWindow(_ window: ProviderQuotaWindow, tint: Color) -> some View {
+        if window.usage_known, let used = window.used_pct {
+            let remaining = max(0, min(100, 100 - used))
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(window.title)
+                        .font(.system(size: 10))
+                        .foregroundStyle(Theme.tSecondary)
+                    Spacer(minLength: 6)
+                    Text(String(format: "%.0f%% 剩余", remaining))
+                        .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(tint)
+                }
+                MiniBar(value: remaining, tint: tint)
+                if window.detail != nil || window.reset != nil {
+                    HStack(spacing: 6) {
+                        if let detail = window.detail, !detail.isEmpty {
+                            Text(detail)
+                                .font(.system(size: 8.5, design: .monospaced))
+                                .foregroundStyle(Theme.tTertiary)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 4)
+                        if let reset = window.reset {
+                            Text("重置 \(Fmt.reset(reset))")
+                                .font(.system(size: 8.5, design: .monospaced))
+                                .foregroundStyle(Theme.tTertiary)
+                        }
+                    }
+                }
+            }
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(window.title)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tSecondary)
+                Spacer(minLength: 6)
+                Text(window.detail ?? "额度比例未知")
+                    .font(.system(size: 8.5, design: .monospaced))
+                    .foregroundStyle(Theme.tTertiary)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(2)
+            }
         }
     }
 
@@ -630,7 +826,8 @@ struct DashboardView: View {
                 models = baseModels
                 wrapped = baseWrapped
             }
-            if !daily.isEmpty || !models.isEmpty || !providerModels.isEmpty || wrapped != nil {
+            if !daily.isEmpty || !models.isEmpty || !providerModels.isEmpty
+                || !providerQuotaItems.isEmpty || wrapped != nil {
                 loading = false
             }
         }

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -84,11 +84,13 @@ struct ModelCost: Codable, Identifiable {
 struct DashboardData: Codable {
     var daily: [DailyCost]
     var models: [ModelCost]
+    var provider_models: [ModelCost]? = nil
 }
 
 struct DashboardPayload: Codable {
     var daily: [DailyCost]
     var models: [ModelCost]
+    var provider_models: [ModelCost]? = nil
     var wrapped: WrappedData
 }
 
@@ -143,9 +145,11 @@ struct DashboardView: View {
     @ObservedObject private var dashboardRepository = DashboardRepository.shared
     @State private var daily: [DailyCost] = []
     @State private var models: [ModelCost] = []
+    @State private var providerModels: [ModelCost] = []
     @State private var wrapped: WrappedData? = nil
     @State private var baseDaily: [DailyCost] = []
     @State private var baseModels: [ModelCost] = []
+    @State private var baseProviderModels: [ModelCost] = []
     @State private var baseWrapped: WrappedData? = nil
     @State private var loading = true
     @State private var wrappedPeriod: WrappedPeriod = .all
@@ -160,9 +164,15 @@ struct DashboardView: View {
                 if let w = wrapped, w.total_tokens > 0 {
                     WrappedView(data: w, period: $wrappedPeriod) { p in loadWrapped(p) }
                 }
-                if !daily.isEmpty {
+                if !models.isEmpty {
                     Divider().opacity(0.15)
                     modelSection
+                }
+                if !providerModels.isEmpty {
+                    Divider().opacity(0.15)
+                    providerModelSection
+                }
+                if !daily.isEmpty {
                     if let w = wrapped, !w.projects.isEmpty {
                         Divider().opacity(0.15)
                         projectsSection(w.projects)
@@ -201,10 +211,33 @@ struct DashboardView: View {
         }
     }
 
+    var providerModelSection: some View {
+        let sorted = providerModels.sorted { ($0.tokens ?? 0) > ($1.tokens ?? 0) }
+        let top = Array(sorted.prefix(8))
+        let maxTokens = Double(top.first?.tokens ?? 1)
+        return VStack(alignment: .leading, spacing: 9) {
+            Text("账号 Provider 模型").font(.system(size: 13, weight: .bold))
+            Text("账号级统计单独展示，不并入本地工具总计")
+                .font(.system(size: 9))
+                .foregroundStyle(Theme.tTertiary)
+            ForEach(top) { model in
+                StatBar(
+                    name: model.name,
+                    tokens: model.tokens ?? ((model.in ?? 0) + (model.out ?? 0)),
+                    cost: model.cost,
+                    maxTokens: maxTokens,
+                    tint: modelTint(model.tool)
+                )
+            }
+        }
+    }
+
     func modelTint(_ tool: String) -> Color {
         switch tool {
         case "codex": return Theme.codex
         case "gemini": return Theme.gemini
+        case "cursor": return Theme.cursor
+        case "zai": return Theme.zai
         case "grok": return Theme.grok
         case "qoder": return Theme.qoder
         case "hermes": return Theme.hermes
@@ -561,7 +594,7 @@ struct DashboardView: View {
     func loadData(showLoading: Bool = false) {
         if let cached = dashboardRepository.payload(for: wrappedPeriod) {
             apply(cached, animated: false)
-        } else if showLoading || (daily.isEmpty && models.isEmpty && wrapped == nil) {
+        } else if showLoading || (daily.isEmpty && models.isEmpty && providerModels.isEmpty && wrapped == nil) {
             loading = true
         }
         dashboardRepository.load(wrappedPeriod)
@@ -577,6 +610,7 @@ struct DashboardView: View {
     func apply(_ payload: DashboardPayload, animated: Bool) {
         baseDaily = payload.daily
         baseModels = payload.models
+        baseProviderModels = payload.provider_models ?? []
         baseWrapped = payload.wrapped
         applyCachedScope(animated: animated)
         loading = false
@@ -585,6 +619,7 @@ struct DashboardView: View {
     func applyCachedScope(animated: Bool) {
         let update = {
             let fallback = DashboardData(daily: baseDaily, models: baseModels)
+            providerModels = baseProviderModels
             if let scoped = scopedUsage() {
                 let scopedDaily = allDeviceDaily(period: wrappedPeriod)
                 daily = scopedDaily
@@ -595,7 +630,7 @@ struct DashboardView: View {
                 models = baseModels
                 wrapped = baseWrapped
             }
-            if !daily.isEmpty || !models.isEmpty || wrapped != nil {
+            if !daily.isEmpty || !models.isEmpty || !providerModels.isEmpty || wrapped != nil {
                 loading = false
             }
         }

--- a/Tokei/Sources/Tokei/DataLoader.swift
+++ b/Tokei/Sources/Tokei/DataLoader.swift
@@ -669,6 +669,9 @@ final class DataLoader {
         }
         var environment = ProcessInfo.processInfo.environment
         environment["TOKEI_DSH_DECOMPRESSED_DIR"] = deepSeekSessions.path
+        for (key, value) in ProviderCredentialStore.environmentOverrides() {
+            environment[key] = value
+        }
         proc.environment = environment
         let outPipe = Pipe()
         let errPipe = Pipe()

--- a/Tokei/Sources/Tokei/Design.swift
+++ b/Tokei/Sources/Tokei/Design.swift
@@ -32,6 +32,10 @@ enum Theme {
     static let claude = Color(red: 0.92, green: 0.52, blue: 0.40)   // 柔珊瑚
     static let codex  = Color(red: 0.42, green: 0.68, blue: 0.98)   // 天青
     static let gemini = Color(red: 0.62, green: 0.52, blue: 0.92)   // 薰衣草
+    static let cursor = Color(red: 0.72, green: 0.77, blue: 0.90)   // 光标银蓝
+    static let zed = Color(red: 0.93, green: 0.38, blue: 0.30)      // Zed 珊瑚红
+    static let sub2api = Color(red: 0.18, green: 0.78, blue: 0.85)  // API 青
+    static let zai = Color(red: 0.38, green: 0.67, blue: 0.98)      // GLM 蓝
     static let grok   = Color(red: 0.65, green: 0.68, blue: 0.75)   // 冷灰银
     static let qoder  = Color(red: 0.90, green: 0.75, blue: 0.35)   // 琥珀金
     static let qoderwork = Color(red: 0.75, green: 0.65, blue: 0.30)  // 暗琥珀

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -748,6 +748,65 @@ struct QwenWorkQuota: Codable {
     }
 }
 
+struct ProviderQuotaWindow: Codable, Identifiable {
+    var id = ""
+    var title = ""
+    var used_pct: Double?
+    var reset: Int?
+    var window_minutes: Int?
+    var detail: String?
+    var usage_known = true
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id) ?? ""
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? id
+        used_pct = try? c.decodeIfPresent(Double.self, forKey: .used_pct)
+        reset = try? c.decodeIfPresent(Int.self, forKey: .reset)
+        window_minutes = try? c.decodeIfPresent(Int.self, forKey: .window_minutes)
+        detail = try? c.decodeIfPresent(String.self, forKey: .detail)
+        usage_known = (try? c.decodeIfPresent(Bool.self, forKey: .usage_known)) ?? true
+    }
+}
+
+struct ProviderQuotaDetail: Codable {
+    var label = ""
+    var value = ""
+    var secondary: String?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        label = try c.decodeIfPresent(String.self, forKey: .label) ?? ""
+        value = try c.decodeIfPresent(String.self, forKey: .value) ?? ""
+        secondary = try? c.decodeIfPresent(String.self, forKey: .secondary)
+    }
+}
+
+struct ProviderQuotaStat: Codable {
+    var available = false
+    var plan: String?
+    var account: String?
+    var windows: [ProviderQuotaWindow] = []
+    var details: [ProviderQuotaDetail] = []
+    var source: String?
+    var updated: Int?
+    var stale = false
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        available = (try? c.decodeIfPresent(Bool.self, forKey: .available)) ?? false
+        plan = try? c.decodeIfPresent(String.self, forKey: .plan)
+        account = try? c.decodeIfPresent(String.self, forKey: .account)
+        windows = (try? c.decodeIfPresent([ProviderQuotaWindow].self, forKey: .windows)) ?? []
+        details = (try? c.decodeIfPresent([ProviderQuotaDetail].self, forKey: .details)) ?? []
+        source = try? c.decodeIfPresent(String.self, forKey: .source)
+        updated = try? c.decodeIfPresent(Int.self, forKey: .updated)
+        stale = (try? c.decodeIfPresent(Bool.self, forKey: .stale)) ?? false
+    }
+}
+
 struct Usage: Codable {
     var claude: ClaudeStat
     var codex: CodexStat
@@ -768,11 +827,16 @@ struct Usage: Codable {
     var qwencode: TokenUsageStat
     var qwenwork: QwenWorkQuota
     var kimicode: TokenUsageStat
+    var antigravity: ProviderQuotaStat
+    var cursor: ProviderQuotaStat
+    var zed: ProviderQuotaStat
+    var sub2api: ProviderQuotaStat
+    var zai: ProviderQuotaStat
 
     enum CodingKeys: String, CodingKey {
         case claude, codex, gemini, grok, qoder, qoderwork, qodercli, hermes, zcode, mimocode
         case openclaw, pi, workbuddy, deepseekHarness = "deepseek_harness", opencode, qwencode
-        case qwenwork, kimicode, prime_agent
+        case qwenwork, kimicode, prime_agent, antigravity, cursor, zed, sub2api, zai
     }
 
     init(from decoder: Decoder) throws {
@@ -800,6 +864,11 @@ struct Usage: Codable {
         qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)
         qwenwork = (try? c.decodeIfPresent(QwenWorkQuota.self, forKey: .qwenwork)) ?? QwenWorkQuota()
         kimicode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .kimicode) ?? TokenUsageStat(ranges: .empty)
+        antigravity = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .antigravity) ?? ProviderQuotaStat()
+        cursor = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .cursor) ?? ProviderQuotaStat()
+        zed = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .zed) ?? ProviderQuotaStat()
+        sub2api = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .sub2api) ?? ProviderQuotaStat()
+        zai = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .zai) ?? ProviderQuotaStat()
     }
 }
 

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -508,6 +508,7 @@ struct HermesRange: Codable {
 }
 struct TokenModelStat: Codable, Identifiable {
     var name: String
+    var tokens: Int?
     var `in`: Int
     var out: Int
     var cr: Int = 0
@@ -521,6 +522,7 @@ struct TokenModelStat: Codable, Identifiable {
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         name = try c.decode(String.self, forKey: .name)
+        tokens = try c.decodeIfPresent(Int.self, forKey: .tokens)
         `in` = try c.decodeIfPresent(Int.self, forKey: .in) ?? 0
         out = try c.decodeIfPresent(Int.self, forKey: .out) ?? 0
         cr = try c.decodeIfPresent(Int.self, forKey: .cr) ?? 0
@@ -604,6 +606,7 @@ struct OpenClawRanges: Codable {
 struct OpenClawStat: Codable { var ranges: OpenClawRanges }
 
 struct TokenUsageRange: Codable {
+    var tokens: Int
     var hit: Double
     var `in`: Int
     var out: Int
@@ -611,11 +614,24 @@ struct TokenUsageRange: Codable {
     var cw: Int
     var reason: Int
     var cost: Double
+    var requests: Int
     var sessions: Int = 0
     var models: [TokenModelStat] = []
+    var coverage: String?
 
-    init(hit: Double = 0, `in` input: Int = 0, out: Int = 0, cr: Int = 0, cw: Int = 0,
-         reason: Int = 0, cost: Double = 0, sessions: Int = 0, models: [TokenModelStat] = []) {
+    var totalTokens: Int {
+        tokens > 0 ? tokens : `in` + out + cr + cw + reason
+    }
+
+    var hasComponents: Bool {
+        `in` + out + cr + cw + reason > 0
+    }
+
+    init(tokens: Int = 0, hit: Double = 0, `in` input: Int = 0, out: Int = 0,
+         cr: Int = 0, cw: Int = 0, reason: Int = 0, cost: Double = 0,
+         requests: Int = 0, sessions: Int = 0, models: [TokenModelStat] = [],
+         coverage: String? = nil) {
+        self.tokens = tokens
         self.hit = hit
         self.in = input
         self.out = out
@@ -623,12 +639,15 @@ struct TokenUsageRange: Codable {
         self.cw = cw
         self.reason = reason
         self.cost = cost
+        self.requests = requests
         self.sessions = sessions
         self.models = models
+        self.coverage = coverage
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        tokens = try c.decodeIfPresent(Int.self, forKey: .tokens) ?? 0
         hit = try c.decodeIfPresent(Double.self, forKey: .hit) ?? 0
         `in` = try c.decodeIfPresent(Int.self, forKey: .in) ?? 0
         out = try c.decodeIfPresent(Int.self, forKey: .out) ?? 0
@@ -636,8 +655,10 @@ struct TokenUsageRange: Codable {
         cw = try c.decodeIfPresent(Int.self, forKey: .cw) ?? 0
         reason = try c.decodeIfPresent(Int.self, forKey: .reason) ?? 0
         cost = try c.decodeIfPresent(Double.self, forKey: .cost) ?? 0
+        requests = try c.decodeIfPresent(Int.self, forKey: .requests) ?? 0
         sessions = try c.decodeIfPresent(Int.self, forKey: .sessions) ?? 0
         models = try c.decodeIfPresent([TokenModelStat].self, forKey: .models) ?? []
+        coverage = try c.decodeIfPresent(String.self, forKey: .coverage)
     }
 }
 struct TokenUsageRanges: Codable {
@@ -788,6 +809,7 @@ struct ProviderQuotaStat: Codable {
     var account: String?
     var windows: [ProviderQuotaWindow] = []
     var details: [ProviderQuotaDetail] = []
+    var usage: TokenUsageStat? = nil
     var source: String?
     var updated: Int?
     var stale = false
@@ -801,6 +823,7 @@ struct ProviderQuotaStat: Codable {
         account = try? c.decodeIfPresent(String.self, forKey: .account)
         windows = (try? c.decodeIfPresent([ProviderQuotaWindow].self, forKey: .windows)) ?? []
         details = (try? c.decodeIfPresent([ProviderQuotaDetail].self, forKey: .details)) ?? []
+        usage = try? c.decodeIfPresent(TokenUsageStat.self, forKey: .usage)
         source = try? c.decodeIfPresent(String.self, forKey: .source)
         updated = try? c.decodeIfPresent(Int.self, forKey: .updated)
         stale = (try? c.decodeIfPresent(Bool.self, forKey: .stale)) ?? false

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -188,6 +188,9 @@ struct GeminiRange: Codable {
     var cost: Double
     var models: [GeminiModelStat] = []
     var sessions: Int = 0
+
+    var totalTokens: Int { self.in + out + cached + thoughts }
+    var hasUsage: Bool { sessions > 0 || totalTokens > 0 }
 }
 
 struct GeminiRanges: Codable {
@@ -198,6 +201,35 @@ struct GeminiRanges: Codable {
     var month: GeminiRange
     var year: GeminiRange
     var all: GeminiRange?
+
+    /// A zero-activity selected range should not hide a recent local session.
+    /// Return the nearest useful range together with its real label so the UI
+    /// never presents yesterday/week data as today's data.
+    func displayRange(for preferred: RangeKey) -> (range: GeminiRange, key: RangeKey) {
+        let order: [RangeKey]
+        switch preferred {
+        case .today:
+            order = [.today, .yesterday, .week, .month, .year, .all]
+        case .yesterday:
+            order = [.yesterday, .today, .week, .month, .year, .all]
+        case .week:
+            order = [.week, .today, .yesterday, .month, .year, .all]
+        case .lastWeek:
+            order = [.lastWeek, .week, .month, .year, .all, .today, .yesterday]
+        case .month:
+            order = [.month, .year, .all, .week, .today, .yesterday]
+        case .year:
+            order = [.year, .all, .month, .week, .today, .yesterday]
+        case .all:
+            order = [.all, .year, .month, .week, .today, .yesterday]
+        }
+        for key in order {
+            let candidate = get(key)
+            if candidate.hasUsage { return (candidate, key) }
+        }
+        return (get(preferred), preferred)
+    }
+
     func get(_ k: RangeKey) -> GeminiRange {
         switch k {
         case .today: return today; case .yesterday: return yesterday

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -40,6 +40,10 @@ struct PanelView: View {
     @AppStorage("showClaude") private var showClaude = true
     @AppStorage("showCodex") private var showCodex = true
     @AppStorage("showGemini") private var showGemini = true
+    @AppStorage("showCursor") private var showCursor = false
+    @AppStorage("showZed") private var showZed = false
+    @AppStorage("showSub2API") private var showSub2API = false
+    @AppStorage("showZai") private var showZai = false
     @AppStorage("showGrok") private var showGrok = true
     @AppStorage("showQoderIde") private var showQoder = true
     @AppStorage("showQoderWork") private var showQoderWork = true
@@ -79,7 +83,8 @@ struct PanelView: View {
     }
 
     private var visibleCount: Int {
-        [showClaude, showCodex, showGemini, showGrok, showQoder, showQoderWork, showQoderCli, showHermes, showZcode, showMimoCode,
+        [showClaude, showCodex, showGemini, showCursor, showZed, showSub2API, showZai,
+         showGrok, showQoder, showQoderWork, showQoderCli, showHermes, showZcode, showMimoCode,
          showOpenClaw, showPi, showWorkBuddy, showDeepSeekHarness, showOpenCode, showQwenCode,
          showQwenWork, showKimiCode, showPrimeAgent].filter { $0 }.count
     }
@@ -340,8 +345,32 @@ struct PanelView: View {
                          active: xr.sessions > 0 || u.codex.p5 != nil || u.codex.pw != nil ||
                              (u.codex.reset_cards?.count ?? 0) > 0,
                          tint: Theme.codex, content: AnyView(codexBlock(u.codex, xr))),
-            ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini, active: gr.sessions > 0,
-                         tint: Theme.gemini, content: AnyView(geminiBlock(gr))),
+            ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini,
+                         active: gr.sessions > 0 || u.antigravity.available,
+                         tint: Theme.gemini,
+                         presentation: gr.sessions == 0 && u.antigravity.available
+                             ? .compactStatus : .standard,
+                         content: AnyView(geminiBlock(gr, quota: u.antigravity))),
+            ToolCardItem(id: "cursor", name: "Cursor", visible: showCursor, active: showCursor,
+                         tint: Theme.cursor, presentation: .compactStatus,
+                         content: AnyView(providerQuotaBlock(
+                            "Cursor", quota: u.cursor, tint: Theme.cursor,
+                            setupHint: "请确认 Cursor.app 已登录；Tokei 会复用其本地登录态读取额度。"))),
+            ToolCardItem(id: "zed", name: "Zed", visible: showZed, active: showZed,
+                         tint: Theme.zed, presentation: .compactStatus,
+                         content: AnyView(providerQuotaBlock(
+                            "Zed", quota: u.zed, tint: Theme.zed,
+                            setupHint: "请先在 Zed 中登录 GitHub；Tokei 会无弹窗读取现有 Keychain 登录态。"))),
+            ToolCardItem(id: "sub2api", name: "Sub2API", visible: showSub2API, active: showSub2API,
+                         tint: Theme.sub2api, presentation: .compactStatus,
+                         content: AnyView(providerQuotaBlock(
+                            "Sub2API", quota: u.sub2api, tint: Theme.sub2api,
+                            setupHint: "请在设置的「Provider 额度」中保存 Base URL 与 Group API Key。"))),
+            ToolCardItem(id: "zai", name: "z.ai / GLM", visible: showZai, active: showZai,
+                         tint: Theme.zai, presentation: .compactStatus,
+                         content: AnyView(providerQuotaBlock(
+                            "z.ai / GLM", quota: u.zai, tint: Theme.zai,
+                            setupHint: "请在设置的「Provider 额度」中选择区域并保存 API Key。"))),
             ToolCardItem(id: "grok", name: "Grok", visible: showGrok,
                          active: kr.sessions > 0 || kr.usage_calls > 0 || u.grok.pct != nil,
                          tint: Theme.grok,
@@ -643,9 +672,10 @@ struct PanelView: View {
 
     // MARK: - Gemini / Antigravity 卡片
     @ViewBuilder
-    func geminiBlock(_ r: GeminiRange) -> some View {
+    func geminiBlock(_ r: GeminiRange, quota: ProviderQuotaStat) -> some View {
         VStack(alignment: .leading, spacing: 11) {
-            cardHead("Gemini / Antigravity", tint: Theme.gemini, sessions: r.sessions, toolID: "gemini")
+            cardHead("Gemini / Antigravity", tint: Theme.gemini, sessions: r.sessions,
+                     toolID: r.sessions > 0 ? "gemini" : nil)
             if r.sessions > 0 {
                 CostHeadline(value: Fmt.human(r.in + r.cached + r.out + r.thoughts), caption: "\(sel.label) 总量", tint: Theme.gemini)
                 metricGrid([.init("dollarsign.circle", "≈成本", String(format: "$%.2f", r.cost))],
@@ -668,10 +698,139 @@ struct PanelView: View {
                     }
                     modelDisclosure(geminiRows, open: $geminiModelsOpen, tint: Theme.gemini)
                 }
-            } else {
+            } else if !quota.available {
                 emptyHint
             }
+            if quota.available {
+                if r.sessions > 0 { thinDivider }
+                providerQuotaContent(quota, tint: Theme.gemini)
+            }
         }
+    }
+
+    // MARK: - CodexBar-compatible quota providers
+    @ViewBuilder
+    func providerQuotaBlock(
+        _ title: String,
+        quota: ProviderQuotaStat,
+        tint: Color,
+        setupHint: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 11) {
+            cardHeadPlain(title, tint: tint)
+            if quota.available {
+                providerQuotaContent(quota, tint: tint)
+            } else {
+                Text(setupHint)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func providerQuotaContent(_ quota: ProviderQuotaStat, tint: Color) -> some View {
+        if quota.plan != nil || quota.account != nil {
+            HStack(spacing: 6) {
+                if let plan = quota.plan, !plan.isEmpty {
+                    providerQuotaPill(plan, tint: tint)
+                }
+                if let account = quota.account, !account.isEmpty {
+                    Text(account)
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundStyle(Theme.tTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+
+        ForEach(quota.windows) { window in
+            if window.usage_known, let used = window.used_pct {
+                quotaRow(
+                    title: window.title,
+                    pct: max(0, min(100, 100 - used)),
+                    detail: window.detail,
+                    reset: window.reset,
+                    tint: tint
+                )
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(window.title)
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.tSecondary)
+                    Spacer(minLength: 6)
+                    Text(window.detail ?? "额度比例未知")
+                        .font(.system(size: 9.5, design: .monospaced))
+                        .foregroundStyle(Theme.tTertiary)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+        }
+
+        if !quota.details.isEmpty {
+            thinDivider
+            VStack(spacing: 6) {
+                ForEach(Array(quota.details.prefix(12).enumerated()), id: \.offset) { item in
+                    let detail = item.element
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(detail.label)
+                            .font(.system(size: 10))
+                            .foregroundStyle(Theme.tTertiary)
+                        Spacer(minLength: 8)
+                        VStack(alignment: .trailing, spacing: 1) {
+                            Text(providerQuotaDetailValue(detail))
+                                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(Theme.tPrimary)
+                            if let secondary = detail.secondary, !secondary.isEmpty {
+                                Text(secondary)
+                                    .font(.system(size: 8.5, design: .monospaced))
+                                    .foregroundStyle(Theme.tTertiary)
+                                    .multilineTextAlignment(.trailing)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if quota.stale {
+            quotaStateNotice(
+                title: "额度数据已过期",
+                detail: "当前展示最近一次成功结果；登录态或网络恢复后会自动刷新。",
+                source: quota.source ?? "Provider 缓存",
+                updated: quota.updated,
+                tint: tint,
+                warning: true
+            )
+        } else if let updated = quota.updated {
+            HStack(spacing: 5) {
+                Image(systemName: "clock")
+                    .font(.system(size: 8.5))
+                Text("额度更新于 \(Fmt.reset(updated))")
+                    .font(.system(size: 9, design: .monospaced))
+                Spacer(minLength: 4)
+            }
+            .foregroundStyle(Theme.tTertiary)
+        }
+    }
+
+    func providerQuotaPill(_ text: String, tint: Color) -> some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+            .foregroundStyle(Theme.tSecondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(tint.opacity(0.16)))
+    }
+
+    func providerQuotaDetailValue(_ detail: ProviderQuotaDetail) -> String {
+        if detail.label.contains("到期"), let epoch = Int(detail.value) {
+            return Fmt.reset(epoch)
+        }
+        return detail.value
     }
 
     // MARK: - Grok 卡片
@@ -1942,6 +2101,13 @@ struct PanelView: View {
     @State private var debugOutput = ""
     @State private var debugExpanded = false
     @State private var cachedRemoteUrl = ""
+    @State private var sub2APIBaseURL = ""
+    @State private var sub2APIKey = ""
+    @State private var sub2APIKeyStored = false
+    @State private var zaiRegion = "global"
+    @State private var zaiKey = ""
+    @State private var zaiKeyStored = false
+    @State private var providerSettingsResult = ""
     @AppStorage("syncDir") private var syncDir = ""
     @AppStorage("deviceName") private var deviceName = ""
     @State private var configuredDeviceID: String?
@@ -1959,6 +2125,7 @@ struct PanelView: View {
             HStack(alignment: .top, spacing: 11) {
                 VStack(alignment: .leading, spacing: 11) {
                     settingsAgentsSection
+                    settingsProviderQuotaSection
                     settingsDiagnosticsSection
                     settingsPricingSection
                 }
@@ -1978,6 +2145,7 @@ struct PanelView: View {
         }
         .onAppear {
             loginItem.refresh()
+            loadProviderSettings()
             if let cfg = SyncManager.loadConfig() {
                 if let persistedID = Self.validSyncDeviceID(cfg.device_id) {
                     configuredDeviceID = persistedID
@@ -2115,6 +2283,10 @@ struct PanelView: View {
                 settingsRow("Claude", tint: Theme.claude, isOn: $showClaude)
                 settingsRow("Codex", tint: Theme.codex, isOn: $showCodex)
                 settingsRow("Gemini / Antigravity", tint: Theme.gemini, isOn: $showGemini)
+                settingsRow("Cursor", tint: Theme.cursor, isOn: $showCursor)
+                settingsRow("Zed", tint: Theme.zed, isOn: $showZed)
+                settingsRow("Sub2API", tint: Theme.sub2api, isOn: $showSub2API)
+                settingsRow("z.ai / GLM", tint: Theme.zai, isOn: $showZai)
                 settingsRow("Grok", tint: Theme.grok, isOn: $showGrok)
                 settingsRow("Qoder Desktop", tint: Theme.qoder, isOn: $showQoder)
                 settingsRow("QoderWork", tint: Theme.qoderwork, isOn: $showQoderWork)
@@ -2136,6 +2308,189 @@ struct PanelView: View {
         .onChange(of: showQoder) { enabled in
             Self.setQoderIdeEnabled(enabled)
         }
+        .onChange(of: showGemini) { enabled in
+            Self.setProviderQuotaEnabled("antigravity", enabled)
+            store.refresh()
+        }
+        .onChange(of: showCursor) { enabled in
+            Self.setProviderQuotaEnabled("cursor", enabled)
+            store.refresh()
+        }
+        .onChange(of: showZed) { enabled in
+            Self.setProviderQuotaEnabled("zed", enabled)
+            store.refresh()
+        }
+        .onChange(of: showSub2API) { enabled in
+            Self.setProviderQuotaEnabled("sub2api", enabled)
+            store.refresh()
+        }
+        .onChange(of: showZai) { enabled in
+            Self.setProviderQuotaEnabled("zai", enabled)
+            store.refresh()
+        }
+    }
+
+    var settingsProviderQuotaSection: some View {
+        settingsSection("key.horizontal.fill", "Provider 额度") {
+            Text("Cursor 复用 Cursor.app 登录态，Zed 复用 Zed Keychain；两者无需在 Tokei 中保存密钥。显示对应卡片即允许查询。")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            thinDivider
+
+            Text("Sub2API")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Theme.sub2api)
+            providerSettingsField(
+                label: "Base URL",
+                placeholder: "https://api.example.com",
+                text: $sub2APIBaseURL
+            )
+            providerSettingsField(
+                label: "API Key",
+                placeholder: sub2APIKeyStored ? "已保存，留空不修改" : "Group API Key",
+                text: $sub2APIKey,
+                secure: true
+            )
+            if sub2APIKeyStored {
+                HStack {
+                    Spacer()
+                    settingsActionButton(icon: "trash", title: "清除 Sub2API 密钥") {
+                        clearProviderToken(.sub2api)
+                    }
+                }
+            }
+
+            thinDivider
+
+            Text("z.ai / GLM")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Theme.zai)
+            HStack(spacing: 8) {
+                Text("区域")
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(Theme.tTertiary)
+                    .frame(width: 52, alignment: .leading)
+                Picker("z.ai 区域", selection: $zaiRegion) {
+                    Text("Global").tag("global")
+                    Text("BigModel CN").tag("bigmodel-cn")
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .controlSize(.mini)
+            }
+            providerSettingsField(
+                label: "API Key",
+                placeholder: zaiKeyStored ? "已保存，留空不修改" : "Z_AI_API_KEY",
+                text: $zaiKey,
+                secure: true
+            )
+            if zaiKeyStored {
+                HStack {
+                    Spacer()
+                    settingsActionButton(icon: "trash", title: "清除 z.ai 密钥") {
+                        clearProviderToken(.zai)
+                    }
+                }
+            }
+
+            HStack {
+                settingsActionButton(icon: "checkmark.circle", title: "保存 Provider 设置") {
+                    saveProviderSettings()
+                }
+                Spacer()
+                if !providerSettingsResult.isEmpty {
+                    Text(providerSettingsResult)
+                        .font(.system(size: 8.5))
+                        .foregroundStyle(providerSettingsResult == "已保存" ? Color.green : Color.orange)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func providerSettingsField(
+        label: String,
+        placeholder: String,
+        text: Binding<String>,
+        secure: Bool = false
+    ) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 9.5))
+                .foregroundStyle(Theme.tTertiary)
+                .frame(width: 52, alignment: .leading)
+            Group {
+                if secure {
+                    SecureField(placeholder, text: text)
+                } else {
+                    TextField(placeholder, text: text)
+                }
+            }
+            .textFieldStyle(.plain)
+            .font(.system(size: 9.5, design: .monospaced))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(0.05))
+            )
+        }
+    }
+
+    private func loadProviderSettings() {
+        sub2APIBaseURL = SyncManager.providerSetting("sub2api_base_url") ?? ""
+        zaiRegion = SyncManager.providerSetting("zai_region") ?? "global"
+        sub2APIKeyStored = ProviderCredentialStore.token(for: .sub2api) != nil
+        zaiKeyStored = ProviderCredentialStore.token(for: .zai) != nil
+    }
+
+    private func saveProviderSettings() {
+        let baseURL = sub2APIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard baseURL.isEmpty || Self.validSub2APIBaseURL(baseURL) else {
+            providerSettingsResult = "Sub2API URL 仅支持 HTTPS 或本机 HTTP"
+            return
+        }
+        let savedURL = SyncManager.setProviderSetting(
+            baseURL.isEmpty ? nil : baseURL,
+            forKey: "sub2api_base_url"
+        )
+        let savedRegion = SyncManager.setProviderSetting(zaiRegion, forKey: "zai_region")
+        let savedSub2APIKey = sub2APIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || ProviderCredentialStore.setToken(sub2APIKey, for: .sub2api)
+        let savedZaiKey = zaiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || ProviderCredentialStore.setToken(zaiKey, for: .zai)
+        guard savedURL, savedRegion, savedSub2APIKey, savedZaiKey else {
+            providerSettingsResult = "保存失败"
+            return
+        }
+        sub2APIKey = ""
+        zaiKey = ""
+        loadProviderSettings()
+        providerSettingsResult = "已保存"
+        store.refresh()
+    }
+
+    private func clearProviderToken(_ provider: ProviderSecret) {
+        guard ProviderCredentialStore.setToken("", for: provider) else {
+            providerSettingsResult = "清除失败"
+            return
+        }
+        loadProviderSettings()
+        providerSettingsResult = "已清除"
+        store.refresh()
+    }
+
+    private static func validSub2APIBaseURL(_ value: String) -> Bool {
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host?.lowercased(),
+              components.user == nil, components.password == nil,
+              components.query == nil, components.fragment == nil else { return false }
+        if scheme == "https" { return true }
+        guard scheme == "http" else { return false }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 
     var settingsPrivacySection: some View {
@@ -2176,6 +2531,10 @@ struct PanelView: View {
         SyncManager.setQwenWorkQuotaEnabled(enabled)
     }
 
+    private static func setProviderQuotaEnabled(_ provider: String, _ enabled: Bool) {
+        SyncManager.setProviderQuotaEnabled(provider, enabled: enabled)
+    }
+
     /// 启动时把 UI 开关(showQoderIde)的当前值落盘到 config.json。
     /// 修复:showQoder 默认开启,但 .onChange 不会在启动时触发,
     /// 导致 qoder_ide_enabled 从未写入、Python 端一直不采集 Qoder IDE 数据。
@@ -2194,6 +2553,22 @@ struct PanelView: View {
     static func syncQwenWorkQuotaConfigOnLaunch() {
         let enabled = UserDefaults.standard.object(forKey: "qwenWorkQuotaEnabled") as? Bool ?? false
         setQwenWorkQuotaEnabled(enabled)
+    }
+
+    /// 新 Provider 默认关闭；Antigravity 跟随现有 Gemini / Antigravity 卡片开关。
+    static func syncProviderQuotaConfigOnLaunch() {
+        let defaults = UserDefaults.standard
+        let settings: [(String, String, Bool)] = [
+            ("antigravity", "showGemini", true),
+            ("cursor", "showCursor", false),
+            ("zed", "showZed", false),
+            ("sub2api", "showSub2API", false),
+            ("zai", "showZai", false),
+        ]
+        for (provider, key, fallback) in settings {
+            let enabled = defaults.object(forKey: key) as? Bool ?? fallback
+            setProviderQuotaEnabled(provider, enabled)
+        }
     }
 
     var settingsPricingSection: some View {
@@ -2816,7 +3191,8 @@ struct PanelView: View {
 
         if let data = result.stdout.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            let tools = ["claude", "codex", "gemini", "grok", "qoder", "qoderwork", "hermes",
+            let tools = ["claude", "codex", "gemini", "antigravity", "cursor", "zed",
+                         "sub2api", "zai", "grok", "qoder", "qoderwork", "hermes",
                          "zcode", "mimocode", "openclaw", "pi", "workbuddy", "deepseek_harness",
                          "opencode", "qwencode", "qwenwork", "kimicode", "prime_agent"]
                 .filter { json[$0] != nil }

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -317,7 +317,8 @@ struct PanelView: View {
 
     private func toolCards(for u: Usage) -> [ToolCardItem] {
         let cr = u.claude.ranges.get(sel), xr = u.codex.ranges.get(sel)
-        let gr = u.gemini.ranges.get(sel), kr = u.grok.ranges.get(sel)
+        let geminiDisplay = u.gemini.ranges.displayRange(for: sel)
+        let kr = u.grok.ranges.get(sel)
         let qr = u.qoder.ranges.get(sel), qwr = u.qoderwork.ranges.get(sel)
         let qclir = u.qodercli.ranges.get(sel)
         let hr = u.hermes.ranges.get(sel)
@@ -350,11 +351,15 @@ struct PanelView: View {
                              (u.codex.reset_cards?.count ?? 0) > 0,
                          tint: Theme.codex, content: AnyView(codexBlock(u.codex, xr))),
             ToolCardItem(id: "gemini", name: "Gemini", visible: showGemini,
-                         active: gr.sessions > 0 || u.antigravity.available,
+                         active: geminiDisplay.range.hasUsage || u.antigravity.available,
                          tint: Theme.gemini,
-                         presentation: gr.sessions == 0 && u.antigravity.available
+                         presentation: !geminiDisplay.range.hasUsage && u.antigravity.available
                              ? .compactStatus : .standard,
-                         content: AnyView(geminiBlock(gr, quota: u.antigravity))),
+                         content: AnyView(geminiBlock(
+                            geminiDisplay.range,
+                            quota: u.antigravity,
+                            displayedRange: geminiDisplay.key
+                         ))),
             ToolCardItem(id: "cursor", name: "Cursor", visible: showCursor,
                          active: u.cursor.available || cursorUsage.totalTokens > 0,
                          tint: Theme.cursor,
@@ -682,12 +687,25 @@ struct PanelView: View {
 
     // MARK: - Gemini / Antigravity 卡片
     @ViewBuilder
-    func geminiBlock(_ r: GeminiRange, quota: ProviderQuotaStat) -> some View {
+    func geminiBlock(
+        _ r: GeminiRange,
+        quota: ProviderQuotaStat,
+        displayedRange: RangeKey? = nil
+    ) -> some View {
+        let usageLabel: String = {
+            guard let displayedRange, displayedRange != sel else { return sel.label }
+            return "\(displayedRange.label)（\(sel.label)无用量）"
+        }()
         VStack(alignment: .leading, spacing: 11) {
             cardHead("Gemini / Antigravity", tint: Theme.gemini, sessions: r.sessions,
-                     toolID: r.sessions > 0 ? "gemini" : nil)
-            if r.sessions > 0 {
-                CostHeadline(value: Fmt.human(r.in + r.cached + r.out + r.thoughts), caption: "\(sel.label) 总量", tint: Theme.gemini)
+                     toolID: r.hasUsage ? "gemini" : nil)
+            if r.hasUsage {
+                if let displayedRange, displayedRange != sel {
+                    Text("\(sel.label)暂无用量，显示\(displayedRange.label)最近用量")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(Theme.tTertiary)
+                }
+                CostHeadline(value: Fmt.human(r.totalTokens), caption: "\(usageLabel) 总量", tint: Theme.gemini)
                 metricGrid([.init("dollarsign.circle", "≈成本", String(format: "$%.2f", r.cost))],
                     hit: r.hit, extra: {
                     var items: [Metric] = [
@@ -706,13 +724,14 @@ struct PanelView: View {
                         return ModelRow(name: m.name, pin: m.pin, pout: m.pout, cost: m.cost, total: total, hit: hit,
                                         tokIn: m.in, tokOut: m.out, tokCR: m.cached, tokCW: m.thoughts)
                     }
-                    modelDisclosure(geminiRows, open: $geminiModelsOpen, tint: Theme.gemini)
+                    modelDisclosure(geminiRows, open: $geminiModelsOpen, tint: Theme.gemini,
+                                    periodLabel: usageLabel)
                 }
             } else {
                 quota.available ? AnyView(usageEmptyHint) : AnyView(emptyHint)
             }
             if quota.available {
-                if r.sessions > 0 { thinDivider }
+                if r.hasUsage { thinDivider }
                 providerQuotaContent(quota, tint: Theme.gemini)
             }
         }
@@ -1801,7 +1820,12 @@ struct PanelView: View {
     }
 
     @ViewBuilder
-    func modelDisclosure(_ models: [ModelRow], open: Binding<Bool>, tint: Color) -> some View {
+    func modelDisclosure(
+        _ models: [ModelRow],
+        open: Binding<Bool>,
+        tint: Color,
+        periodLabel: String? = nil
+    ) -> some View {
         Button {
             open.wrappedValue.toggle()
         } label: {
@@ -1821,7 +1845,7 @@ struct PanelView: View {
         .buttonStyle(.plain)
         if open.wrappedValue {
             VStack(alignment: .leading, spacing: 6) {
-                Text("按模型 · \(sel.label)")
+                Text("按模型 · \(periodLabel ?? sel.label)")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(Theme.tSecondary)
                 ForEach(models) { m in

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -10,6 +10,8 @@ struct PanelView: View {
     @State private var codexModelsOpen = false
     @State private var codexResetCardsOpen = false
     @State private var geminiModelsOpen = false
+    @State private var cursorModelsOpen = false
+    @State private var zaiModelsOpen = false
     @State private var grokModelsOpen = false
     @State private var zcodeModelsOpen = false
     @State private var mimocodeModelsOpen = false
@@ -332,6 +334,8 @@ struct PanelView: View {
         let grokQuotaState = SubscriptionQuotaState.resolve([
             (value: u.grok.pct, stale: u.grok.stale),
         ])
+        let cursorUsage = u.cursor.usage?.ranges.get(sel) ?? TokenUsageRange()
+        let zaiUsage = u.zai.usage?.ranges.get(sel) ?? TokenUsageRange()
         let qcr = u.qwencode.ranges.get(sel), kcr = u.kimicode.ranges.get(sel)
         return [
             ToolCardItem(id: "claude", name: "Claude", visible: showClaude,
@@ -351,10 +355,13 @@ struct PanelView: View {
                          presentation: gr.sessions == 0 && u.antigravity.available
                              ? .compactStatus : .standard,
                          content: AnyView(geminiBlock(gr, quota: u.antigravity))),
-            ToolCardItem(id: "cursor", name: "Cursor", visible: showCursor, active: showCursor,
-                         tint: Theme.cursor, presentation: .compactStatus,
+            ToolCardItem(id: "cursor", name: "Cursor", visible: showCursor,
+                         active: u.cursor.available || cursorUsage.totalTokens > 0,
+                         tint: Theme.cursor,
+                         presentation: cursorUsage.totalTokens > 0 ? .standard : .compactStatus,
                          content: AnyView(providerQuotaBlock(
-                            "Cursor", quota: u.cursor, tint: Theme.cursor,
+                            "Cursor", quota: u.cursor, usage: cursorUsage,
+                            modelsOpen: $cursorModelsOpen, tint: Theme.cursor,
                             setupHint: "请确认 Cursor.app 已登录；Tokei 会复用其本地登录态读取额度。"))),
             ToolCardItem(id: "zed", name: "Zed", visible: showZed, active: showZed,
                          tint: Theme.zed, presentation: .compactStatus,
@@ -366,10 +373,13 @@ struct PanelView: View {
                          content: AnyView(providerQuotaBlock(
                             "Sub2API", quota: u.sub2api, tint: Theme.sub2api,
                             setupHint: "请在设置的「Provider 额度」中保存 Base URL 与 Group API Key。"))),
-            ToolCardItem(id: "zai", name: "z.ai / GLM", visible: showZai, active: showZai,
-                         tint: Theme.zai, presentation: .compactStatus,
+            ToolCardItem(id: "zai", name: "z.ai / GLM", visible: showZai,
+                         active: u.zai.available || zaiUsage.totalTokens > 0,
+                         tint: Theme.zai,
+                         presentation: zaiUsage.totalTokens > 0 ? .standard : .compactStatus,
                          content: AnyView(providerQuotaBlock(
-                            "z.ai / GLM", quota: u.zai, tint: Theme.zai,
+                            "z.ai / GLM", quota: u.zai, usage: zaiUsage,
+                            modelsOpen: $zaiModelsOpen, tint: Theme.zai,
                             setupHint: "请在设置的「Provider 额度」中选择区域并保存 API Key。"))),
             ToolCardItem(id: "grok", name: "Grok", visible: showGrok,
                          active: kr.sessions > 0 || kr.usage_calls > 0 || u.grok.pct != nil,
@@ -698,8 +708,8 @@ struct PanelView: View {
                     }
                     modelDisclosure(geminiRows, open: $geminiModelsOpen, tint: Theme.gemini)
                 }
-            } else if !quota.available {
-                emptyHint
+            } else {
+                quota.available ? AnyView(usageEmptyHint) : AnyView(emptyHint)
             }
             if quota.available {
                 if r.sessions > 0 { thinDivider }
@@ -713,18 +723,68 @@ struct PanelView: View {
     func providerQuotaBlock(
         _ title: String,
         quota: ProviderQuotaStat,
+        usage: TokenUsageRange? = nil,
+        modelsOpen: Binding<Bool>? = nil,
         tint: Color,
         setupHint: String
     ) -> some View {
+        let range = usage ?? TokenUsageRange()
+        let hasUsage = range.totalTokens > 0 || range.requests > 0
         VStack(alignment: .leading, spacing: 11) {
             cardHeadPlain(title, tint: tint)
+            if hasUsage {
+                providerTokenUsageContent(range, modelsOpen: modelsOpen, tint: tint)
+            }
             if quota.available {
+                if hasUsage { thinDivider }
                 providerQuotaContent(quota, tint: tint)
-            } else {
+            } else if !hasUsage {
                 Text(setupHint)
                     .font(.system(size: 10))
                     .foregroundStyle(Theme.tTertiary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    func providerTokenUsageContent(
+        _ r: TokenUsageRange,
+        modelsOpen: Binding<Bool>?,
+        tint: Color
+    ) -> some View {
+        var top: [Metric] = []
+        if r.cost > 0 {
+            top.append(.init("dollarsign.circle", "API 价", String(format: "$%.2f", r.cost)))
+        }
+        if r.requests > 0 {
+            top.append(.init("arrow.triangle.2.circlepath", "请求", Fmt.human(r.requests)))
+        }
+        var details: [Metric] = []
+        if r.hasComponents {
+            details = [
+                .init("arrow.down", "输入", Fmt.human(r.in)),
+                .init("arrow.up", "输出", Fmt.human(r.out)),
+            ]
+            if r.cr > 0 { details.append(.init("bolt.fill", "缓存读", Fmt.human(r.cr))) }
+            if r.cw > 0 {
+                details.append(.init("square.stack.3d.up.fill", "缓存写", Fmt.human(r.cw)))
+            }
+            if r.reason > 0 { details.append(.init("brain", "推理", Fmt.human(r.reason))) }
+        }
+        return VStack(alignment: .leading, spacing: 9) {
+            CostHeadline(
+                value: Fmt.human(r.totalTokens),
+                caption: "\(r.coverage ?? sel.label) 账号总量",
+                tint: tint
+            )
+            Text("账号级用量 · 单列统计，避免与本地工具日志重复计算")
+                .font(.system(size: 8.5))
+                .foregroundStyle(Theme.tTertiary)
+            if !top.isEmpty || !details.isEmpty {
+                metricGrid(top, hit: r.hit, extra: details, tint: tint)
+            }
+            if !r.models.isEmpty, let modelsOpen {
+                tokenModelDisclosure(r.models, open: modelsOpen, tint: tint)
             }
         }
     }
@@ -1550,7 +1610,8 @@ struct PanelView: View {
     }
 
     func tokenModelTotal(_ m: TokenModelStat, reasonIncludedInOutput: Bool = false) -> Int {
-        m.in + m.out + m.cr + m.cw + (reasonIncludedInOutput ? 0 : m.reason)
+        if let tokens = m.tokens, tokens > 0 { return tokens }
+        return m.in + m.out + m.cr + m.cw + (reasonIncludedInOutput ? 0 : m.reason)
     }
 
     func tokenModelHit(_ m: TokenModelStat) -> Double {
@@ -1679,19 +1740,26 @@ struct PanelView: View {
                 ForEach(models) { m in
                     let total = tokenModelTotal(m, reasonIncludedInOutput: reasonIncludedInOutput)
                     let hit = tokenModelHit(m)
+                    let hasBreakdown = m.in + m.out + m.cr + m.cw + m.reason > 0
+                        || m.cost > 0 || m.pin > 0 || m.pout > 0
                     let isExpanded = expandedModels.contains(m.id)
                     VStack(alignment: .leading, spacing: 0) {
                         Button {
+                            guard hasBreakdown else { return }
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 if isExpanded { expandedModels.remove(m.id) }
                                 else { expandedModels.insert(m.id) }
                             }
                         } label: {
                             HStack(spacing: 7) {
-                                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                                    .font(.system(size: 7, weight: .bold))
-                                    .foregroundStyle(Theme.tTertiary)
-                                    .frame(width: 8)
+                                if hasBreakdown {
+                                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                                        .font(.system(size: 7, weight: .bold))
+                                        .foregroundStyle(Theme.tTertiary)
+                                        .frame(width: 8)
+                                } else {
+                                    Color.clear.frame(width: 8, height: 8)
+                                }
                                 Circle().fill(tint.opacity(0.7)).frame(width: 5, height: 5)
                                 Text(m.name).font(.system(size: 11.5)).foregroundStyle(Theme.tPrimary)
                                     .lineLimit(1)
@@ -1715,7 +1783,7 @@ struct PanelView: View {
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
-                        if isExpanded {
+                        if isExpanded && hasBreakdown {
                             modelDetailRow(tokIn: inclusiveIO ? m.in + m.cr + m.cw : m.in,
                                            tokOut: inclusiveIO ? m.out + m.reason : m.out,
                                            tokCR: m.cr, tokCW: m.cw,

--- a/Tokei/Sources/Tokei/ProviderCredentialStore.swift
+++ b/Tokei/Sources/Tokei/ProviderCredentialStore.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Darwin
+import LocalAuthentication
+import Security
+
+enum ProviderSecret: String {
+    case sub2api
+    case zai
+}
+
+enum ProviderCredentialStore {
+    private static let service = "com.cclank.tokei.provider-api-key"
+
+    static func token(for provider: ProviderSecret) -> String? {
+        var query = baseQuery(for: provider)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        applyNoUI(to: &query)
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    @discardableResult
+    static func setToken(_ token: String, for provider: ProviderSecret) -> Bool {
+        let value = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = baseQuery(for: provider)
+        if value.isEmpty {
+            let status = SecItemDelete(query as CFDictionary)
+            return status == errSecSuccess || status == errSecItemNotFound
+        }
+        let data = Data(value.utf8)
+        let update = [kSecValueData as String: data]
+        let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        if status == errSecSuccess { return true }
+        guard status == errSecItemNotFound else { return false }
+        var item = query
+        item[kSecValueData as String] = data
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        return SecItemAdd(item as CFDictionary, nil) == errSecSuccess
+    }
+
+    static func environmentOverrides() -> [String: String] {
+        var result: [String: String] = [:]
+        if let token = token(for: .sub2api) {
+            result["SUB2API_API_KEY"] = token
+        }
+        if let token = token(for: .zai) {
+            result["Z_AI_API_KEY"] = token
+        }
+        if let credentials = zedCredentials() {
+            result["TOKEI_ZED_USER_ID"] = credentials.userID
+            result["TOKEI_ZED_ACCESS_TOKEN"] = credentials.accessToken
+        }
+        return result
+    }
+
+    private static func baseQuery(for provider: ProviderSecret) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: provider.rawValue,
+        ]
+    }
+
+    private struct ZedSettings: Decodable {
+        var credentialsURL: String?
+        var serverURL: String?
+
+        enum CodingKeys: String, CodingKey {
+            case credentialsURL = "credentials_url"
+            case serverURL = "server_url"
+        }
+    }
+
+    private static func zedCredentials() -> (userID: String, accessToken: String)? {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/zed/settings.json")
+        let settings = (try? Data(contentsOf: url))
+            .flatMap { try? JSONDecoder().decode(ZedSettings.self, from: $0) }
+        let credentialsURL = settings?.credentialsURL?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let serverURL = settings?.serverURL?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let serviceURL = [credentialsURL, serverURL, "https://zed.dev"]
+            .compactMap { value -> String? in
+                guard let value, !value.isEmpty else { return nil }
+                return value
+            }
+            .first ?? "https://zed.dev"
+
+        if let credentials = queryZedCredentials(
+            itemClass: kSecClassInternetPassword, attribute: kSecAttrServer, value: serviceURL
+        ) {
+            return credentials
+        }
+        return queryZedCredentials(
+            itemClass: kSecClassGenericPassword, attribute: kSecAttrService, value: serviceURL
+        )
+    }
+
+    private static func queryZedCredentials(
+        itemClass: CFTypeRef,
+        attribute: CFString,
+        value: String
+    ) -> (userID: String, accessToken: String)? {
+        var query: [String: Any] = [
+            kSecClass as String: itemClass,
+            attribute as String: value,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+        ]
+        applyNoUI(to: &query)
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let item = result as? [String: Any],
+              let userID = item[kSecAttrAccount as String] as? String,
+              let data = item[kSecValueData as String] as? Data,
+              let accessToken = String(data: data, encoding: .utf8),
+              !userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !accessToken.isEmpty else { return nil }
+        return (userID, accessToken)
+    }
+
+    private static let uiFailPolicy: String = {
+        let path = "/System/Library/Frameworks/Security.framework/Security"
+        guard let handle = dlopen(path, RTLD_NOW) else { return "u_AuthUIF" }
+        defer { dlclose(handle) }
+        guard let symbol = dlsym(handle, "kSecUseAuthenticationUIFail") else {
+            return "u_AuthUIF"
+        }
+        return symbol.assumingMemoryBound(to: CFString?.self).pointee as String? ?? "u_AuthUIF"
+    }()
+
+    private static func applyNoUI(to query: inout [String: Any]) {
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        query[kSecUseAuthenticationContext as String] = context
+        query[kSecUseAuthenticationUI as String] = uiFailPolicy as CFString
+    }
+}

--- a/Tokei/Sources/Tokei/ProviderCredentialStore.swift
+++ b/Tokei/Sources/Tokei/ProviderCredentialStore.swift
@@ -9,39 +9,119 @@ enum ProviderSecret: String {
 }
 
 enum ProviderCredentialStore {
-    private static let service = "com.cclank.tokei.provider-api-key"
+#if TOKEI_PROVIDER_CREDENTIAL_STORE_TEST
+    // The test binary is compiled with a separate service so its round-trip
+    // checks can never touch a user's real provider credentials.
+    private static let service = "com.tokei.app.provider-api-key.test." + UUID().uuidString
+    private static let testKeychainURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tokei-provider-" + UUID().uuidString + ".keychain-db")
+    private static let testKeychain: SecKeychain = {
+        let password = Data("tokei-provider-test".utf8)
+        var keychain: SecKeychain?
+        let status = testKeychainURL.path.withCString { path in
+            password.withUnsafeBytes { bytes in
+                SecKeychainCreate(
+                    path,
+                    UInt32(password.count),
+                    bytes.baseAddress,
+                    false,
+                    nil,
+                    &keychain
+                )
+            }
+        }
+        guard status == errSecSuccess, let keychain else {
+            fatalError("Unable to create isolated provider test keychain: \(status)")
+        }
+        return keychain
+    }()
+#else
+    // v2 avoids inaccessible items created by older ad-hoc builds whose ACL is
+    // tied to a one-off code hash. Do not probe the old service: macOS can block
+    // indefinitely while decrypting those items even when UI is disabled.
+    private static let service = "com.tokei.app.provider-api-key.v2"
+#endif
+    private static let interactionLock = NSLock()
+    private static let clearedMarker = "__TOKEI_PROVIDER_CLEARED_V1__"
+
+#if TOKEI_PROVIDER_CREDENTIAL_STORE_TEST
+    static func purgeTestItems() {
+        for provider in [ProviderSecret.sub2api, .zai] {
+            _ = SecItemDelete(baseQuery(for: provider, service: service) as CFDictionary)
+        }
+    }
+
+    static func destroyTestKeychain() {
+        _ = SecKeychainDelete(testKeychain)
+        try? FileManager.default.removeItem(at: testKeychainURL)
+    }
+#endif
+
+    private enum TokenLookup {
+        case missing
+        case cleared
+        case value(String)
+    }
 
     static func token(for provider: ProviderSecret) -> String? {
-        var query = baseQuery(for: provider)
+        switch tokenLookup(for: provider, service: service) {
+        case .value(let value): return value
+        case .cleared, .missing: return nil
+        }
+    }
+
+    private static func tokenLookup(
+        for provider: ProviderSecret,
+        service: String
+    ) -> TokenLookup {
+        var query = baseQuery(for: provider, service: service)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         applyNoUI(to: &query)
         var result: AnyObject?
         guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let value = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
+              let data = result as? Data else { return .missing }
+        guard let rawValue = String(data: data, encoding: .utf8) else { return .cleared }
+        if rawValue == clearedMarker { return .cleared }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+              !value.isEmpty else { return .cleared }
+        return .value(value)
     }
 
     @discardableResult
     static func setToken(_ token: String, for provider: ProviderSecret) -> Bool {
         let value = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        let query = baseQuery(for: provider)
         if value.isEmpty {
-            let status = SecItemDelete(query as CFDictionary)
-            return status == errSecSuccess || status == errSecItemNotFound
+            let currentStatus = writeTokenData(
+                Data(clearedMarker.utf8),
+                for: provider, service: service, createIfMissing: true
+            )
+            return currentStatus == errSecSuccess
         }
-        let data = Data(value.utf8)
+        return writeTokenData(
+            Data(value.utf8), for: provider, service: service, createIfMissing: true
+        ) == errSecSuccess
+    }
+
+    private static func writeTokenData(
+        _ data: Data,
+        for provider: ProviderSecret,
+        service: String,
+        createIfMissing: Bool
+    ) -> OSStatus {
+        var query = baseQuery(for: provider, service: service)
+        applyNoUI(to: &query)
         let update = [kSecValueData as String: data]
         let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
-        if status == errSecSuccess { return true }
-        guard status == errSecItemNotFound else { return false }
-        var item = query
+        if status == errSecSuccess || !createIfMissing { return status }
+        guard status == errSecItemNotFound else { return status }
+        var item = baseQuery(for: provider, service: service)
+        targetTestKeychainForAdd(&item)
         item[kSecValueData as String] = data
         item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        return SecItemAdd(item as CFDictionary, nil) == errSecSuccess
+        applyNoUI(to: &item)
+        return SecItemAdd(item as CFDictionary, nil)
     }
 
     static func environmentOverrides() -> [String: String] {
@@ -59,19 +139,30 @@ enum ProviderCredentialStore {
         return result
     }
 
-    private static func baseQuery(for provider: ProviderSecret) -> [String: Any] {
-        [
+    private static func baseQuery(
+        for provider: ProviderSecret,
+        service: String
+    ) -> [String: Any] {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: provider.rawValue,
-            // Avoid the legacy login-keychain ACL path, which can block indefinitely
-            // after an ad-hoc rebuild even when authentication UI is disabled.
-            kSecUseDataProtectionKeychain as String: true,
         ]
+#if TOKEI_PROVIDER_CREDENTIAL_STORE_TEST
+        query[kSecMatchSearchList as String] = [testKeychain]
+#endif
+        return query
+    }
+
+    private static func targetTestKeychainForAdd(_ item: inout [String: Any]) {
+#if TOKEI_PROVIDER_CREDENTIAL_STORE_TEST
+        item.removeValue(forKey: kSecMatchSearchList as String)
+        item[kSecUseKeychain as String] = testKeychain
+#endif
     }
 
     private static func providerQuotaEnabled(_ provider: String) -> Bool {
-        let envKey = "TOKEI_(provider.uppercased())_QUOTA"
+        let envKey = "TOKEI_\(provider.uppercased())_QUOTA"
         if ProcessInfo.processInfo.environment[envKey] == "1" { return true }
         if ProcessInfo.processInfo.environment[envKey] == "0" { return false }
         let url = FileManager.default.homeDirectoryForCurrentUser
@@ -79,7 +170,7 @@ enum ProviderCredentialStore {
         guard let data = try? Data(contentsOf: url),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return false }
-        return object["(provider)_quota_enabled"] as? Bool ?? false
+        return object["\(provider)_quota_enabled"] as? Bool ?? false
     }
 
     private struct ZedSettings: Decodable {
@@ -132,17 +223,10 @@ enum ProviderCredentialStore {
         ]
         applyNoUI(to: &query)
         var result: AnyObject?
-        var interactionAllowed: DarwinBoolean = false
-        let interactionStatus = SecKeychainGetUserInteractionAllowed(&interactionAllowed)
-        if interactionStatus == errSecSuccess {
-            SecKeychainSetUserInteractionAllowed(false)
+        let status = withoutKeychainUI {
+            SecItemCopyMatching(query as CFDictionary, &result)
         }
-        defer {
-            if interactionStatus == errSecSuccess {
-                SecKeychainSetUserInteractionAllowed(interactionAllowed.boolValue)
-            }
-        }
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+        guard status == errSecSuccess,
               let item = result as? [String: Any],
               let userID = item[kSecAttrAccount as String] as? String,
               let data = item[kSecValueData as String] as? Data,
@@ -150,6 +234,22 @@ enum ProviderCredentialStore {
               !userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !accessToken.isEmpty else { return nil }
         return (userID, accessToken)
+    }
+
+    private static func withoutKeychainUI<T>(_ body: () -> T) -> T {
+        interactionLock.lock()
+        defer { interactionLock.unlock() }
+        var interactionAllowed: DarwinBoolean = false
+        let status = SecKeychainGetUserInteractionAllowed(&interactionAllowed)
+        if status == errSecSuccess {
+            SecKeychainSetUserInteractionAllowed(false)
+        }
+        defer {
+            if status == errSecSuccess {
+                SecKeychainSetUserInteractionAllowed(interactionAllowed.boolValue)
+            }
+        }
+        return body()
     }
 
     private static let uiFailPolicy: String = {

--- a/Tokei/Sources/Tokei/ProviderCredentialStore.swift
+++ b/Tokei/Sources/Tokei/ProviderCredentialStore.swift
@@ -52,7 +52,7 @@ enum ProviderCredentialStore {
         if let token = token(for: .zai) {
             result["Z_AI_API_KEY"] = token
         }
-        if let credentials = zedCredentials() {
+        if providerQuotaEnabled("zed"), let credentials = zedCredentials() {
             result["TOKEI_ZED_USER_ID"] = credentials.userID
             result["TOKEI_ZED_ACCESS_TOKEN"] = credentials.accessToken
         }
@@ -64,7 +64,22 @@ enum ProviderCredentialStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: provider.rawValue,
+            // Avoid the legacy login-keychain ACL path, which can block indefinitely
+            // after an ad-hoc rebuild even when authentication UI is disabled.
+            kSecUseDataProtectionKeychain as String: true,
         ]
+    }
+
+    private static func providerQuotaEnabled(_ provider: String) -> Bool {
+        let envKey = "TOKEI_(provider.uppercased())_QUOTA"
+        if ProcessInfo.processInfo.environment[envKey] == "1" { return true }
+        if ProcessInfo.processInfo.environment[envKey] == "0" { return false }
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".tokei/config.json")
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return object["(provider)_quota_enabled"] as? Bool ?? false
     }
 
     private struct ZedSettings: Decodable {
@@ -117,6 +132,16 @@ enum ProviderCredentialStore {
         ]
         applyNoUI(to: &query)
         var result: AnyObject?
+        var interactionAllowed: DarwinBoolean = false
+        let interactionStatus = SecKeychainGetUserInteractionAllowed(&interactionAllowed)
+        if interactionStatus == errSecSuccess {
+            SecKeychainSetUserInteractionAllowed(false)
+        }
+        defer {
+            if interactionStatus == errSecSuccess {
+                SecKeychainSetUserInteractionAllowed(interactionAllowed.boolValue)
+            }
+        }
         guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
               let item = result as? [String: Any],
               let userID = item[kSecAttrAccount as String] as? String,

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -256,6 +256,57 @@ final class SyncManager {
         } ?? false
     }
 
+    private static let providerQuotaIDs: Set<String> = [
+        "cursor", "zed", "sub2api", "zai", "antigravity",
+    ]
+    private static let providerSettingKeys: Set<String> = [
+        "sub2api_base_url", "zai_region", "zai_usage_scope",
+        "zai_organization", "zai_project",
+    ]
+
+    @discardableResult
+    static func setProviderQuotaEnabled(_ provider: String, enabled: Bool) -> Bool {
+        guard providerQuotaIDs.contains(provider) else { return false }
+        return setConfigValue(enabled, forKey: "\(provider)_quota_enabled")
+    }
+
+    static func providerSetting(_ key: String) -> String? {
+        guard providerSettingKeys.contains(key),
+              let data = try? Data(contentsOf: configPath),
+              let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = dictionary[key] as? String else { return nil }
+        let cleaned = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    @discardableResult
+    static func setProviderSetting(_ value: String?, forKey key: String) -> Bool {
+        guard providerSettingKeys.contains(key) else { return false }
+        let cleaned = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stored = (cleaned?.isEmpty == false) ? cleaned : nil
+        return setConfigValue(stored, forKey: key)
+    }
+
+    private static func setConfigValue(_ value: Any?, forKey key: String) -> Bool {
+        withConfigLock {
+            var dictionary: [String: Any] = [:]
+            if FileManager.default.fileExists(atPath: configPath.path) {
+                let data = try Data(contentsOf: configPath)
+                guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                dictionary = object
+            }
+            if let value {
+                dictionary[key] = value
+            } else {
+                dictionary.removeValue(forKey: key)
+            }
+            try writeConfigDictionary(dictionary)
+            return true
+        } ?? false
+    }
+
     // MARK: - Read peers
 
     func loadPeers() -> PeerLoadReport {

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -255,6 +255,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         PanelView.syncQoderIdeConfigOnLaunch()
         PanelView.syncGrokLiveQuotaConfigOnLaunch()
         PanelView.syncQwenWorkQuotaConfigOnLaunch()
+        PanelView.syncProviderQuotaConfigOnLaunch()
         if var syncConfig = store.syncManager.config {
             let interval = SyncManager.normalizedSyncInterval(syncConfig.sync_interval)
             if syncConfig.sync_interval != interval {

--- a/Tokei/package.sh
+++ b/Tokei/package.sh
@@ -17,6 +17,28 @@ if [[ ! "$BUILD_DATE" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
     exit 1
 fi
 
+# Command Line Tools 27 的 SwiftUI SDK 会引用 SwiftUIMacros.StateMacro，
+# 但部分 CLT 安装并未包含对应插件。此时使用同一工具链自带的 26.x SDK。
+if [[ -z "${SDKROOT:-}" ]]; then
+    DEVELOPER_PATH="$(xcode-select -p 2>/dev/null || true)"
+    DEFAULT_SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null || true)"
+    SWIFTUI_CORE_MODULES="$DEFAULT_SDK/System/Library/Frameworks/SwiftUICore.framework/Versions/A/Modules"
+    SWIFTUI_MACROS_PLUGIN="$DEVELOPER_PATH/usr/lib/swift/host/plugins/libSwiftUIMacros.dylib"
+
+    if [[ "$DEVELOPER_PATH" == */CommandLineTools ]] \
+        && [[ -d "$SWIFTUI_CORE_MODULES" ]] \
+        && grep -Rqs 'type: "StateMacro"' "$SWIFTUI_CORE_MODULES" \
+        && [[ ! -f "$SWIFTUI_MACROS_PLUGIN" ]]; then
+        COMPATIBLE_SDK="$DEVELOPER_PATH/SDKs/MacOSX26.sdk"
+        if [[ ! -d "$COMPATIBLE_SDK" ]]; then
+            echo "当前 Command Line Tools 缺少 SwiftUIMacros，请安装完整 Xcode 后重试" >&2
+            exit 1
+        fi
+        export SDKROOT="$COMPATIBLE_SDK"
+        echo "Command Line Tools 缺少 SwiftUIMacros，使用兼容 SDK: $SDKROOT"
+    fi
+fi
+
 swift build -c release
 
 APP="Tokei.app"

--- a/Tokei/package.sh
+++ b/Tokei/package.sh
@@ -81,7 +81,32 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-codesign --force --deep --sign - "$APP"
+# A stable local signing identity keeps macOS Keychain ACLs valid across
+# rebuilds. Prefer Developer ID, then Apple Development; CI can force ad-hoc
+# signing with TOKEI_CODESIGN_IDENTITY=-.
+CODESIGN_IDENTITY="${TOKEI_CODESIGN_IDENTITY:-auto}"
+if [ "$CODESIGN_IDENTITY" = "auto" ]; then
+    CODESIGN_IDENTITY=""
+    if command -v security &>/dev/null; then
+        IDENTITIES="$(security find-identity -v -p codesigning 2>/dev/null || true)"
+        CODESIGN_IDENTITY="$(echo "$IDENTITIES" \
+            | sed -nE 's/^[[:space:]]*[0-9]+\) [0-9A-F]+ "(Developer ID Application:[^"]+)".*/\1/p' \
+            | head -n 1)"
+        if [ -z "$CODESIGN_IDENTITY" ]; then
+            CODESIGN_IDENTITY="$(echo "$IDENTITIES" \
+                | sed -nE 's/^[[:space:]]*[0-9]+\) [0-9A-F]+ "(Apple Development:[^"]+)".*/\1/p' \
+                | head -n 1)"
+        fi
+    fi
+    [ -n "$CODESIGN_IDENTITY" ] || CODESIGN_IDENTITY="-"
+fi
+
+if [ "$CODESIGN_IDENTITY" = "-" ]; then
+    echo "未找到稳定签名证书，使用 ad-hoc 签名；后续重编译可能需要重新保存 Provider 密钥"
+else
+    echo "使用代码签名: $CODESIGN_IDENTITY"
+fi
+codesign --force --deep --sign "$CODESIGN_IDENTITY" "$APP"
 codesign --verify --deep --strict "$APP"
 xattr -cr "$APP" 2>/dev/null || true
 echo "Built: $(pwd)/$APP"

--- a/Tokei/package.sh
+++ b/Tokei/package.sh
@@ -131,15 +131,25 @@ INSTALL
     rm -rf "$MOUNT_DIR"
 
     # 挂载并用 AppleScript 设置窗口样式
-    DEVICE=$(hdiutil attach -readwrite -noverify "$TMP_DMG" | grep '/Volumes/Tokei' | awk '{print $1}')
+    ATTACH_OUTPUT="$(hdiutil attach -readwrite -noverify "$TMP_DMG")"
+    DEVICE="$(echo "$ATTACH_OUTPUT" | awk '/^\/dev\/disk/ {print $1; exit}')"
+    VOLUME_PATH="$(echo "$ATTACH_OUTPUT" | sed -n 's|^.*\(/Volumes/.*\)$|\1|p' | head -n 1)"
+    if [ -z "$DEVICE" ]; then
+        echo "无法识别已挂载 DMG 的设备" >&2
+        exit 1
+    fi
     sleep 1
 
-    # 隐藏 dot 文件夹
-    SetFile -a V /Volumes/Tokei/.background 2>/dev/null || true
-    SetFile -a V /Volumes/Tokei/.fseventsd 2>/dev/null || true
+    # 新版 hdiutil 可能只附加设备而不返回 /Volumes 挂载点；窗口装饰是可选项。
+    if [ -n "$VOLUME_PATH" ] && [ -d "$VOLUME_PATH" ]; then
+        [ -d "$VOLUME_PATH/.background" ] \
+            && SetFile -a V "$VOLUME_PATH/.background" 2>/dev/null || true
+        [ -d "$VOLUME_PATH/.fseventsd" ] \
+            && SetFile -a V "$VOLUME_PATH/.fseventsd" 2>/dev/null || true
+    fi
 
-    if [ -f "/Volumes/Tokei/.background/bg.png" ]; then
-        osascript <<'APPLE'
+    if [ -n "$VOLUME_PATH" ] && [ -f "$VOLUME_PATH/.background/bg.png" ]; then
+        osascript <<'APPLE' || true
 tell application "Finder"
     tell disk "Tokei"
         open
@@ -164,7 +174,22 @@ APPLE
     fi
 
     sync
-    hdiutil detach "$DEVICE" 2>/dev/null
+    if command -v diskutil &>/dev/null; then
+        EJECT_COMMAND=(diskutil eject "$DEVICE")
+    else
+        EJECT_COMMAND=(hdiutil detach "$DEVICE")
+    fi
+    EJECTED=0
+    for _attempt in 1 2 3 4 5; do
+        sleep 1
+        if "${EJECT_COMMAND[@]}" >/dev/null 2>&1; then
+            EJECTED=1
+            break
+        fi
+    done
+    if [ "$EJECTED" -ne 1 ]; then
+        hdiutil detach -force "$DEVICE" 2>/dev/null
+    fi
     sleep 1
 
     # 转为压缩只读 DMG

--- a/site/index.html
+++ b/site/index.html
@@ -895,12 +895,12 @@ body::after{
     <div class="sec-centered rv">
       <div class="sec-label"><span class="en">Supported Tools</span><span class="zh">支持的工具</span></div>
       <h2 class="sec-title">
-        <span class="en">17 AI agents.<br>One dashboard.</span>
-        <span class="zh">18 款 AI agent<br>一个面板</span>
+        <span class="en">20+ AI agents.<br>One dashboard.</span>
+        <span class="zh">20+ 款 AI agent<br>一个面板</span>
       </h2>
       <p class="sec-sub">
-        <span class="en">Tokei reads local session logs from each tool. No API keys, no network access.</span>
-        <span class="zh">Tokei 读取每个工具的本地会话日志。无需 API 密钥，无需网络连接。</span>
+        <span class="en">Usage stays local-first. Optional quota cards reuse an existing sign-in or a Keychain API key.</span>
+        <span class="zh">用量统计坚持本地优先；可选额度卡复用现有登录态或 Keychain API Key。</span>
       </p>
     </div>
 
@@ -919,6 +919,26 @@ body::after{
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--lavender),#7A5FC9)">Ge</div>
         <h3>Gemini CLI</h3>
         <p><span class="en">Tokens, thoughts, cost</span><span class="zh">Token · 思考 · 成本</span></p>
+      </div>
+      <div class="tool-card rv rv-d4" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#B8C4E6,#667494)">Cu</div>
+        <h3>Cursor</h3>
+        <p><span class="en">Plan quota, on-demand budget</span><span class="zh">套餐额度 · 按量预算</span></p>
+      </div>
+      <div class="tool-card rv rv-d5" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#ED6150,#A92D28)">Ze</div>
+        <h3>Zed</h3>
+        <p><span class="en">Predictions, plan cycle</span><span class="zh">预测额度 · 套餐周期</span></p>
+      </div>
+      <div class="tool-card rv rv-d6" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#2EC6D8,#177C92)">S2</div>
+        <h3>Sub2API</h3>
+        <p><span class="en">Quota windows, balance</span><span class="zh">额度窗口 · 余额</span></p>
+      </div>
+      <div class="tool-card rv rv-d7" data-tilt>
+        <div class="tool-icon" style="background:linear-gradient(135deg,#61AAFA,#3159C9)">ZA</div>
+        <h3>z.ai / GLM</h3>
+        <p><span class="en">Session, cycle, MCP quota</span><span class="zh">会话 · 周期 · MCP 额度</span></p>
       </div>
       <div class="tool-card rv rv-d4" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,var(--silver),#888)"><span style="color:#222">Gk</span></div>
@@ -1004,8 +1024,8 @@ body::after{
         <span class="zh">60 秒即刻启动</span>
       </h2>
       <p class="sec-sub">
-        <span class="en">No configuration, no API keys, no cloud accounts. Just install and go.</span>
-        <span class="zh">无需配置，无需 API 密钥，无需云账号。安装即用。</span>
+        <span class="en">Core local usage needs no configuration. Enable external quota cards only when you want them.</span>
+        <span class="zh">核心本地用量无需配置；仅在需要时开启外部 Provider 额度卡。</span>
       </p>
     </div>
     <div class="how-steps">
@@ -1036,18 +1056,18 @@ body::after{
         <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="1.5" stroke-linecap="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/><circle cx="12" cy="16" r="1"/></svg>
       </span>
       <h2>
-        <span class="en">Zero telemetry. Zero network.<br>Your data stays on your Mac.</span>
-        <span class="zh">零遥测 · 零网络<br>数据只留在你的 Mac 上</span>
+        <span class="en">Zero telemetry. Local-first.<br>Your usage data stays on your Mac.</span>
+        <span class="zh">零遥测 · 本地优先<br>用量数据只留在你的 Mac 上</span>
       </h2>
       <p>
-        <span class="en">Tokei reads only local session logs. It never connects to the internet, never sends data anywhere, and never will.</span>
-        <span class="zh">Tokei 仅读取本地会话日志。从不联网，从不上传数据，永远不会。</span>
+        <span class="en">Core analytics read local logs. External quota cards are off by default and only contact the selected provider after you enable them.</span>
+        <span class="zh">核心分析读取本地日志。外部额度卡默认关闭，仅在你开启后联系对应 Provider。</span>
       </p>
       <div class="pills">
         <span class="pill"><span class="en">No analytics</span><span class="zh">无分析追踪</span></span>
         <span class="pill"><span class="en">No tracking</span><span class="zh">无行为监控</span></span>
         <span class="pill"><span class="en">No cloud required</span><span class="zh">无需云端</span></span>
-        <span class="pill"><span class="en">100% offline</span><span class="zh">100% 离线</span></span>
+        <span class="pill"><span class="en">Quota APIs opt-in</span><span class="zh">额度 API 可选</span></span>
       </div>
     </div>
   </div>
@@ -1081,7 +1101,7 @@ body::after{
             <td style="text-align:left;padding:10px 16px;color:var(--t2)">
               <span class="en">Supported tools</span><span class="zh">支持工具</span>
             </td>
-            <td style="padding:10px 16px;color:var(--t2)">17</td>
+            <td style="padding:10px 16px;color:var(--t2)">20+</td>
             <td style="padding:10px 16px;color:var(--t2)">40+</td>
           </tr>
           <tr style="border-bottom:1px solid var(--border)">
@@ -1156,7 +1176,7 @@ body::after{
               <span class="en">Network required</span><span class="zh">需要联网</span>
             </td>
             <td style="padding:10px 16px">
-              <span class="en">No</span><span class="zh">否</span>
+              <span class="en">Only optional quotas/updates</span><span class="zh">仅可选额度/更新</span>
             </td>
             <td style="padding:10px 16px;color:var(--t2)">
               <span class="en">Yes (API/cookies)</span><span class="zh">是（API/Cookie）</span>
@@ -1167,7 +1187,7 @@ body::after{
               <span class="en">Login required</span><span class="zh">需要登录</span>
             </td>
             <td style="padding:10px 16px">
-              <span class="en">No</span><span class="zh">否</span>
+              <span class="en">Core: no; quotas reuse existing auth</span><span class="zh">核心：否；额度复用已有登录态</span>
             </td>
             <td style="padding:10px 16px;color:var(--t2)">
               <span class="en">Yes (per provider)</span><span class="zh">是（按提供商）</span>
@@ -1178,7 +1198,7 @@ body::after{
               <span class="en">Data source</span><span class="zh">数据来源</span>
             </td>
             <td style="padding:10px 16px;color:var(--t2)">
-              <span class="en">Local logs</span><span class="zh">本地日志</span>
+              <span class="en">Local logs + optional quota APIs</span><span class="zh">本地日志 + 可选额度 API</span>
             </td>
             <td style="padding:10px 16px;color:var(--t2)">
               <span class="en">Remote APIs</span><span class="zh">远程 API</span>
@@ -1188,8 +1208,8 @@ body::after{
       </table>
     </div>
     <p style="max-width:600px;margin:24px auto 0;font-size:13px;color:var(--t3);line-height:1.6;text-align:center">
-      <span class="en">CodexBar excels at provider coverage and quota visibility. Tokei goes deeper — token-level analytics, cost trends, project breakdowns, and cross-device sync — all without needing a single login.</span>
-      <span class="zh">CodexBar 在提供商覆盖和配额可见性上表现出色。Tokei 更深入——Token 级分析、成本趋势、项目维度拆分、跨设备同步——全部无需登录。</span>
+      <span class="en">CodexBar excels at provider coverage and quota visibility. Tokei keeps core analytics local-first, while optional quota cards reuse an existing sign-in.</span>
+      <span class="zh">CodexBar 在提供商覆盖和配额可见性上表现出色。Tokei 的核心分析保持本地优先，可选额度卡复用已有登录态。</span>
     </p>
   </div>
 </section>
@@ -1231,8 +1251,8 @@ body::after{
           </li>
         </ol>
         <p style="font-size:13px;color:var(--t3);margin-top:14px">
-          <span class="en">That's it. No account, no API key, no configuration needed.</span>
-          <span class="zh">就这么简单。无需账号、无需 API 密钥、无需任何配置。</span>
+          <span class="en">That's it for local usage. External quota cards remain optional.</span>
+          <span class="zh">本地用量到这里即可；外部 Provider 额度卡始终是可选项。</span>
         </p>
       </div>
 

--- a/tests/swift/ProviderCredentialStoreCheck.swift
+++ b/tests/swift/ProviderCredentialStoreCheck.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+private enum TestFailure: Error {
+    case assertion(String)
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() { throw TestFailure.assertion(message) }
+}
+
+@main
+struct ProviderCredentialStoreCheck {
+    static func main() throws {
+        let first = "tokei-provider-test-" + UUID().uuidString
+        let second = first + "-updated"
+        ProviderCredentialStore.purgeTestItems()
+        defer {
+            ProviderCredentialStore.purgeTestItems()
+            ProviderCredentialStore.destroyTestKeychain()
+        }
+
+        for provider in [ProviderSecret.sub2api, .zai] {
+            try expect(ProviderCredentialStore.setToken(first, for: provider),
+                       "initial save failed for " + provider.rawValue)
+            try expect(ProviderCredentialStore.token(for: provider) == first,
+                       "initial read failed for " + provider.rawValue)
+            try expect(ProviderCredentialStore.setToken(second, for: provider),
+                       "update failed for " + provider.rawValue)
+            try expect(ProviderCredentialStore.token(for: provider) == second,
+                       "updated read failed for " + provider.rawValue)
+            try expect(ProviderCredentialStore.setToken("", for: provider),
+                       "delete failed for " + provider.rawValue)
+            try expect(ProviderCredentialStore.token(for: provider) == nil,
+                       "deleted item is still readable for " + provider.rawValue)
+        }
+
+        print("provider credential keychain checks passed")
+    }
+}

--- a/tests/swift/ProviderQuotaModelCheck.swift
+++ b/tests/swift/ProviderQuotaModelCheck.swift
@@ -40,6 +40,13 @@ struct ProviderQuotaModelCheck {
           "details": [
             {"label": "余额", "value": "$42.50", "secondary": "USD"}
           ],
+          "usage": {
+            "ranges": {
+              "today": {"tokens": 205, "in": 140, "out": 25, "cr": 30, "cw": 10, "requests": 2, "cost": 0.15, "models": [{"name": "GPT-5.6 Sol", "tokens": 205}]},
+              "yesterday": {}, "week": {}, "last_week": {},
+              "month": {}, "year": {"coverage": "近30天"}
+            }
+          },
           "source": "fixture",
           "updated": 1787702400,
           "stale": false
@@ -51,6 +58,10 @@ struct ProviderQuotaModelCheck {
         try expect(quota.windows.first?.used_pct == 35.5, "window percent")
         try expect(quota.windows.first?.window_minutes == 10080, "window minutes")
         try expect(quota.details.first?.secondary == "USD", "detail secondary")
+        try expect(quota.usage?.ranges.today.totalTokens == 205, "provider token total")
+        try expect(quota.usage?.ranges.today.requests == 2, "provider request count")
+        try expect(quota.usage?.ranges.today.models.first?.tokens == 205, "provider model tokens")
+        try expect(quota.usage?.ranges.year.coverage == "近30天", "provider range coverage")
 
         let empty = try JSONDecoder().decode(ProviderQuotaStat.self, from: Data("{}".utf8))
         try expect(!empty.available, "empty availability")

--- a/tests/swift/ProviderQuotaModelCheck.swift
+++ b/tests/swift/ProviderQuotaModelCheck.swift
@@ -67,6 +67,22 @@ struct ProviderQuotaModelCheck {
         try expect(!empty.available, "empty availability")
         try expect(empty.windows.isEmpty, "empty windows")
         try expect(empty.details.isEmpty, "empty details")
+
+        let geminiRanges = try JSONDecoder().decode(GeminiRanges.self, from: Data("""
+        {
+          "today": {"hit": 0, "in": 0, "out": 0, "cached": 0, "thoughts": 0, "cost": 0, "models": [], "sessions": 0},
+          "yesterday": {"hit": 75, "in": 100, "out": 20, "cached": 30, "thoughts": 10, "cost": 1.25, "models": [], "sessions": 1},
+          "week": {"hit": 75, "in": 100, "out": 20, "cached": 30, "thoughts": 10, "cost": 1.25, "models": [], "sessions": 1},
+          "last_week": {"hit": 0, "in": 0, "out": 0, "cached": 0, "thoughts": 0, "cost": 0, "models": [], "sessions": 0},
+          "month": {"hit": 75, "in": 100, "out": 20, "cached": 30, "thoughts": 10, "cost": 1.25, "models": [], "sessions": 1},
+          "year": {"hit": 75, "in": 100, "out": 20, "cached": 30, "thoughts": 10, "cost": 1.25, "models": [], "sessions": 1}
+        }
+        """.utf8))
+        let geminiDisplay = geminiRanges.displayRange(for: .today)
+        try expect(geminiDisplay.key == .yesterday, "Gemini should expose the nearest non-empty range")
+        try expect(geminiDisplay.range.totalTokens == 160, "Gemini display total")
+        try expect(geminiDisplay.range.hasUsage, "Gemini display usage flag")
+
         print("provider quota model checks passed")
     }
 }

--- a/tests/swift/ProviderQuotaModelCheck.swift
+++ b/tests/swift/ProviderQuotaModelCheck.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+private enum TestFailure: Error {
+    case assertion(String)
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() { throw TestFailure.assertion(message) }
+}
+
+@main
+struct ProviderQuotaModelCheck {
+    static func main() throws {
+        if CommandLine.arguments.contains("--usage-stdin") {
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            let usage = try JSONDecoder().decode(Usage.self, from: data)
+            try expect(!usage.cursor.available, "disabled Cursor should decode as unavailable")
+            try expect(!usage.zed.available, "disabled Zed should decode as unavailable")
+            try expect(!usage.sub2api.available, "disabled Sub2API should decode as unavailable")
+            try expect(!usage.zai.available, "disabled z.ai should decode as unavailable")
+            print("provider quota usage decode passed")
+            return
+        }
+        let data = Data("""
+        {
+          "available": true,
+          "plan": "Pro",
+          "account": "user@example.com",
+          "windows": [
+            {
+              "id": "weekly",
+              "title": "周额度",
+              "used_pct": 35.5,
+              "reset": 1788220800,
+              "window_minutes": 10080,
+              "detail": "35.5 / 100",
+              "usage_known": true
+            }
+          ],
+          "details": [
+            {"label": "余额", "value": "$42.50", "secondary": "USD"}
+          ],
+          "source": "fixture",
+          "updated": 1787702400,
+          "stale": false
+        }
+        """.utf8)
+        let quota = try JSONDecoder().decode(ProviderQuotaStat.self, from: data)
+        try expect(quota.available, "available")
+        try expect(quota.plan == "Pro", "plan")
+        try expect(quota.windows.first?.used_pct == 35.5, "window percent")
+        try expect(quota.windows.first?.window_minutes == 10080, "window minutes")
+        try expect(quota.details.first?.secondary == "USD", "detail secondary")
+
+        let empty = try JSONDecoder().decode(ProviderQuotaStat.self, from: Data("{}".utf8))
+        try expect(!empty.available, "empty availability")
+        try expect(empty.windows.isEmpty, "empty windows")
+        try expect(empty.details.isEmpty, "empty details")
+        print("provider quota model checks passed")
+    }
+}

--- a/tests/swift/SyncManagerProviderConfigTypes.swift
+++ b/tests/swift/SyncManagerProviderConfigTypes.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct DailyCost: Codable {}
+struct WrappedData: Codable {}
+
+func providerConfigTypesCompile() {
+    _ = SyncManager.setProviderQuotaEnabled("cursor", enabled: true)
+    _ = SyncManager.providerSetting("sub2api_base_url")
+    _ = SyncManager.setProviderSetting("https://api.example.com", forKey: "sub2api_base_url")
+}

--- a/tests/test_dashboard_cache.py
+++ b/tests/test_dashboard_cache.py
@@ -145,6 +145,38 @@ class DashboardCacheTests(unittest.TestCase):
         self.assertEqual(wrapped["total_cost"], 7.25)
         self.assertEqual(sum(wrapped["hours"]), 255)
 
+    def test_account_provider_models_are_reported_without_double_counting_local_totals(self):
+        today = date.today().isoformat()
+        cache = {
+            "v": USAGE._SCAN_CACHE_VERSION,
+            "_dirty": False,
+            USAGE._CURSOR_PROVIDER_DAYS_CACHE_KEY: {
+                today: {
+                    "tokens": 160, "in": 100, "out": 20, "cr": 30, "cw": 10,
+                    "cost": 0.25, "requests": 2, "hours": [160] + [0] * 23,
+                    "models": {"gpt-5.6-sol-medium": {
+                        "tokens": 160, "in": 100, "out": 20, "cr": 30, "cw": 10,
+                        "reason": 0, "cost": 0.25,
+                    }},
+                },
+            },
+            USAGE._ZAI_PROVIDER_DAYS_CACHE_KEY: {
+                today: {
+                    "tokens": 500, "hours": [0] * 24,
+                    "models": {"glm-5.3": {"tokens": 500}},
+                },
+            },
+        }
+
+        result = USAGE.build_daily_costs("1d", refresh=False, _cache=cache)
+
+        self.assertEqual(result["daily"], [])
+        self.assertEqual(sum(model["tokens"] for model in result["provider_models"]), 660)
+        self.assertEqual(
+            {model["tool"] for model in result["provider_models"]},
+            {"cursor", "zai"},
+        )
+
     def test_swift_all_device_qoderwork_tokens_are_preserved(self):
         root = Path(__file__).resolve().parents[1]
         model = (root / "Tokei/Sources/Tokei/Model.swift").read_text()

--- a/tests/test_gemini_usage.py
+++ b/tests/test_gemini_usage.py
@@ -244,6 +244,40 @@ class AntigravityRobustnessTests(unittest.TestCase):
         conn.close()
         return str(path)
 
+    def test_current_antigravity_rows_use_referenced_step_timestamp(self):
+        now_sec = int(datetime.now().astimezone().timestamp())
+        tokens = (self._field(2, 0, 200) + self._field(3, 0, 50)
+                  + self._field(5, 0, 800) + self._field(9, 0, 20))
+        generation = self._field(19, 2, "gemini-3.7-flash") + self._field(4, 2, tokens)
+        # Current Antigravity rows omit the old embedded timestamp. Field 2 is a
+        # packed list of referenced step indexes; the step metadata owns the time.
+        row = self._field(2, 2, self._varint(4) + self._varint(5)) \
+            + self._field(1, 2, generation)
+        step_metadata = self._field(1, 2, self._field(1, 0, now_sec))
+
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, True))
+        path = root / "current.db"
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER)")
+        conn.execute("CREATE TABLE steps (idx INTEGER PRIMARY KEY, metadata BLOB)")
+        conn.execute("INSERT INTO gen_metadata VALUES (0, ?, ?)", (row, len(row)))
+        conn.execute("INSERT INTO steps VALUES (4, ?)", (step_metadata,))
+        conn.execute("INSERT INTO steps VALUES (5, ?)", (step_metadata,))
+        conn.commit()
+        conn.close()
+
+        parsed = USAGE._load_antigravity_db(str(path))
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(len(parsed["events"]), 1)
+        event = parsed["events"][0]
+        self.assertEqual(event["model"], "gemini-3.7-flash")
+        self.assertEqual(event["tokens"]["input"], 1000)
+        self.assertEqual(event["tokens"]["cached"], 800)
+        self.assertEqual(event["timestamp"], datetime.fromtimestamp(
+            now_sec, USAGE.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
     def test_oversized_varint_is_rejected_instead_of_hanging(self):
         # 不封顶时 val 会长成百万位大整数,O(n²) 能把 30 秒一轮的采集器拖死。
         with self.assertRaises(ValueError):

--- a/tests/test_provider_credentials.py
+++ b/tests/test_provider_credentials.py
@@ -1,0 +1,42 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProviderCredentialStoreTests(unittest.TestCase):
+    def test_legacy_keychain_round_trip_is_noninteractive(self):
+        swiftc = shutil.which("swiftc")
+        if swiftc is None:
+            self.skipTest("swiftc is required")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "provider-credential-store-check"
+            result = subprocess.run(
+                [
+                    swiftc,
+                    "-parse-as-library",
+                    "-D",
+                    "TOKEI_PROVIDER_CREDENTIAL_STORE_TEST",
+                    str(ROOT / "Tokei/Sources/Tokei/ProviderCredentialStore.swift"),
+                    str(ROOT / "tests/swift/ProviderCredentialStoreCheck.swift"),
+                    "-o",
+                    str(binary),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            result = subprocess.run([str(binary)], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("provider credential keychain checks passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_quota_model.py
+++ b/tests/test_provider_quota_model.py
@@ -1,0 +1,49 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProviderQuotaModelTests(unittest.TestCase):
+    def test_swift_model_decodes_provider_quota(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "provider-quota-model-check"
+            result = subprocess.run(
+                [
+                    "swiftc",
+                    "-parse-as-library",
+                    str(ROOT / "Tokei/Sources/Tokei/Model.swift"),
+                    str(ROOT / "tests/swift/ProviderQuotaModelCheck.swift"),
+                    "-o",
+                    str(binary),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            result = subprocess.run([str(binary)], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("provider quota model checks passed", result.stdout)
+
+    def test_sync_manager_provider_config_typechecks(self):
+        result = subprocess.run(
+            [
+                "swiftc",
+                "-typecheck",
+                str(ROOT / "Tokei/Sources/Tokei/Model.swift"),
+                str(ROOT / "Tokei/Sources/Tokei/SyncManager.swift"),
+                str(ROOT / "tests/swift/SyncManagerProviderConfigTypes.swift"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_quotas.py
+++ b/tests/test_provider_quotas.py
@@ -1,0 +1,493 @@
+import base64
+import json
+import sqlite3
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+try:
+    from .test_codex_limits import USAGE
+except ImportError:
+    from test_codex_limits import USAGE
+
+
+def _jwt(payload):
+    def encode(value):
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{encode({'alg': 'none'})}.{encode(payload)}.signature"
+
+
+class ProviderQuotaTests(unittest.TestCase):
+    def setUp(self):
+        self.old_user_dir = USAGE._USER_DIR
+        self.old_cache = getattr(USAGE, "PROVIDER_QUOTA_CACHE", None)
+        self.old_env = dict(USAGE.os.environ)
+
+    def tearDown(self):
+        USAGE._USER_DIR = self.old_user_dir
+        if self.old_cache is not None:
+            USAGE.PROVIDER_QUOTA_CACHE = self.old_cache
+        USAGE.os.environ.clear()
+        USAGE.os.environ.update(self.old_env)
+
+    def isolate_cache(self, root):
+        USAGE._USER_DIR = str(root)
+        USAGE.PROVIDER_QUOTA_CACHE = str(root / "provider_quota_cache.json")
+
+    def test_provider_queries_are_opt_in_except_local_antigravity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            USAGE._USER_DIR = tmp
+            Path(tmp, "config.json").write_text("{}", encoding="utf-8")
+            self.assertFalse(USAGE._provider_quota_enabled("cursor"))
+            self.assertFalse(USAGE._provider_quota_enabled("zed"))
+            self.assertFalse(USAGE._provider_quota_enabled("sub2api"))
+            self.assertFalse(USAGE._provider_quota_enabled("zai"))
+            self.assertTrue(USAGE._provider_quota_enabled("antigravity"))
+
+            Path(tmp, "config.json").write_text(
+                json.dumps({"cursor_quota_enabled": True}), encoding="utf-8")
+            self.assertTrue(USAGE._provider_quota_enabled("cursor"))
+            with mock.patch.dict(USAGE.os.environ, {"TOKEI_CURSOR_QUOTA": "0"}):
+                self.assertFalse(USAGE._provider_quota_enabled("cursor"))
+
+    def test_provider_http_does_not_follow_redirects_with_credentials(self):
+        leaked = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/start":
+                    self.send_response(302)
+                    self.send_header("Location", "/leak")
+                    self.end_headers()
+                    return
+                leaked.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, _format, *_args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+
+        with self.assertRaises(RuntimeError):
+            USAGE._provider_json_request(
+                f"http://127.0.0.1:{server.server_port}/start",
+                headers={"Authorization": "Bearer secret"},
+            )
+        self.assertEqual(leaked, [])
+
+    def test_cursor_reads_app_auth_and_maps_usage_summary(self):
+        token = _jwt({
+            "sub": "auth0|cursor-user",
+            "email": "cursor@example.com",
+            "exp": 4_000_000_000,
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp, "state.vscdb")
+            connection = sqlite3.connect(db_path)
+            connection.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)")
+            connection.execute(
+                "INSERT INTO ItemTable (key, value) VALUES (?, ?)",
+                ("cursorAuth/accessToken", token),
+            )
+            connection.commit()
+            connection.close()
+
+            session = USAGE._cursor_app_session(str(db_path), now_epoch=1_800_000_000)
+
+        self.assertEqual(session["account"], "cursor@example.com")
+        self.assertIn("WorkosCursorSessionToken=cursor-user%3A%3A", session["cookie"])
+        summary = {
+            "billingCycleStart": "2026-08-01T00:00:00Z",
+            "billingCycleEnd": "2026-09-01T00:00:00Z",
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": {
+                    "used": 388,
+                    "limit": 2000,
+                    "totalPercentUsed": 19.4,
+                    "autoPercentUsed": 12.5,
+                    "apiPercentUsed": 7.5,
+                },
+                "onDemand": {"enabled": True, "used": 450, "limit": 1000},
+            },
+        }
+        quota = USAGE._normalize_cursor_quota(summary, identity=session, updated=1_800_000_000)
+
+        self.assertTrue(quota["available"])
+        self.assertEqual(quota["plan"], "Cursor Pro")
+        self.assertEqual([row["used_pct"] for row in quota["windows"]], [19.4, 12.5, 7.5])
+        self.assertEqual(quota["windows"][0]["reset"], 1_788_220_800)
+        self.assertEqual(quota["details"][0]["value"], "$3.88 / $20.00")
+        self.assertEqual(quota["details"][1]["value"], "$4.50 / $10.00")
+
+    def test_cursor_legacy_request_quota_overrides_token_percent(self):
+        summary = {
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": {"used": 500, "limit": 1000, "totalPercentUsed": 50},
+            },
+        }
+        legacy = {"gpt-4": {"numRequestsTotal": 240, "maxRequestUsage": 500}}
+        quota = USAGE._normalize_cursor_quota(summary, request_usage=legacy)
+
+        self.assertEqual(len(quota["windows"]), 1)
+        self.assertEqual(quota["windows"][0]["used_pct"], 48.0)
+        self.assertEqual(quota["windows"][0]["detail"], "240 / 500 requests")
+
+    def test_cursor_fetch_uses_cookie_and_normalized_legacy_user_id(self):
+        session = {
+            "cookie": "WorkosCursorSessionToken=cursor-user%3A%3Atoken",
+            "account": "cursor@example.com",
+            "subject": "auth0|cursor-user",
+            "user_id": "cursor-user",
+            "marker": "cursor-marker",
+        }
+        requests = []
+
+        def request(url, **kwargs):
+            requests.append((url, kwargs))
+            self.assertEqual(
+                kwargs["headers"]["Cookie"],
+                "WorkosCursorSessionToken=cursor-user%3A%3Atoken",
+            )
+            if url.endswith("/api/usage-summary"):
+                return {
+                    "membershipType": "pro",
+                    "individualUsage": {"plan": {"used": 100, "limit": 1000}},
+                }
+            if url.endswith("/api/auth/me"):
+                return {"sub": "auth0|cursor-user", "email": "cursor@example.com"}
+            if "/api/usage?" in url:
+                self.assertTrue(url.endswith("user=cursor-user"), url)
+                return {"gpt-4": {"numRequestsTotal": 24, "maxRequestUsage": 100}}
+            self.assertEqual(kwargs["method"], "POST")
+            self.assertEqual(kwargs["headers"]["Origin"], "https://cursor.com")
+            return {"hasNonZeroIncludedLimit": False}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.isolate_cache(Path(tmp))
+            with mock.patch.object(USAGE, "_provider_json_request", side_effect=request):
+                quota = USAGE.fetch_cursor_quota(session)
+
+        self.assertEqual(quota["windows"][0]["used_pct"], 24.0)
+        self.assertEqual(len(requests), 4)
+
+    def test_zed_maps_limited_and_unlimited_prediction_plans(self):
+        payload = {
+            "user": {"id": 42, "github_login": "octocat", "name": "Octo Cat"},
+            "plan": {
+                "plan_v3": "zed_pro",
+                "subscription_period": {
+                    "started_at": "2026-08-01T00:00:00Z",
+                    "ended_at": "2026-09-01T00:00:00Z",
+                },
+                "usage": {"edit_predictions": {"used": 12, "limit": {"limited": 50}}},
+                "has_overdue_invoices": False,
+            },
+        }
+        quota = USAGE._normalize_zed_quota(payload, updated=1_800_000_000)
+
+        self.assertEqual(quota["plan"], "Zed Pro")
+        self.assertEqual(quota["account"], "octocat")
+        self.assertEqual(quota["windows"][0]["used_pct"], 24.0)
+        self.assertEqual(quota["windows"][0]["detail"], "12 / 50 predictions")
+
+        payload["plan"]["usage"]["edit_predictions"]["limit"] = "unlimited"
+        unlimited = USAGE._normalize_zed_quota(payload)
+        self.assertEqual(unlimited["windows"][0]["used_pct"], 0.0)
+        self.assertEqual(unlimited["windows"][0]["detail"], "Unlimited")
+
+    def test_zed_settings_reject_cross_origin_credentials(self):
+        trusted = USAGE._zed_connection_settings({
+            "credentials_url": "zed-preview-key",
+            "server_url": "https://zed.dev",
+        })
+        self.assertEqual(trusted["service"], "zed-preview-key")
+        self.assertEqual(trusted["api_url"], "https://cloud.zed.dev/client/users/me")
+        self.assertIsNone(USAGE._zed_connection_settings({
+            "credentials_url": "https://zed.dev",
+            "server_url": "https://attacker.example.com",
+        }))
+        self.assertIsNone(USAGE._zed_connection_settings({
+            "server_url": "http://localhost:3000",
+        }))
+
+    def test_zed_fetch_sends_native_authorization_header(self):
+        payload = {
+            "user": {"id": 42, "github_login": "octocat", "name": None},
+            "plan": {
+                "plan_v3": "zed_pro",
+                "subscription_period": None,
+                "usage": {"edit_predictions": {"used": 1, "limit": {"limited": 10}}},
+                "has_overdue_invoices": False,
+            },
+        }
+
+        def request(url, **kwargs):
+            self.assertEqual(url, "https://cloud.zed.dev/client/users/me")
+            self.assertEqual(kwargs["headers"]["Authorization"], "42 zed-token")
+            return payload
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.isolate_cache(Path(tmp))
+            with mock.patch.dict(USAGE.os.environ, {
+                "TOKEI_ZED_USER_ID": "42",
+                "TOKEI_ZED_ACCESS_TOKEN": "zed-token",
+            }), mock.patch.object(USAGE, "_load_zed_connection_settings", return_value={
+                "service": "https://zed.dev",
+                "api_url": "https://cloud.zed.dev/client/users/me",
+            }), mock.patch.object(USAGE, "_provider_json_request", side_effect=request):
+                quota = USAGE.fetch_zed_quota()
+
+        self.assertEqual(quota["windows"][0]["used_pct"], 10.0)
+
+    def test_sub2api_validates_url_and_maps_subscription_windows(self):
+        self.assertEqual(
+            USAGE._sub2api_usage_url("https://api.example.com", timezone_name="Asia/Taipei"),
+            "https://api.example.com/v1/usage?days=30&timezone=Asia%2FTaipei",
+        )
+        self.assertEqual(
+            USAGE._sub2api_usage_url("http://127.0.0.1:8080/v1", timezone_name="UTC"),
+            "http://127.0.0.1:8080/v1/usage?days=30&timezone=UTC",
+        )
+        self.assertIsNone(USAGE._sub2api_usage_url("http://api.example.com"))
+        self.assertIsNone(USAGE._sub2api_usage_url("https://user:pass@api.example.com"))
+
+        quota = USAGE._normalize_sub2api_quota({
+            "mode": "unrestricted",
+            "isValid": True,
+            "planName": "Claude Team",
+            "balance": 42.5,
+            "unit": "USD",
+            "subscription": {
+                "daily_usage_usd": 2,
+                "weekly_usage_usd": 10,
+                "monthly_usage_usd": 30,
+                "daily_limit_usd": 10,
+                "weekly_limit_usd": 40,
+                "monthly_limit_usd": 100,
+                "expires_at": "2026-09-01T00:00:00Z",
+            },
+            "usage": {
+                "today": {"requests": 4, "total_tokens": 1200, "actual_cost": 1.25},
+            },
+        })
+
+        self.assertEqual(quota["plan"], "Claude Team")
+        self.assertEqual([row["used_pct"] for row in quota["windows"][:3]], [20.0, 25.0, 30.0])
+        self.assertEqual(quota["details"][0]["value"], "$42.50")
+        self.assertEqual(quota["details"][2]["value"], "1,200")
+        self.assertEqual(quota["details"][2]["secondary"], "$1.25")
+
+    def test_sub2api_fetch_sends_bearer_key_to_normalized_usage_url(self):
+        def request(url, **kwargs):
+            self.assertIn("/v1/usage?days=30&timezone=", url)
+            self.assertEqual(kwargs["headers"]["Authorization"], "Bearer group-key")
+            self.assertEqual(kwargs["timeout"], 15)
+            return {"isValid": True, "balance": 5}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.isolate_cache(Path(tmp))
+            with mock.patch.dict(USAGE.os.environ, {
+                "SUB2API_API_KEY": "group-key",
+                "SUB2API_BASE_URL": "https://api.example.com",
+            }), mock.patch.object(USAGE, "_provider_json_request", side_effect=request):
+                quota = USAGE.fetch_sub2api_quota()
+
+        self.assertEqual(quota["details"][0]["value"], "$5.00")
+
+    def test_zai_maps_session_weekly_and_mcp_limits(self):
+        payload = {
+            "code": 200,
+            "success": True,
+            "data": {
+                "planName": "Pro",
+                "limits": [
+                    {
+                        "type": "TOKENS_LIMIT", "unit": 3, "number": 5,
+                        "percentage": 25, "nextResetTime": 1_785_816_000_000,
+                    },
+                    {
+                        "type": "TOKENS_LIMIT", "unit": 6, "number": 1,
+                        "percentage": 9, "nextResetTime": 1_786_291_200_000,
+                    },
+                    {
+                        "type": "TIME_LIMIT", "unit": 5, "number": 1,
+                        "usage": 1000, "currentValue": 224, "remaining": 776,
+                        "percentage": 22,
+                        "usageDetails": [{"modelCode": "search-prime", "usage": 210}],
+                    },
+                ],
+            },
+        }
+        quota = USAGE._normalize_zai_quota(payload, region="global", updated=1_800_000_000)
+
+        self.assertEqual(quota["plan"], "Pro")
+        self.assertEqual([row["used_pct"] for row in quota["windows"]], [25.0, 9.0, 22.4])
+        self.assertEqual(quota["windows"][0]["window_minutes"], 300)
+        self.assertEqual(quota["windows"][1]["window_minutes"], 10080)
+        self.assertEqual(quota["windows"][2]["title"], "MCP")
+        self.assertEqual(quota["details"][-1]["value"], "210")
+
+    def test_zai_team_url_replaces_existing_type_parameter(self):
+        self.assertEqual(
+            USAGE._zai_quota_url(
+                "https://api.z.ai/api/monitor/usage/quota/limit?keep=1&type=9",
+                scope="team",
+            ),
+            "https://api.z.ai/api/monitor/usage/quota/limit?keep=1&type=2",
+        )
+
+    def test_zai_team_fetch_sends_scope_headers_and_type(self):
+        def request(url, **kwargs):
+            self.assertTrue(url.endswith("/api/monitor/usage/quota/limit?type=2"), url)
+            self.assertEqual(kwargs["headers"]["Authorization"], "Bearer zai-key")
+            self.assertEqual(kwargs["headers"]["Bigmodel-Organization"], "org")
+            self.assertEqual(kwargs["headers"]["Bigmodel-Project"], "project")
+            return {
+                "code": 200,
+                "success": True,
+                "data": {"limits": [
+                    {"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 25},
+                ]},
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.isolate_cache(Path(tmp))
+            with mock.patch.dict(USAGE.os.environ, {
+                "Z_AI_API_KEY": "zai-key",
+                "Z_AI_REGION": "global",
+                "Z_AI_USAGE_SCOPE": "team",
+                "Z_AI_ORGANIZATION": "org",
+                "Z_AI_PROJECT": "project",
+            }), mock.patch.object(USAGE, "_provider_json_request", side_effect=request):
+                quota = USAGE.fetch_zai_quota()
+
+        self.assertEqual(quota["windows"][0]["used_pct"], 25.0)
+
+    def test_antigravity_parses_process_and_quota_summary(self):
+        output = """
+        123 /Applications/Antigravity.app/Contents/Resources/language_server_macos_arm \
+          --csrf_token language-token --app_data_dir antigravity \
+          --extension_server_port 64123 --extension_server_csrf_token extension-token
+        """
+        processes = USAGE._antigravity_process_infos(output)
+        self.assertEqual(processes[0]["pid"], 123)
+        self.assertEqual(processes[0]["csrf_token"], "language-token")
+        self.assertEqual(processes[0]["extension_port"], 64123)
+
+        quota = USAGE._normalize_antigravity_quota_summary({
+            "response": {
+                "groups": [
+                    {
+                        "displayName": "Gemini Models",
+                        "buckets": [
+                            {
+                                "bucketId": "gemini-weekly",
+                                "displayName": "Weekly Limit",
+                                "remaining": {"remainingFraction": 0.82},
+                                "resetTime": "2026-09-01T00:00:00Z",
+                            },
+                            {
+                                "bucketId": "gemini-5h",
+                                "displayName": "Five Hour Limit",
+                                "remaining": {"case": "remainingFraction", "value": 0.91},
+                            },
+                        ],
+                    },
+                    {
+                        "displayName": "Claude and GPT models",
+                        "buckets": [
+                            {
+                                "bucketId": "3p-weekly",
+                                "displayName": "Weekly Limit",
+                                "remaining": {"remainingFraction": 0.64},
+                            },
+                            {
+                                "bucketId": "3p-5h",
+                                "displayName": "Five Hour Limit",
+                                "remaining": {"remainingFraction": 0.73},
+                            },
+                        ],
+                    },
+                ],
+            },
+        }, updated=1_800_000_000)
+
+        self.assertEqual(
+            [row["title"] for row in quota["windows"]],
+            ["Gemini 5h", "Gemini 周", "Claude/GPT 5h", "Claude/GPT 周"],
+        )
+        self.assertEqual([row["used_pct"] for row in quota["windows"]], [9.0, 18.0, 27.0, 36.0])
+        self.assertEqual(quota["windows"][0]["window_minutes"], 300)
+        self.assertEqual(quota["windows"][1]["window_minutes"], 10080)
+
+    def test_antigravity_request_is_loopback_only_and_sends_csrf(self):
+        with mock.patch.object(USAGE, "_provider_json_request", return_value={}) as request:
+            USAGE._antigravity_request(
+                ("https", 64123, "csrf-token", True),
+                "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+                {"metadata": {}},
+            )
+
+        args, kwargs = request.call_args
+        self.assertEqual(
+            args[0],
+            "https://127.0.0.1:64123/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        )
+        self.assertEqual(kwargs["headers"]["X-Codeium-Csrf-Token"], "csrf-token")
+        self.assertEqual(kwargs["headers"]["Connect-Protocol-Version"], "1")
+        self.assertTrue(kwargs["allow_insecure_loopback_tls"])
+
+    def test_provider_cache_is_scoped_to_credentials_without_storing_secret(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            USAGE._USER_DIR = tmp
+            USAGE.PROVIDER_QUOTA_CACHE = str(Path(tmp, "provider_quota_cache.json"))
+            marker = USAGE._provider_credential_marker("sub2api", "secret-a", "https://api.test")
+            quota = {"available": True, "windows": [], "updated": 1_800_000_000}
+            USAGE._save_provider_quota_cache("sub2api", marker, quota, fetched_at=1_800_000_000)
+
+            cache_text = Path(USAGE.PROVIDER_QUOTA_CACHE).read_text(encoding="utf-8")
+            self.assertNotIn("secret-a", cache_text)
+            self.assertEqual(Path(USAGE.PROVIDER_QUOTA_CACHE).stat().st_mode & 0o777, 0o600)
+            self.assertEqual(
+                USAGE._cached_provider_quota(
+                    "sub2api", marker, max_age=60, now_epoch=1_800_000_030
+                )["available"],
+                True,
+            )
+            other = USAGE._provider_credential_marker("sub2api", "secret-b", "https://api.test")
+            self.assertIsNone(USAGE._cached_provider_quota(
+                "sub2api", other, max_age=60, now_epoch=1_800_000_030
+            ))
+
+    def test_provider_accounts_are_not_written_to_sync_snapshots(self):
+        payload = {
+            "claude": {"ranges": {}},
+            "cursor": {"account": "cursor@example.com"},
+            "zed": {"account": "octocat"},
+            "sub2api": {"available": True},
+            "zai": {"available": True},
+            "antigravity": {"account": "gemini@example.com"},
+        }
+        snapshot = USAGE._sync_safe_usage_payload(payload)
+
+        self.assertIn("claude", snapshot)
+        for provider in ("cursor", "zed", "sub2api", "zai", "antigravity"):
+            self.assertNotIn(provider, snapshot)
+        self.assertIn("cursor", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_quotas.py
+++ b/tests/test_provider_quotas.py
@@ -4,6 +4,7 @@ import sqlite3
 import tempfile
 import threading
 import unittest
+from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest import mock
@@ -171,6 +172,9 @@ class ProviderQuotaTests(unittest.TestCase):
             if "/api/usage?" in url:
                 self.assertTrue(url.endswith("user=cursor-user"), url)
                 return {"gpt-4": {"numRequestsTotal": 24, "maxRequestUsage": 100}}
+            if url.endswith("/api/dashboard/get-filtered-usage-events"):
+                self.assertEqual(kwargs["method"], "POST")
+                return {"totalUsageEventsCount": 0, "usageEventsDisplay": []}
             self.assertEqual(kwargs["method"], "POST")
             self.assertEqual(kwargs["headers"]["Origin"], "https://cursor.com")
             return {"hasNonZeroIncludedLimit": False}
@@ -181,7 +185,44 @@ class ProviderQuotaTests(unittest.TestCase):
                 quota = USAGE.fetch_cursor_quota(session)
 
         self.assertEqual(quota["windows"][0]["used_pct"], 24.0)
-        self.assertEqual(len(requests), 4)
+        self.assertEqual(len(requests), 5)
+        self.assertEqual(quota["usage"]["ranges"]["today"]["tokens"], 0)
+
+    def test_cursor_usage_events_map_tokens_cost_and_models(self):
+        now = datetime.now().astimezone().replace(hour=12, minute=0, second=0, microsecond=0)
+        events = [
+            {
+                "timestamp": str(int(now.timestamp() * 1000)),
+                "model": "gpt-5.6-sol-medium",
+                "tokenUsage": {
+                    "inputTokens": 100, "outputTokens": 20,
+                    "cacheReadTokens": 30, "cacheWriteTokens": 10,
+                    "totalCents": 12.5,
+                },
+            },
+            {
+                "timestamp": int(now.timestamp() * 1000),
+                "model": "gpt-5.6-sol-medium",
+                "tokenUsage": {
+                    "inputTokens": 40, "outputTokens": 5,
+                    "cacheReadTokens": 0, "cacheWriteTokens": 0,
+                    "totalCents": "2.5",
+                },
+            },
+        ]
+
+        usage = USAGE._normalize_cursor_usage_events(events, bounds=USAGE.range_bounds())
+        today = usage["ranges"]["today"]
+
+        self.assertEqual(today["tokens"], 205)
+        self.assertEqual(today["in"], 140)
+        self.assertEqual(today["out"], 25)
+        self.assertEqual(today["cr"], 30)
+        self.assertEqual(today["cw"], 10)
+        self.assertEqual(today["requests"], 2)
+        self.assertAlmostEqual(today["cost"], 0.15)
+        self.assertEqual(today["models"][0]["name"], "GPT-5.6 Sol")
+        self.assertEqual(today["models"][0]["tokens"], 205)
 
     def test_zed_maps_limited_and_unlimited_prediction_plans(self):
         payload = {
@@ -350,11 +391,20 @@ class ProviderQuotaTests(unittest.TestCase):
         )
 
     def test_zai_team_fetch_sends_scope_headers_and_type(self):
+        requests = []
+
         def request(url, **kwargs):
-            self.assertTrue(url.endswith("/api/monitor/usage/quota/limit?type=2"), url)
+            requests.append(url)
             self.assertEqual(kwargs["headers"]["Authorization"], "Bearer zai-key")
             self.assertEqual(kwargs["headers"]["Bigmodel-Organization"], "org")
             self.assertEqual(kwargs["headers"]["Bigmodel-Project"], "project")
+            if "/api/monitor/usage/model-usage?" in url:
+                self.assertIn("type=3", url)
+                return {
+                    "code": 200, "success": True,
+                    "data": {"x_time": [], "modelDataList": []},
+                }
+            self.assertTrue(url.endswith("/api/monitor/usage/quota/limit?type=2"), url)
             return {
                 "code": 200,
                 "success": True,
@@ -375,6 +425,35 @@ class ProviderQuotaTests(unittest.TestCase):
                 quota = USAGE.fetch_zai_quota()
 
         self.assertEqual(quota["windows"][0]["used_pct"], 25.0)
+        self.assertEqual(len(requests), 2)
+        self.assertEqual(quota["usage"]["ranges"]["month"]["tokens"], 0)
+
+    def test_zai_model_usage_maps_daily_ranges_and_models(self):
+        today = datetime.now().astimezone().replace(hour=8, minute=0, second=0, microsecond=0)
+        yesterday = today - timedelta(days=1)
+        payload = {
+            "code": 200,
+            "success": True,
+            "data": {
+                "x_time": [today.strftime("%Y-%m-%d %H:%M"),
+                           yesterday.strftime("%Y-%m-%d %H:%M")],
+                "modelDataList": [
+                    {"modelName": "glm-5.3", "tokensUsage": [100, 50]},
+                    {"modelName": "glm-4.7", "tokensUsage": [20, None]},
+                ],
+            },
+        }
+
+        usage = USAGE._normalize_zai_model_usage(payload, bounds=USAGE.range_bounds())
+
+        self.assertEqual(usage["ranges"]["today"]["tokens"], 120)
+        self.assertEqual(usage["ranges"]["yesterday"]["tokens"], 50)
+        self.assertEqual(usage["ranges"]["all"]["tokens"], 170)
+        self.assertEqual(usage["ranges"]["year"]["coverage"], "近30天")
+        self.assertEqual(usage["ranges"]["today"]["models"][0], {
+            "name": "Glm 5.3", "tokens": 100, "in": 0, "out": 0,
+            "cr": 0, "cw": 0, "reason": 0, "cost": 0.0,
+        })
 
     def test_antigravity_parses_process_and_quota_summary(self):
         output = """

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -10,7 +10,9 @@
 # (config grok_live_quota_enabled 或 TOKEI_GROK_LIVE_QUOTA=1)。
 # 千问办公额度同样默认关闭；开启后仅访问官方桌面端的 127.0.0.1 MCP 适配器，
 # 不读取或解密账号凭据 (config qwenwork_quota_enabled 或 TOKEI_QWENWORK_QUOTA=1)。
-# 仅 --update-prices 显式联网更新价格表:
+# Cursor / Zed / Sub2API / z.ai 额度默认关闭；开启卡片后才复用本机登录态或 Keychain
+# API Key 查询对应官方/自托管接口。Antigravity 额度只探测已运行的 127.0.0.1 服务。
+# --update-prices 仍只在用户显式触发时更新价格表。
 #   Claude Code: ~/.claude/projects/<proj>/<session>.jsonl  (assistant 行 message.usage,增量)
 #   Codex:       ~/.codex/{sessions,archived_sessions}/**/rollout-*.jsonl (token_count 事件,含额度)
 #   Pi:          ~/.pi/agent/sessions/**/*.jsonl + ~/.omp/agent/sessions/**/*.jsonl
@@ -28,6 +30,8 @@ import json
 import math
 import re
 import sqlite3
+import subprocess
+import threading
 from datetime import datetime, timedelta, date, timezone
 from pathlib import Path
 
@@ -175,6 +179,7 @@ CODEX_RESET_CARDS_CACHE = _writable_path("codex_reset_cards_cache.json")
 CLAUDE_QUOTA_CACHE = _writable_path("claude_quota_cache.json")
 GROK_QUOTA_CACHE = _writable_path("grok_quota_cache.json")
 QWENWORK_QUOTA_CACHE = _writable_path("qwenwork_quota_cache.json")
+PROVIDER_QUOTA_CACHE = _writable_path("provider_quota_cache.json")
 
 # 每 1M token 美元单价。基准价来自 OpenRouter,外置在 pricing.json(由 --update-prices 同步);
 # pricing_overrides.json 做本地修正(write1h / 别名 / 缺漏),一键更新不覆盖它。
@@ -4143,6 +4148,1194 @@ def scan_qwenwork_quota():
     return fallback or {}
 
 
+# ---------- CodexBar-compatible provider quotas ----------
+# Remote providers are opt-in. Antigravity is the exception: it only probes an
+# already-running loopback language server and never starts the app/CLI.
+_PROVIDER_QUOTA_TTL = 300
+_PROVIDER_QUOTA_FALLBACK_TTL = 3600
+_PROVIDER_QUOTA_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_PROVIDER_QUOTA_CACHE_LOCK = threading.Lock()
+_PROVIDER_QUOTA_ENV = {
+    "cursor": "TOKEI_CURSOR_QUOTA",
+    "zed": "TOKEI_ZED_QUOTA",
+    "sub2api": "TOKEI_SUB2API_QUOTA",
+    "zai": "TOKEI_ZAI_QUOTA",
+    "antigravity": "TOKEI_ANTIGRAVITY_QUOTA",
+}
+
+
+def _provider_quota_enabled(provider):
+    env_key = _PROVIDER_QUOTA_ENV.get(provider)
+    env = os.environ.get(env_key) if env_key else None
+    if env == "0":
+        return False
+    if env == "1":
+        return True
+    default = provider == "antigravity"
+    return bool(_tokei_config().get(f"{provider}_quota_enabled", default))
+
+
+def _provider_config_string(env_key, config_key):
+    value = os.environ.get(env_key)
+    if not isinstance(value, str) or not value.strip():
+        value = _tokei_config().get(config_key)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _provider_number(value):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        try:
+            number = float(value.strip())
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _provider_integer(value):
+    number = _provider_number(value)
+    return int(number) if number is not None and number.is_integer() else None
+
+
+def _provider_percent(value):
+    number = _provider_number(value)
+    return round(max(0.0, min(100.0, number)), 6) if number is not None else None
+
+
+def _provider_epoch(value):
+    number = _provider_number(value)
+    if number is not None:
+        if number > 100_000_000_000:
+            number /= 1000.0
+        return int(number) if number > 0 else None
+    parsed = parse_ts(value) if isinstance(value, str) else None
+    return int(parsed.timestamp()) if parsed else None
+
+
+def _provider_money(value, unit="USD"):
+    number = _provider_number(value)
+    if number is None:
+        return None
+    if str(unit or "USD").upper() == "USD":
+        return f"${number:,.2f}"
+    return f"{number:,.2f} {unit}"
+
+
+def _provider_window(window_id, title, used_pct=None, reset=None, window_minutes=None,
+                     detail=None, usage_known=True):
+    return {
+        "id": str(window_id),
+        "title": str(title),
+        "used_pct": _provider_percent(used_pct),
+        "reset": _provider_epoch(reset),
+        "window_minutes": int(window_minutes) if isinstance(window_minutes, (int, float))
+        and window_minutes > 0 else None,
+        "detail": str(detail) if detail else None,
+        "usage_known": bool(usage_known),
+    }
+
+
+def _provider_credential_marker(provider, *parts):
+    material = "\0".join(str(part or "") for part in (provider,) + parts)
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _cached_provider_quota(provider, marker, max_age, now_epoch=None, stale=False):
+    with _PROVIDER_QUOTA_CACHE_LOCK:
+        root = _load_json(PROVIDER_QUOTA_CACHE, {})
+    entry = (root.get("providers") or {}).get(provider) if isinstance(root, dict) else None
+    if not isinstance(entry, dict) or entry.get("marker") != marker:
+        return None
+    fetched_at = _provider_number(entry.get("fetched_at"))
+    quota = entry.get("quota")
+    now_epoch = int(now_epoch if now_epoch is not None else datetime.now().timestamp())
+    if fetched_at is None or not isinstance(quota, dict):
+        return None
+    age = now_epoch - int(fetched_at)
+    if age < -300 or age > max_age:
+        return None
+    out = json.loads(json.dumps(quota))
+    if stale:
+        out["stale"] = True
+        out["source"] = "cache"
+    return out
+
+
+def _save_provider_quota_cache(provider, marker, quota, fetched_at=None):
+    if not isinstance(quota, dict) or not quota.get("available"):
+        return
+    with _PROVIDER_QUOTA_CACHE_LOCK:
+        root = _load_json(PROVIDER_QUOTA_CACHE, {})
+        if not isinstance(root, dict):
+            root = {}
+        providers = root.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+        providers[provider] = {
+            "marker": marker,
+            "fetched_at": int(fetched_at if fetched_at is not None else datetime.now().timestamp()),
+            "quota": quota,
+        }
+        root = {"version": 1, "providers": providers}
+        try:
+            _atomic_write_json(PROVIDER_QUOTA_CACHE, root)
+            os.chmod(PROVIDER_QUOTA_CACHE, 0o600)
+        except OSError:
+            pass
+
+
+def _provider_json_request(url, *, headers=None, method="GET", body=None, timeout=5,
+                           max_bytes=_PROVIDER_QUOTA_MAX_RESPONSE_BYTES,
+                           allow_insecure_loopback_tls=False):
+    import ssl
+    import urllib.error
+    import urllib.request
+    from urllib.parse import urlsplit
+
+    raw_body = None
+    request_headers = dict(headers or {})
+    if body is not None:
+        raw_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/json")
+    request_headers.setdefault("Accept", "application/json")
+    request = urllib.request.Request(
+        url, data=raw_body, headers=request_headers, method=method)
+    context = None
+    parsed = urlsplit(url)
+    if allow_insecure_loopback_tls and parsed.scheme == "https" \
+            and parsed.hostname in {"127.0.0.1", "::1", "localhost"}:
+        context = ssl._create_unverified_context()
+    class NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, response_headers, new_url):
+            return None
+
+    handlers = [NoRedirect()]
+    if context is not None:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    opener = urllib.request.build_opener(*handlers)
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            data = response.read(max_bytes + 1)
+    except urllib.error.HTTPError as error:
+        status = error.code
+        error.close()
+        raise RuntimeError(f"HTTP {status}") from error
+    if len(data) > max_bytes:
+        raise ValueError("provider response too large")
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as error:
+        raise ValueError("provider response was not valid JSON") from error
+
+
+# ----- Cursor -----
+
+
+def _cursor_app_auth_paths():
+    return _path_candidates(
+        "TOKEI_CURSOR_AUTH_DB",
+        os.path.join(HOME, "Library", "Application Support", "Cursor",
+                     "User", "globalStorage", "state.vscdb"),
+        os.path.join(HOME, ".config", "Cursor", "User",
+                     "globalStorage", "state.vscdb"))
+
+
+def _cursor_app_session(path=None, now_epoch=None):
+    db_path = path or _first_existing_file(_cursor_app_auth_paths())
+    if not db_path or not os.path.isfile(db_path):
+        return None
+    try:
+        connection = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True, timeout=0.25)
+        row = connection.execute(
+            "SELECT value FROM ItemTable WHERE key = ? LIMIT 1",
+            ("cursorAuth/accessToken",)).fetchone()
+        connection.close()
+    except sqlite3.Error:
+        return None
+    if not row:
+        return None
+    token = row[0]
+    if isinstance(token, bytes):
+        token = token.decode("utf-8", "ignore")
+    if not isinstance(token, str) or not token.strip():
+        return None
+    token = token.strip()
+    claims = _decode_jwt_claims(token) or {}
+    subject = claims.get("sub") if isinstance(claims.get("sub"), str) else None
+    user_id = subject.rsplit("|", 1)[-1] if subject else None
+    if not user_id or not re.fullmatch(r"[A-Za-z0-9._-]+", user_id):
+        return None
+    expiration = _provider_number(claims.get("exp"))
+    now_epoch = int(now_epoch if now_epoch is not None else datetime.now().timestamp())
+    if expiration is None or expiration <= now_epoch + 60:
+        return None
+    email = claims.get("email") if isinstance(claims.get("email"), str) else None
+    return {
+        "cookie": f"WorkosCursorSessionToken={user_id}%3A%3A{token}",
+        "account": email.strip() if email and email.strip() else subject,
+        "subject": subject,
+        "user_id": user_id,
+        "marker": _provider_credential_marker("cursor", subject, token),
+    }
+
+
+def _cursor_cookie_session(cookie):
+    if not isinstance(cookie, str) or not cookie.strip():
+        return None
+    from urllib.parse import unquote
+
+    account = subject = user_id = None
+    for component in cookie.split(";"):
+        name, separator, value = component.strip().partition("=")
+        if separator and name == "WorkosCursorSessionToken":
+            token = unquote(value).split("::")[-1]
+            claims = _decode_jwt_claims(token) or {}
+            subject = claims.get("sub") if isinstance(claims.get("sub"), str) else None
+            user_id = subject.rsplit("|", 1)[-1] if subject else None
+            email = claims.get("email")
+            account = email.strip() if isinstance(email, str) and email.strip() else subject
+            break
+    return {
+        "cookie": cookie.strip(),
+        "account": account,
+        "subject": subject,
+        "user_id": user_id,
+        "marker": _provider_credential_marker("cursor", cookie.strip()),
+    }
+
+
+def _cursor_session():
+    manual = _provider_config_string("TOKEI_CURSOR_COOKIE", "cursor_cookie")
+    return _cursor_cookie_session(manual) if manual else _cursor_app_session()
+
+
+def _cursor_plan_name(raw):
+    names = {
+        "enterprise": "Enterprise", "express": "Start", "free": "Free",
+        "free_trial": "Pro Trial", "hobby": "Hobby", "pro": "Pro",
+        "pro_student": "Pro", "pro_plus": "Pro+", "team": "Team",
+        "ultra": "Ultra",
+    }
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    value = names.get(raw.strip().lower(), raw.strip())
+    return f"Cursor {value}"
+
+
+def _normalize_cursor_quota(summary, *, request_usage=None, sand_usage=None, user_info=None,
+                            identity=None, updated=None):
+    if not isinstance(summary, dict):
+        return {}
+    individual = summary.get("individualUsage") if isinstance(
+        summary.get("individualUsage"), dict) else {}
+    team = summary.get("teamUsage") if isinstance(summary.get("teamUsage"), dict) else {}
+    plan = individual.get("plan") if isinstance(individual.get("plan"), dict) else {}
+    overall = individual.get("overall") if isinstance(individual.get("overall"), dict) else {}
+    pooled = team.get("pooled") if isinstance(team.get("pooled"), dict) else {}
+
+    plan_used = _provider_number(plan.get("used")) or 0.0
+    plan_limit = _provider_number(plan.get("limit")) or 0.0
+    auto_pct = _provider_percent(plan.get("autoPercentUsed"))
+    api_pct = _provider_percent(plan.get("apiPercentUsed"))
+    total_pct = _provider_percent(plan.get("totalPercentUsed"))
+    if total_pct is None and auto_pct is not None and api_pct is not None:
+        total_pct = _provider_percent((auto_pct + api_pct) / 2)
+    if total_pct is None:
+        total_pct = api_pct if api_pct is not None else auto_pct
+    if total_pct is None and plan_limit > 0:
+        total_pct = _provider_percent(plan_used / plan_limit * 100)
+    if total_pct is None:
+        for block in (overall, pooled):
+            used = _provider_number(block.get("used"))
+            limit = _provider_number(block.get("limit"))
+            if used is not None and limit is not None and limit > 0:
+                total_pct = _provider_percent(used / limit * 100)
+                plan_used, plan_limit = used, limit
+                break
+    total_pct = total_pct if total_pct is not None else 0.0
+
+    request_block = request_usage.get("gpt-4") if isinstance(request_usage, dict) \
+        and isinstance(request_usage.get("gpt-4"), dict) else {}
+    requests_used = _provider_number(
+        request_block.get("numRequestsTotal") if request_block.get("numRequestsTotal") is not None
+        else request_block.get("numRequests"))
+    requests_limit = _provider_number(request_block.get("maxRequestUsage"))
+    legacy = requests_used is not None and requests_limit is not None and requests_limit > 0
+
+    cycle_start = _provider_epoch(summary.get("billingCycleStart"))
+    cycle_end = _provider_epoch(summary.get("billingCycleEnd"))
+    window_minutes = int((cycle_end - cycle_start) / 60) \
+        if cycle_start and cycle_end and cycle_end > cycle_start else None
+    if legacy:
+        total_pct = _provider_percent(requests_used / requests_limit * 100)
+        primary_detail = f"{int(requests_used)} / {int(requests_limit)} requests"
+    else:
+        primary_detail = (
+            f"{_provider_money(plan_used / 100)} / {_provider_money(plan_limit / 100)}"
+            if plan_limit > 0 else None)
+
+    windows = [_provider_window(
+        "cursor-total", "总额度", total_pct, cycle_end, window_minutes, primary_detail)]
+    if not legacy:
+        if auto_pct is not None:
+            windows.append(_provider_window(
+                "cursor-auto", "Cursor 模型", auto_pct, cycle_end, window_minutes))
+        if api_pct is not None:
+            windows.append(_provider_window(
+                "cursor-api", "第三方模型", api_pct, cycle_end, window_minutes))
+        if isinstance(sand_usage, dict) and sand_usage.get("hasNonZeroIncludedLimit") is True:
+            sand_pct = _provider_percent(sand_usage.get("usagePercent"))
+            if sand_pct is not None:
+                sand_start = _provider_epoch(sand_usage.get("currentPeriodStart"))
+                sand_reset = _provider_epoch(sand_usage.get("nextResetTimestampUtc"))
+                sand_minutes = int((sand_reset - sand_start) / 60) \
+                    if sand_start and sand_reset and sand_reset > sand_start else None
+                windows.append(_provider_window(
+                    "cursor-grok-bot", "Grok Bot", sand_pct, sand_reset, sand_minutes))
+
+    details = []
+    if plan_limit > 0 and not legacy:
+        details.append({
+            "label": "套餐用量",
+            "value": f"{_provider_money(plan_used / 100)} / {_provider_money(plan_limit / 100)}",
+        })
+    on_demand = individual.get("onDemand") if isinstance(individual.get("onDemand"), dict) else {}
+    team_on_demand = team.get("onDemand") if isinstance(team.get("onDemand"), dict) else {}
+    on_used = _provider_number(on_demand.get("used")) or 0.0
+    on_limit = _provider_number(on_demand.get("limit"))
+    if not on_limit or on_limit <= 0:
+        team_limit = _provider_number(team_on_demand.get("limit"))
+        if team_limit and team_limit > 0:
+            on_used = _provider_number(team_on_demand.get("used")) or 0.0
+            on_limit = team_limit
+    if on_limit and on_limit > 0:
+        details.append({
+            "label": "按量预算",
+            "value": f"{_provider_money(on_used / 100)} / {_provider_money(on_limit / 100)}",
+        })
+
+    user_info = user_info if isinstance(user_info, dict) else {}
+    identity = identity if isinstance(identity, dict) else {}
+    account = user_info.get("email") or identity.get("account")
+    return {
+        "available": True,
+        "plan": _cursor_plan_name(summary.get("membershipType")),
+        "account": account,
+        "windows": windows,
+        "details": details,
+        "source": "cursor-api",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def fetch_cursor_quota(session=None):
+    session = session or _cursor_session()
+    if not session:
+        return {}
+    marker = session["marker"]
+    cached = _cached_provider_quota("cursor", marker, _PROVIDER_QUOTA_TTL)
+    if cached:
+        return cached
+    headers = {"Cookie": session["cookie"]}
+    base = "https://cursor.com"
+    try:
+        summary = _provider_json_request(base + "/api/usage-summary", headers=headers)
+        user_info = None
+        try:
+            user_info = _provider_json_request(base + "/api/auth/me", headers=headers)
+        except Exception:
+            pass
+        request_usage = None
+        user_id = (user_info or {}).get("sub") if isinstance(user_info, dict) else None
+        user_id = user_id or session.get("subject") or session.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            user_id = user_id.rsplit("|", 1)[-1]
+            from urllib.parse import quote
+            try:
+                request_usage = _provider_json_request(
+                    base + "/api/usage?user=" + quote(user_id, safe=""), headers=headers)
+            except Exception:
+                pass
+        sand_usage = None
+        try:
+            sand_usage = _provider_json_request(
+                base + "/api/dashboard/get-sand-usage-status",
+                headers={**headers, "Origin": base}, method="POST", body={})
+        except Exception:
+            pass
+        quota = _normalize_cursor_quota(
+            summary, request_usage=request_usage, sand_usage=sand_usage,
+            user_info=user_info, identity=session)
+        _save_provider_quota_cache("cursor", marker, quota)
+        return quota
+    except Exception:
+        fallback = _cached_provider_quota(
+            "cursor", marker, _PROVIDER_QUOTA_FALLBACK_TTL, stale=True)
+        if fallback:
+            return fallback
+        raise
+
+
+def scan_cursor_quota():
+    return fetch_cursor_quota() if _provider_quota_enabled("cursor") else {}
+
+
+# ----- Zed -----
+
+
+def _zed_connection_settings(settings):
+    settings = settings if isinstance(settings, dict) else {}
+    credentials = settings.get("credentials_url")
+    server = settings.get("server_url")
+    credentials = credentials.strip() if isinstance(credentials, str) and credentials.strip() else None
+    server = server.strip().rstrip("/") if isinstance(server, str) and server.strip() else "https://zed.dev"
+    service = credentials or server
+    trusted = server in {"https://zed.dev", "https://staging.zed.dev"}
+    if not trusted and credentials and credentials.rstrip("/") != server:
+        return None
+    from urllib.parse import urlsplit
+    parsed = urlsplit(server)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password \
+            or parsed.query or parsed.fragment:
+        return None
+    api_base = "https://cloud.zed.dev" if trusted else server
+    return {"service": service, "api_url": api_base + "/client/users/me"}
+
+
+def _load_zed_connection_settings(path=None):
+    path = path or _provider_config_string(
+        "TOKEI_ZED_SETTINGS", "zed_settings_path") \
+        or os.path.join(HOME, ".config", "zed", "settings.json")
+    settings = _load_json(path, {}) if os.path.isfile(path) else {}
+    return _zed_connection_settings(settings)
+
+
+def _zed_plan_name(raw):
+    names = {
+        "zed_free": "Zed Free", "zed_pro": "Zed Pro",
+        "zed_pro_trial": "Zed Pro Trial", "zed_student": "Zed Student",
+        "zed_business": "Zed Business",
+    }
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    value = raw.strip()
+    return names.get(value.lower(), " ".join(word.capitalize() for word in value.split("_")))
+
+
+def _normalize_zed_quota(payload, updated=None):
+    if not isinstance(payload, dict):
+        return {}
+    user = payload.get("user") if isinstance(payload.get("user"), dict) else {}
+    plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+    usage = plan.get("usage") if isinstance(plan.get("usage"), dict) else {}
+    predictions = usage.get("edit_predictions") if isinstance(
+        usage.get("edit_predictions"), dict) else {}
+    used = max(0.0, _provider_number(predictions.get("used")) or 0.0)
+    limit_value = predictions.get("limit")
+    if isinstance(limit_value, dict):
+        limit_value = limit_value.get("limited")
+    windows = []
+    if isinstance(limit_value, str) and limit_value.lower() == "unlimited":
+        windows.append(_provider_window(
+            "zed-predictions", "Edit Predictions", 0, detail="Unlimited"))
+    else:
+        limit = _provider_number(limit_value)
+        if limit is not None and limit > 0:
+            clamped = min(used, limit)
+            windows.append(_provider_window(
+                "zed-predictions", "Edit Predictions", clamped / limit * 100,
+                detail=f"{int(clamped)} / {int(limit)} predictions"))
+
+    period = plan.get("subscription_period") if isinstance(
+        plan.get("subscription_period"), dict) else {}
+    start = _provider_epoch(period.get("started_at"))
+    end = _provider_epoch(period.get("ended_at"))
+    now = int(updated if updated is not None else datetime.now().timestamp())
+    if start and end and end > start:
+        windows.append(_provider_window(
+            "zed-cycle", "订阅周期", (now - start) / (end - start) * 100, end,
+            int((end - start) / 60)))
+    if plan.get("has_overdue_invoices") is True:
+        windows.append(_provider_window(
+            "zed-overdue", "账单", None, detail="Overdue invoices", usage_known=False))
+
+    details = []
+    if isinstance(user.get("name"), str) and user["name"].strip():
+        details.append({"label": "账号", "value": user["name"].strip()})
+    return {
+        "available": bool(windows or plan),
+        "plan": _zed_plan_name(plan.get("plan_v3")),
+        "account": user.get("github_login"),
+        "windows": windows,
+        "details": details,
+        "source": "zed-cloud",
+        "updated": now,
+        "stale": False,
+    }
+
+
+def fetch_zed_quota():
+    user_id = _provider_config_string("TOKEI_ZED_USER_ID", "zed_user_id")
+    token = _provider_config_string("TOKEI_ZED_ACCESS_TOKEN", "zed_access_token")
+    connection = _load_zed_connection_settings()
+    if not user_id or not token or not connection:
+        return {}
+    marker = _provider_credential_marker(
+        "zed", user_id, token, connection["service"], connection["api_url"])
+    cached = _cached_provider_quota("zed", marker, _PROVIDER_QUOTA_TTL)
+    if cached:
+        return cached
+    try:
+        payload = _provider_json_request(
+            connection["api_url"], headers={"Authorization": f"{user_id} {token}"})
+        quota = _normalize_zed_quota(payload)
+        _save_provider_quota_cache("zed", marker, quota)
+        return quota
+    except Exception:
+        fallback = _cached_provider_quota(
+            "zed", marker, _PROVIDER_QUOTA_FALLBACK_TTL, stale=True)
+        if fallback:
+            return fallback
+        raise
+
+
+def scan_zed_quota():
+    return fetch_zed_quota() if _provider_quota_enabled("zed") else {}
+
+
+# ----- sub2api -----
+
+
+def _local_timezone_name():
+    configured = os.environ.get("TZ")
+    if configured and configured.strip():
+        return configured.strip()
+    try:
+        target = os.path.realpath("/etc/localtime")
+        marker = "/zoneinfo/"
+        if marker in target:
+            return target.split(marker, 1)[1]
+    except OSError:
+        pass
+    zone = datetime.now().astimezone().tzinfo
+    return getattr(zone, "key", None) or datetime.now().astimezone().tzname() or "UTC"
+
+
+def _sub2api_usage_url(base_url, timezone_name=None):
+    if not isinstance(base_url, str) or not base_url.strip():
+        return None
+    import ipaddress
+    from urllib.parse import urlencode, urlsplit, urlunsplit
+
+    parsed = urlsplit(base_url.strip())
+    if parsed.scheme not in {"https", "http"} or not parsed.hostname \
+            or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return None
+    if parsed.scheme == "http":
+        try:
+            loopback = ipaddress.ip_address(parsed.hostname).is_loopback
+        except ValueError:
+            loopback = parsed.hostname.lower() == "localhost"
+        if not loopback:
+            return None
+    path = parsed.path.rstrip("/")
+    if not re.search(r"/v1(?:/usage)?$", path):
+        path += "/v1"
+    if not path.endswith("/usage"):
+        path += "/usage"
+    query = urlencode({"days": 30, "timezone": timezone_name or _local_timezone_name()})
+    return urlunsplit((parsed.scheme, parsed.netloc, path, query, ""))
+
+
+def _normalize_sub2api_quota(data, updated=None):
+    if not isinstance(data, dict) or data.get("isValid") is False:
+        return {}
+    unit = data.get("unit") if isinstance(data.get("unit"), str) else "USD"
+    windows = []
+
+    def add_window(window_id, title, used, limit, minutes=None, reset=None, value_unit=None):
+        used_number = _provider_number(used)
+        limit_number = _provider_number(limit)
+        if used_number is None or limit_number is None or limit_number <= 0:
+            return
+        detail = f"{_provider_money(used_number, value_unit or unit)} / " \
+            f"{_provider_money(limit_number, value_unit or unit)}"
+        windows.append(_provider_window(
+            window_id, title, used_number / limit_number * 100, reset, minutes, detail))
+
+    subscription = data.get("subscription") if isinstance(data.get("subscription"), dict) else None
+    quota = data.get("quota") if isinstance(data.get("quota"), dict) else None
+    if subscription:
+        add_window("sub2api-daily", "日额度", subscription.get("daily_usage_usd"),
+                   subscription.get("daily_limit_usd"), 1440)
+        add_window("sub2api-weekly", "周额度", subscription.get("weekly_usage_usd"),
+                   subscription.get("weekly_limit_usd"), 10080)
+        add_window("sub2api-monthly", "月额度", subscription.get("monthly_usage_usd"),
+                   subscription.get("monthly_limit_usd"), 43200)
+    elif quota:
+        quota_unit = quota.get("unit") if isinstance(quota.get("unit"), str) else unit
+        add_window("sub2api-quota", "额度", quota.get("used"), quota.get("limit"),
+                   value_unit=quota_unit)
+
+    rate_minutes = {"5h": 300, "1d": 1440, "7d": 10080}
+    rate_titles = {"5h": "5h 额度", "1d": "日限额", "7d": "周限额"}
+    rates = data.get("rate_limits") if isinstance(data.get("rate_limits"), list) else []
+    for index, rate in enumerate(rates):
+        if not isinstance(rate, dict):
+            continue
+        name = str(rate.get("window") or f"rate-{index}")
+        add_window(
+            f"sub2api-{name}", rate_titles.get(name.lower(), f"{name} 限额"),
+            rate.get("used"), rate.get("limit"), rate_minutes.get(name.lower()),
+            rate.get("reset_at"))
+
+    details = []
+    balance = _provider_number(data.get("balance"))
+    if balance is not None:
+        details.append({"label": "余额", "value": _provider_money(balance, unit)})
+    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+    for key, label in (("today", "今日"), ("total", "累计")):
+        row = usage.get(key) if isinstance(usage.get(key), dict) else None
+        if not row:
+            continue
+        requests = 0 if row.get("requests") is None else _provider_integer(row.get("requests"))
+        tokens = 0 if row.get("total_tokens") is None else _provider_integer(row.get("total_tokens"))
+        if requests is None or tokens is None:
+            raise ValueError(f"sub2api {key} usage counts must be integers")
+        cost = _provider_number(row.get("actual_cost")) or 0
+        details.append({"label": f"{label}请求", "value": f"{requests:,}"})
+        token_row = {"label": f"{label} Token", "value": f"{tokens:,}"}
+        if cost:
+            token_row["secondary"] = _provider_money(cost)
+        details.append(token_row)
+
+    expiration = (subscription or {}).get("expires_at") or data.get("expires_at")
+    expiration_epoch = _provider_epoch(expiration)
+    if expiration_epoch:
+        details.append({"label": "套餐到期", "value": str(expiration_epoch)})
+    plan_name = data.get("planName") if isinstance(data.get("planName"), str) else None
+    return {
+        "available": bool(windows or details or plan_name),
+        "plan": plan_name,
+        "account": None,
+        "windows": windows,
+        "details": details,
+        "source": "sub2api",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def fetch_sub2api_quota():
+    api_key = _provider_config_string("SUB2API_API_KEY", "sub2api_api_key")
+    base_url = _provider_config_string("SUB2API_BASE_URL", "sub2api_base_url")
+    usage_url = _sub2api_usage_url(base_url) if base_url else None
+    if not api_key or not usage_url:
+        return {}
+    marker = _provider_credential_marker("sub2api", api_key, usage_url)
+    cached = _cached_provider_quota("sub2api", marker, _PROVIDER_QUOTA_TTL)
+    if cached:
+        return cached
+    try:
+        payload = _provider_json_request(
+            usage_url, headers={"Authorization": f"Bearer {api_key}"}, timeout=15)
+        if isinstance(payload, dict) and payload.get("isValid") is False:
+            raise PermissionError("sub2api rejected the API key")
+        quota = _normalize_sub2api_quota(payload)
+        _save_provider_quota_cache("sub2api", marker, quota)
+        return quota
+    except Exception:
+        fallback = _cached_provider_quota(
+            "sub2api", marker, _PROVIDER_QUOTA_FALLBACK_TTL, stale=True)
+        if fallback:
+            return fallback
+        raise
+
+
+def scan_sub2api_quota():
+    return fetch_sub2api_quota() if _provider_quota_enabled("sub2api") else {}
+
+
+# ----- z.ai / GLM -----
+
+
+def _zai_quota_url(url, scope="personal"):
+    if scope != "team":
+        return url
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+    parsed = urlsplit(url)
+    query = [(key, value) for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+             if key != "type"]
+    query.append(("type", "2"))
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment))
+
+
+def _zai_limit(raw):
+    if not isinstance(raw, dict) or raw.get("type") not in {
+            "TOKENS_LIMIT", "CREDIT_LIMIT", "TIME_LIMIT"}:
+        return None
+    unit = _provider_integer(raw.get("unit"))
+    number = _provider_integer(raw.get("number"))
+    percent_raw = _provider_integer(raw.get("percentage"))
+    percent = _provider_percent(percent_raw)
+    if unit is None or number is None or percent is None:
+        return None
+    usage = _provider_number(raw.get("usage"))
+    current = _provider_number(raw.get("currentValue"))
+    remaining = _provider_number(raw.get("remaining"))
+    if usage is not None and usage > 0:
+        used = None
+        if remaining is not None:
+            used = max(usage - remaining, current if current is not None else usage - remaining)
+        elif current is not None:
+            used = current
+        if used is not None:
+            percent = _provider_percent(max(0, min(usage, used)) / usage * 100)
+    multipliers = {1: 1440, 3: 60, 5: 1, 6: 10080}
+    unit_int, number_int = unit, number
+    minutes = number_int * multipliers[unit_int] \
+        if number_int > 0 and unit_int in multipliers else None
+    if raw.get("type") == "TIME_LIMIT" and unit_int == 5 and number_int == 1:
+        minutes = 30 * 24 * 60
+    details = raw.get("usageDetails") if isinstance(raw.get("usageDetails"), list) else []
+    return {
+        "raw": raw, "usage": usage, "current": current, "remaining": remaining,
+        "percent": percent, "window_minutes": minutes,
+        "reset": _provider_epoch(raw.get("nextResetTime")), "details": details,
+    }
+
+
+def _zai_limit_detail(limit):
+    parts = []
+    if limit.get("usage") is not None:
+        parts.append(f"{limit['usage']:g} limit")
+    if limit.get("remaining") is not None:
+        parts.append(f"{limit['remaining']:g} remaining")
+    return " · ".join(parts) or None
+
+
+def _normalize_zai_quota(payload, *, region="global", balance=None, updated=None):
+    if not isinstance(payload, dict) or payload.get("success") is not True \
+            or _provider_number(payload.get("code")) != 200:
+        return {}
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    limits = [_zai_limit(item) for item in data.get("limits", [])]
+    limits = [item for item in limits if item]
+    token_limits = sorted(
+        [item for item in limits if item["raw"].get("type") in {"TOKENS_LIMIT", "CREDIT_LIMIT"}],
+        key=lambda item: item.get("window_minutes") or sys.maxsize)
+    time_limits = [item for item in limits if item["raw"].get("type") == "TIME_LIMIT"]
+    token_limit = token_limits[-1] if token_limits else None
+    session_limit = token_limits[0] if len(token_limits) >= 2 else None
+    time_limit = time_limits[-1] if time_limits else None
+    primary = session_limit or token_limit or time_limit
+    windows = []
+    if primary:
+        windows.append(_provider_window(
+            "zai-primary", "会话额度" if session_limit else "额度", primary["percent"],
+            primary.get("reset"), primary.get("window_minutes"), _zai_limit_detail(primary)))
+    if session_limit and token_limit:
+        windows.append(_provider_window(
+            "zai-secondary", "周期额度", token_limit["percent"], token_limit.get("reset"),
+            token_limit.get("window_minutes"), _zai_limit_detail(token_limit)))
+    if time_limit and (token_limit or session_limit):
+        windows.append(_provider_window(
+            "zai-mcp", "MCP", time_limit["percent"], time_limit.get("reset"),
+            time_limit.get("window_minutes"), _zai_limit_detail(time_limit)))
+
+    details = []
+    if token_limit:
+        label = "Credit quota" if token_limit["raw"].get("type") == "CREDIT_LIMIT" else "Token quota"
+        details.append({"label": label, "value": f"{token_limit['percent']:g}% used",
+                        "secondary": _zai_limit_detail(token_limit)})
+    if session_limit:
+        label = "Session credit quota" if session_limit["raw"].get("type") == "CREDIT_LIMIT" \
+            else "Session token quota"
+        details.append({"label": label, "value": f"{session_limit['percent']:g}% used",
+                        "secondary": _zai_limit_detail(session_limit)})
+    if time_limit:
+        details.append({"label": "MCP quota", "value": f"{time_limit['percent']:g}% used",
+                        "secondary": _zai_limit_detail(time_limit)})
+        for item in time_limit.get("details", [])[:20]:
+            if isinstance(item, dict) and isinstance(item.get("modelCode"), str):
+                value = _provider_number(item.get("usage"))
+                if value is not None and value >= 0:
+                    details.append({"label": item["modelCode"], "value": f"{int(value):,}"})
+
+    if region == "bigmodel-cn" and isinstance(balance, dict) and balance.get("success") is True:
+        balance_data = balance.get("data") if isinstance(balance.get("data"), dict) else {}
+        available = _provider_number(balance_data.get("availableBalance"))
+        current = _provider_number(balance_data.get("balance"))
+        amount = available if available is not None else current
+        if amount is not None:
+            secondary = []
+            for key, label in (("rechargeAmount", "recharged"),
+                               ("giveAmount", "granted"),
+                               ("totalSpendAmount", "spent")):
+                value = _provider_number(balance_data.get(key))
+                if value is not None and (key != "giveAmount" or value > 0):
+                    secondary.append(f"{label} ¥{value:.2f}")
+            row = {"label": "Account balance", "value": f"¥{amount:.2f}"}
+            if secondary:
+                row["secondary"] = " · ".join(secondary)
+            details.append(row)
+
+    plan_name = next((data.get(key).strip() for key in (
+        "planName", "plan", "plan_type", "packageName", "level")
+        if isinstance(data.get(key), str) and data.get(key).strip()), None)
+    return {
+        "available": bool(windows or details or plan_name),
+        "plan": plan_name,
+        "account": None,
+        "windows": windows,
+        "details": details,
+        "source": "zai-api",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def fetch_zai_quota():
+    region = (_provider_config_string("Z_AI_REGION", "zai_region") or "global").lower()
+    if region not in {"global", "bigmodel-cn"}:
+        return {}
+    scope = (_provider_config_string("Z_AI_USAGE_SCOPE", "zai_usage_scope") or "personal").lower()
+    if scope not in {"personal", "team"}:
+        return {}
+    api_key = _provider_config_string("Z_AI_API_KEY", "zai_api_key")
+    if not api_key and region == "bigmodel-cn":
+        api_key = _provider_config_string("BIGMODEL_API_KEY", "zai_api_key")
+    organization = _provider_config_string("Z_AI_ORGANIZATION", "zai_organization")
+    project = _provider_config_string("Z_AI_PROJECT", "zai_project")
+    if not api_key or (scope == "team" and (not organization or not project)):
+        return {}
+    base = "https://open.bigmodel.cn" if region == "bigmodel-cn" else "https://api.z.ai"
+    quota_url = _zai_quota_url(base + "/api/monitor/usage/quota/limit", scope)
+    marker = _provider_credential_marker(
+        "zai", api_key, region, scope, organization, project, quota_url)
+    cached = _cached_provider_quota("zai", marker, _PROVIDER_QUOTA_TTL)
+    if cached:
+        return cached
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if scope == "team":
+        headers["Bigmodel-Organization"] = organization
+        headers["Bigmodel-Project"] = project
+    try:
+        payload = _provider_json_request(quota_url, headers=headers)
+        balance = None
+        if region == "bigmodel-cn":
+            try:
+                balance = _provider_json_request(
+                    "https://www.bigmodel.cn/api/biz/account/query-customer-account-report",
+                    headers=headers, timeout=5)
+            except Exception:
+                pass
+        quota = _normalize_zai_quota(payload, region=region, balance=balance)
+        _save_provider_quota_cache("zai", marker, quota)
+        return quota
+    except Exception:
+        fallback = _cached_provider_quota(
+            "zai", marker, _PROVIDER_QUOTA_FALLBACK_TTL, stale=True)
+        if fallback:
+            return fallback
+        raise
+
+
+def scan_zai_quota():
+    return fetch_zai_quota() if _provider_quota_enabled("zai") else {}
+
+
+# ----- Antigravity loopback quota -----
+
+
+def _antigravity_extract_flag(command, flag):
+    match = re.search(re.escape(flag) + r"(?:=|\s+)([^\s]+)", command, re.I)
+    return match.group(1) if match else None
+
+
+def _antigravity_process_kind(command):
+    lower = command.lower()
+    language_server = re.search(
+        r"(^|[/\\])language(?:_|-)server(?:[_-][a-z0-9]+)*(?:\.exe)?(?:\s|$)", lower)
+    app_match = ("--app_data_dir" in lower and "antigravity" in lower) or any(
+        marker in lower for marker in ("antigravity.app/", "/gemini.app/",
+                                       "antigravity ide.app/"))
+    if language_server and app_match:
+        return "ide"
+    if re.search(r"(^|[/\\])(antigravity-cli|antigravity_cli|agy)(?:\s|[/\\]|$)", lower):
+        return "cli"
+    return None
+
+
+def _antigravity_process_infos(output):
+    results = []
+    for line in str(output or "").splitlines():
+        match = re.match(r"^\s*(\d+)\s+(.+)$", line)
+        if not match:
+            continue
+        pid, command = int(match.group(1)), match.group(2)
+        kind = _antigravity_process_kind(command)
+        if not kind:
+            continue
+        csrf = _antigravity_extract_flag(command, "--csrf_token")
+        if kind != "cli" and not csrf:
+            continue
+        extension_port = _provider_integer(
+            _antigravity_extract_flag(command, "--extension_server_port"))
+        if extension_port is not None and not 0 < extension_port <= 65535:
+            extension_port = None
+        results.append({
+            "pid": pid, "kind": kind, "csrf_token": csrf or "",
+            "extension_port": extension_port,
+            "extension_csrf_token": _antigravity_extract_flag(
+                command, "--extension_server_csrf_token"),
+        })
+    return results
+
+
+def _antigravity_running_processes():
+    try:
+        result = subprocess.run(
+            ["/bin/ps", "-ax", "-o", "pid=,command="],
+            capture_output=True, text=True, timeout=2, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return _antigravity_process_infos(result.stdout)
+
+
+def _antigravity_listening_ports(pid):
+    lsof = next((path for path in ("/usr/sbin/lsof", "/usr/bin/lsof")
+                 if os.path.isfile(path) and os.access(path, os.X_OK)), None)
+    if not lsof:
+        return []
+    try:
+        result = subprocess.run(
+            [lsof, "-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", str(pid)],
+            capture_output=True, text=True, timeout=2, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return sorted({int(value) for value in re.findall(r":(\d+)\s+\(LISTEN\)", result.stdout)})
+
+
+def _antigravity_endpoints(process):
+    endpoints = []
+    extension_port = process.get("extension_port")
+    if extension_port:
+        for token in (process.get("extension_csrf_token"), process.get("csrf_token")):
+            if token is not None:
+                endpoints.append(("http", extension_port, token, True))
+    for port in _antigravity_listening_ports(process["pid"]):
+        endpoints.append(("https", port, process.get("csrf_token") or "",
+                          process.get("kind") != "cli"))
+    unique = []
+    for endpoint in endpoints:
+        if endpoint not in unique:
+            unique.append(endpoint)
+    return unique
+
+
+def _antigravity_request(endpoint, path, body):
+    scheme, port, csrf, requires_csrf = endpoint
+    headers = {"Connect-Protocol-Version": "1"}
+    if requires_csrf:
+        headers["X-Codeium-Csrf-Token"] = csrf
+    return _provider_json_request(
+        f"{scheme}://127.0.0.1:{port}{path}", headers=headers, method="POST", body=body,
+        timeout=2, allow_insecure_loopback_tls=True)
+
+
+def _antigravity_remaining(value):
+    if not isinstance(value, dict):
+        return None
+    raw = value.get("remainingFraction")
+    if raw is None and value.get("case") == "remainingFraction":
+        raw = value.get("value")
+    number = _provider_number(raw)
+    return max(0.0, min(1.0, number)) if number is not None else None
+
+
+def _normalize_antigravity_quota_summary(payload, updated=None):
+    root = payload.get("response") if isinstance(payload, dict) \
+        and isinstance(payload.get("response"), dict) else payload
+    groups = root.get("groups") if isinstance(root, dict) and isinstance(root.get("groups"), list) else []
+    windows = []
+    for group_index, group in enumerate(groups):
+        if not isinstance(group, dict):
+            continue
+        display = str(group.get("displayName") or f"Group {group_index + 1}")
+        lower_group = display.lower()
+        if "gemini" in lower_group:
+            family, family_order = "Gemini", 0
+        elif "claude" in lower_group or "gpt" in lower_group or "third" in lower_group:
+            family, family_order = "Claude/GPT", 1
+        else:
+            family, family_order = display, 2 + group_index
+        for bucket_index, bucket in enumerate(group.get("buckets") or []):
+            if not isinstance(bucket, dict) or bucket.get("disabled") is True:
+                continue
+            bucket_id = str(bucket.get("bucketId") or f"bucket-{bucket_index}")
+            cadence = (bucket_id + " " + str(bucket.get("displayName") or "")).lower()
+            normalized = cadence.replace("_", "-")
+            if any(marker in normalized for marker in ("5h", "5-hour", "five hour",
+                                                        "five-hour", "session")):
+                cadence_title, minutes, cadence_order = "5h", 300, 0
+            elif any(marker in normalized for marker in ("weekly", "week", "7d")):
+                cadence_title, minutes, cadence_order = "周", 10080, 1
+            else:
+                cadence_title, minutes, cadence_order = str(
+                    bucket.get("displayName") or bucket_id), None, 2
+            remaining = _antigravity_remaining(bucket.get("remaining"))
+            windows.append((family_order, cadence_order, bucket_index, _provider_window(
+                "antigravity-" + bucket_id, f"{family} {cadence_title}",
+                (1 - remaining) * 100 if remaining is not None else None,
+                bucket.get("resetTime"), minutes, bucket.get("description"),
+                usage_known=remaining is not None)))
+    windows.sort(key=lambda item: item[:3])
+    rows = [item[3] for item in windows]
+    return {
+        "available": bool(rows),
+        "plan": None, "account": None, "windows": rows, "details": [],
+        "source": "antigravity-local",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def _normalize_antigravity_user_status(payload, updated=None):
+    if not isinstance(payload, dict):
+        return {}
+    status = payload.get("userStatus") if isinstance(payload.get("userStatus"), dict) else payload
+    config_data = status.get("cascadeModelConfigData") if isinstance(
+        status.get("cascadeModelConfigData"), dict) else {}
+    configs = config_data.get("clientModelConfigs")
+    if not isinstance(configs, list):
+        configs = payload.get("clientModelConfigs") if isinstance(
+            payload.get("clientModelConfigs"), list) else []
+    windows = []
+    for index, config in enumerate(configs):
+        if not isinstance(config, dict) or not isinstance(config.get("quotaInfo"), dict):
+            continue
+        info = config["quotaInfo"]
+        remaining = _provider_number(info.get("remainingFraction"))
+        if remaining is None:
+            continue
+        label = config.get("label")
+        model = config.get("modelOrAlias") if isinstance(config.get("modelOrAlias"), dict) else {}
+        model_id = model.get("model") or f"model-{index}"
+        windows.append(_provider_window(
+            "antigravity-model-" + str(model_id), str(label or model_id),
+            (1 - max(0, min(1, remaining))) * 100, info.get("resetTime")))
+    windows.sort(key=lambda row: (-(row.get("used_pct") or 0), row["title"]))
+    tier = status.get("userTier") if isinstance(status.get("userTier"), dict) else {}
+    plan_status = status.get("planStatus") if isinstance(status.get("planStatus"), dict) else {}
+    plan_info = plan_status.get("planInfo") if isinstance(plan_status.get("planInfo"), dict) else {}
+    plan = next((value.strip() for value in (
+        tier.get("name"), plan_info.get("planName"), plan_info.get("planDisplayName"),
+        plan_info.get("displayName"), plan_info.get("productName"),
+        plan_info.get("planShortName")) if isinstance(value, str) and value.strip()), None)
+    account = status.get("email") if isinstance(status.get("email"), str) else None
+    return {
+        "available": bool(windows), "plan": plan, "account": account,
+        "windows": windows[:12], "details": [], "source": "antigravity-local",
+        "updated": int(updated if updated is not None else datetime.now().timestamp()),
+        "stale": False,
+    }
+
+
+def fetch_antigravity_quota():
+    paths = {
+        "summary": "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+        "status": "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        "models": "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
+    }
+    metadata = {"metadata": {
+        "ideName": "antigravity", "extensionName": "antigravity",
+        "ideVersion": "unknown", "locale": "en",
+    }}
+    last_error = None
+    for process in _antigravity_running_processes():
+        endpoints = _antigravity_endpoints(process)
+        if not endpoints:
+            continue
+        marker = _provider_credential_marker(
+            "antigravity", process.get("pid"), process.get("csrf_token"), endpoints)
+        cached = _cached_provider_quota("antigravity", marker, _PROVIDER_QUOTA_TTL)
+        if cached:
+            return cached
+        for endpoint in endpoints:
+            try:
+                summary_payload = _antigravity_request(
+                    endpoint, paths["summary"], {"forceRefresh": True})
+                quota = _normalize_antigravity_quota_summary(summary_payload)
+                if quota.get("available"):
+                    try:
+                        identity_payload = _antigravity_request(endpoint, paths["status"], metadata)
+                        identity = _normalize_antigravity_user_status(identity_payload)
+                        quota["plan"] = identity.get("plan")
+                        quota["account"] = identity.get("account")
+                    except Exception:
+                        pass
+                    _save_provider_quota_cache("antigravity", marker, quota)
+                    return quota
+            except Exception as error:
+                last_error = error
+        for path, body in ((paths["status"], metadata), (paths["models"], metadata)):
+            for endpoint in endpoints:
+                try:
+                    quota = _normalize_antigravity_user_status(
+                        _antigravity_request(endpoint, path, body))
+                    if quota.get("available"):
+                        _save_provider_quota_cache("antigravity", marker, quota)
+                        return quota
+                except Exception as error:
+                    last_error = error
+        fallback = _cached_provider_quota(
+            "antigravity", marker, _PROVIDER_QUOTA_FALLBACK_TTL, stale=True)
+        if fallback:
+            return fallback
+    if last_error:
+        raise last_error
+    return {}
+
+
+def scan_antigravity_quota():
+    return fetch_antigravity_quota() if _provider_quota_enabled("antigravity") else {}
+
+
+def scan_provider_quotas(errors=None):
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    all_scans = {
+        "cursor": scan_cursor_quota,
+        "zed": scan_zed_quota,
+        "sub2api": scan_sub2api_quota,
+        "zai": scan_zai_quota,
+        "antigravity": scan_antigravity_quota,
+    }
+    result = {name: {} for name in all_scans}
+    scans = {name: scan for name, scan in all_scans.items()
+             if _provider_quota_enabled(name)}
+    if not scans:
+        return result
+    with ThreadPoolExecutor(max_workers=len(scans), thread_name_prefix="tokei-quota") as pool:
+        futures = {pool.submit(scan): name for name, scan in scans.items()}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                value = future.result()
+                result[name] = value if isinstance(value, dict) else {}
+            except Exception as error:
+                if errors is not None:
+                    errors[f"{name}_quota"] = f"{type(error).__name__}: {error}"
+    return result
+
+
 def scan_grok(bounds, cache=None):
     ledger_touch("grok")
     cache = cache if cache is not None else {"v": _SCAN_CACHE_VERSION}
@@ -7398,6 +8591,7 @@ def compute():
     grok_quota = _safe_scan("grok_quota", scan_grok_quota, lambda: {}, errors) or {}
     qwenwork_quota = _safe_scan(
         "qwenwork_quota", scan_qwenwork_quota, lambda: {}, errors) or {}
+    provider_quotas = scan_provider_quotas(errors)
     codex_reset_cards = _safe_scan(
         "codex_reset_cards", fetch_codex_reset_cards, lambda: {}, errors) or {}
 
@@ -7423,6 +8617,11 @@ def compute():
         "gemini": {
             "ranges": granges,
         },
+        "antigravity": provider_quotas["antigravity"],
+        "cursor": provider_quotas["cursor"],
+        "zed": provider_quotas["zed"],
+        "sub2api": provider_quotas["sub2api"],
+        "zai": provider_quotas["zai"],
         "grok": {
             "ranges": kranges,
             "model": gk["model"],
@@ -7614,6 +8813,15 @@ def _write_sync_snapshot(sync_dir, device_id, payload):
         return False
 
 
+def _sync_safe_usage_payload(payload):
+    snapshot = dict(payload)
+    # Provider quotas are account-local, are not merged by SyncManager, and may
+    # contain an email/login label. Keep them in the local cache only.
+    for key in ("cursor", "zed", "sub2api", "zai", "antigravity"):
+        snapshot.pop(key, None)
+    return snapshot
+
+
 def _write_configured_sync_snapshot(d):
     cfg = _load_tokei_config()
     if not cfg:
@@ -7626,16 +8834,17 @@ def _write_configured_sync_snapshot(d):
         return False
 
     import time
-    d["_device"] = device_id
-    d["_ts"] = int(time.time())
-    d["_range_bounds"] = range_boundaries()
+    snapshot = _sync_safe_usage_payload(d)
+    snapshot["_device"] = device_id
+    snapshot["_ts"] = int(time.time())
+    snapshot["_range_bounds"] = range_boundaries()
     cache = _load_scan_cache()
-    d["_dashboard"] = {
+    snapshot["_dashboard"] = {
         "daily": build_daily_costs("all", refresh=False, _cache=cache).get("daily", []),
         "wrapped": {p: build_wrapped(p, refresh=False, _cache=cache)
                     for p in ["all", "1d", "7d", "30d", "365d"]},
     }
-    return _write_sync_snapshot(sync_dir, device_id, d)
+    return _write_sync_snapshot(sync_dir, device_id, snapshot)
 
 
 def main_json():

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -491,6 +491,8 @@ _CODEX_PARSER_VERSION = 3
 _CODEX_SCAN_CHECKPOINT_INTERVAL = 5.0
 _GEMINI_DAYS_CACHE_KEY = "_gemini_dashboard_days"
 _GROK_DAYS_CACHE_KEY = "_grok_dashboard_days"
+_CURSOR_PROVIDER_DAYS_CACHE_KEY = "_cursor_provider_days"
+_ZAI_PROVIDER_DAYS_CACHE_KEY = "_zai_provider_days"
 
 
 def _remove_codex_event_cache_dir():
@@ -2922,7 +2924,7 @@ _ANTIGRAVITY_MAX_TOKENS = 100_000_000  # 单次生成的 token 上界,超了就�
 _ANTIGRAVITY_MIN_TS = 1_577_836_800    # 2020-01-01,更早的时间戳必然是错位
 
 
-def _antigravity_gen_step(record):
+def _antigravity_gen_step(record, fallback_ts=None):
     """解一条生成记录 → (model, input, output, cached, thoughts, ts_sec);解不出返回 None。"""
     model = "unknown"
     inp = out = cached = thoughts = 0
@@ -2953,12 +2955,35 @@ def _antigravity_gen_step(record):
                             ts_sec = stval
     # 账本是逐日高水位,虚高数字一旦写进去就永久留着且无法纠正 —— 宁可丢也不能记错。
     if not isinstance(ts_sec, int) or not (_ANTIGRAVITY_MIN_TS <= ts_sec <= 1 << 34):
+        ts_sec = fallback_ts
+    if not isinstance(ts_sec, int) or not (_ANTIGRAVITY_MIN_TS <= ts_sec <= 1 << 34):
         return None
     if max(inp, out, cached, thoughts) > _ANTIGRAVITY_MAX_TOKENS:
         return None
     if not model or len(model) > 120 or not model.isprintable():
         model = "unknown"
     return model, inp, out, cached, thoughts, ts_sec
+
+
+def _decode_packed_varints(data):
+    values = []
+    offset = 0
+    while offset < len(data):
+        value, offset = _decode_proto_varint(data, offset)
+        values.append(value)
+    return values
+
+
+def _antigravity_step_timestamp(metadata):
+    """Current Antigravity stores a google.protobuf.Timestamp in steps.metadata field 1."""
+    for field_num, wire_type, value in _parse_proto_fields(metadata or b""):
+        if field_num != 1 or wire_type != 2:
+            continue
+        for sub_num, sub_wire, sub_value in _parse_proto_fields(value):
+            if sub_num == 1 and sub_wire == 0 \
+                    and _ANTIGRAVITY_MIN_TS <= sub_value <= 1 << 34:
+                return sub_value
+    return None
 
 
 def _load_antigravity_db(path):
@@ -2969,21 +2994,42 @@ def _load_antigravity_db(path):
     try:
         conn = sqlite3.connect(_sqlite_ro_uri(path), uri=True, timeout=1)
         rows = conn.execute("SELECT idx, data FROM gen_metadata ORDER BY idx ASC").fetchall()
+        try:
+            step_rows = conn.execute("SELECT idx, metadata FROM steps").fetchall()
+        except sqlite3.Error:
+            step_rows = []
     except Exception:
         return None
     finally:
         if conn is not None:
             conn.close()
 
+    step_timestamps = {
+        int(step_idx): timestamp
+        for step_idx, metadata in step_rows
+        if (timestamp := _antigravity_step_timestamp(metadata)) is not None
+    }
+
     for idx, data in rows:
         if not data:
             continue
-        for fn, wt, val in _parse_proto_fields(data):
+        fields = _parse_proto_fields(data)
+        referenced_steps = []
+        for fn, wt, val in fields:
+            if fn == 2 and wt == 2:
+                try:
+                    referenced_steps.extend(_decode_packed_varints(val))
+                except ValueError:
+                    pass
+        fallback_ts = next((step_timestamps.get(step_idx) for step_idx in referenced_steps
+                            if step_timestamps.get(step_idx) is not None), None)
+        record_index = 0
+        for fn, wt, val in fields:
             if fn != 1 or wt != 2:
                 continue
             # 逐条兜异常:一行坏数据不该把同一个库里的好数据一起带走。
             try:
-                step = _antigravity_gen_step(val)
+                step = _antigravity_gen_step(val, fallback_ts=fallback_ts)
             except Exception:
                 step = None
             if step is None:
@@ -2993,7 +3039,7 @@ def _load_antigravity_db(path):
             if iso_ts > max_ts:
                 max_ts = iso_ts
             events.append({
-                "id": f"{os.path.basename(path)}:{idx}",
+                "id": f"{os.path.basename(path)}:{idx}:{record_index}",
                 "timestamp": iso_ts,
                 "model": model,
                 "tokens": {
@@ -3003,6 +3049,7 @@ def _load_antigravity_db(path):
                     "thoughts": thoughts,
                 },
             })
+            record_index += 1
 
     if not events:
         return None
@@ -4226,6 +4273,86 @@ def _provider_money(value, unit="USD"):
     return f"{number:,.2f} {unit}"
 
 
+_PROVIDER_USAGE_FIELDS = ("in", "out", "cr", "cw", "reason")
+
+
+def _provider_usage_int(value):
+    number = _provider_integer(value)
+    return number if number is not None and number >= 0 else 0
+
+
+def _provider_usage_from_days(days, *, bounds=None, limited_coverage=None):
+    bounds = bounds or range_bounds()
+    buckets = {
+        key: {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+              "reason": 0, "cost": 0.0, "requests": 0, "models": {}}
+        for key in RANGE_KEYS
+    }
+    clean_days = days if isinstance(days, dict) else {}
+    for day_key, day in clean_days.items():
+        if not isinstance(day, dict):
+            continue
+        try:
+            local_day = date.fromisoformat(str(day_key)[:10])
+        except ValueError:
+            continue
+        components = {field: _provider_usage_int(day.get(field))
+                      for field in _PROVIDER_USAGE_FIELDS}
+        total = _provider_usage_int(day.get("tokens")) or sum(components.values())
+        cost = _provider_number(day.get("cost")) or 0.0
+        cost = cost if cost >= 0 else 0.0
+        requests = _provider_usage_int(day.get("requests"))
+        models = day.get("models") if isinstance(day.get("models"), dict) else {}
+        for range_key in classify_date(local_day, bounds):
+            bucket = buckets[range_key]
+            bucket["tokens"] += total
+            bucket["cost"] += cost
+            bucket["requests"] += requests
+            for field, value in components.items():
+                bucket[field] += value
+            for raw_name, raw_usage in models.items():
+                if not isinstance(raw_usage, dict):
+                    continue
+                model = bucket["models"].setdefault(
+                    str(raw_name or "unknown"),
+                    {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+                     "reason": 0, "cost": 0.0})
+                model_components = {field: _provider_usage_int(raw_usage.get(field))
+                                    for field in _PROVIDER_USAGE_FIELDS}
+                model["tokens"] += _provider_usage_int(raw_usage.get("tokens")) \
+                    or sum(model_components.values())
+                for field, value in model_components.items():
+                    model[field] += value
+                model_cost = _provider_number(raw_usage.get("cost")) or 0.0
+                if model_cost >= 0:
+                    model["cost"] += model_cost
+
+    ranges = {}
+    for range_key, bucket in buckets.items():
+        formatted = {}
+        for raw_name, usage in bucket.pop("models").items():
+            display_name = nice_model(raw_name)
+            model = formatted.setdefault(
+                display_name,
+                {"name": display_name, "tokens": 0, "in": 0, "out": 0,
+                 "cr": 0, "cw": 0, "reason": 0, "cost": 0.0})
+            for field in ("tokens",) + _PROVIDER_USAGE_FIELDS:
+                model[field] += usage[field]
+            model["cost"] += usage["cost"]
+        row = dict(bucket)
+        input_total = row["in"] + row["cr"] + row["cw"]
+        row["hit"] = row["cr"] / input_total * 100 if input_total else 0.0
+        row["cost"] = round(row["cost"], 6)
+        row["models"] = sorted(
+            formatted.values(), key=lambda item: (-item["tokens"], item["name"]))
+        for model in row["models"]:
+            model["cost"] = round(model["cost"], 6)
+        if limited_coverage and range_key in {"year", "all"}:
+            row["coverage"] = limited_coverage
+        ranges[range_key] = row
+    return {"ranges": ranges, "days": clean_days}
+
+
 def _provider_window(window_id, title, used_pct=None, reset=None, window_minutes=None,
                      detail=None, usage_known=True):
     return {
@@ -4335,6 +4462,9 @@ def _provider_json_request(url, *, headers=None, method="GET", body=None, timeou
 
 # ----- Cursor -----
 
+_CURSOR_USAGE_PAGE_SIZE = 1000
+_CURSOR_USAGE_MAX_PAGES = 200
+
 
 def _cursor_app_auth_paths():
     return _path_candidates(
@@ -4425,6 +4555,120 @@ def _cursor_plan_name(raw):
         return None
     value = names.get(raw.strip().lower(), raw.strip())
     return f"Cursor {value}"
+
+
+def _normalize_cursor_usage_events(events, *, bounds=None):
+    days = {}
+    for event in events if isinstance(events, list) else []:
+        if not isinstance(event, dict):
+            continue
+        timestamp = _provider_number(event.get("timestamp"))
+        usage = event.get("tokenUsage")
+        if timestamp is None or timestamp <= 0 or not isinstance(usage, dict):
+            continue
+        timestamp_seconds = timestamp / 1000.0 if timestamp > 100_000_000_000 else timestamp
+        try:
+            dt = datetime.fromtimestamp(timestamp_seconds, timezone.utc).astimezone()
+        except (OverflowError, OSError, ValueError):
+            continue
+        components = {
+            "in": _provider_usage_int(usage.get("inputTokens")),
+            "out": _provider_usage_int(usage.get("outputTokens")),
+            "cr": _provider_usage_int(usage.get("cacheReadTokens")),
+            "cw": _provider_usage_int(usage.get("cacheWriteTokens")),
+            "reason": 0,
+        }
+        total = sum(components.values())
+        if total <= 0:
+            continue
+        cents = _provider_number(usage.get("totalCents"))
+        cost = cents / 100.0 if cents is not None and cents >= 0 else 0.0
+        model_name = event.get("model")
+        model_name = model_name.strip() if isinstance(model_name, str) and model_name.strip() else "unknown"
+        day_key = dt.date().isoformat()
+        day = days.setdefault(
+            day_key,
+            {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+             "reason": 0, "cost": 0.0, "requests": 0, "models": {},
+             "hours": [0] * 24})
+        day["tokens"] += total
+        day["cost"] += cost
+        day["requests"] += 1
+        day["hours"][dt.hour] += total
+        for field, value in components.items():
+            day[field] += value
+        model = day["models"].setdefault(
+            model_name,
+            {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+             "reason": 0, "cost": 0.0})
+        model["tokens"] += total
+        model["cost"] += cost
+        for field, value in components.items():
+            model[field] += value
+    return _provider_usage_from_days(days, bounds=bounds)
+
+
+def _cursor_boundary_overlap(previous, current):
+    limit = min(len(previous), len(current))
+    for count in range(limit, 0, -1):
+        if previous[-count:] == current[:count]:
+            return count
+    return 0
+
+
+def _fetch_cursor_usage_events(session, now=None):
+    now = now or datetime.now().astimezone()
+    start = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    headers = {"Cookie": session["cookie"], "Origin": "https://cursor.com"}
+    pages = []
+    expected_total = None
+    completed = False
+    for page_number in range(1, _CURSOR_USAGE_MAX_PAGES + 1):
+        payload = _provider_json_request(
+            "https://cursor.com/api/dashboard/get-filtered-usage-events",
+            headers=headers, method="POST", timeout=15, max_bytes=16 * 1024 * 1024,
+            body={
+                "page": page_number,
+                "pageSize": _CURSOR_USAGE_PAGE_SIZE,
+                "startDate": str(int(start.timestamp() * 1000)),
+                "endDate": str(int(now.timestamp() * 1000)),
+            })
+        reported = _provider_integer(payload.get("totalUsageEventsCount")) \
+            if isinstance(payload, dict) else None
+        if reported is not None and reported < 0:
+            raise ValueError("cursor usage event count cannot be negative")
+        if reported is not None:
+            if expected_total is not None and reported != expected_total:
+                raise ValueError("cursor usage pagination count changed")
+            expected_total = reported
+        events = payload.get("usageEventsDisplay") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            raise ValueError("cursor usage events response was invalid")
+        if not events:
+            completed = True
+            break
+        pages.append(events)
+        if len(events) < _CURSOR_USAGE_PAGE_SIZE:
+            completed = True
+            break
+    if not completed:
+        raise ValueError("cursor usage pagination did not complete")
+    raw = [event for page in pages for event in page]
+    if expected_total is None:
+        return raw
+    if len(raw) < expected_total:
+        raise ValueError("cursor usage pagination was incomplete")
+    if len(raw) == expected_total:
+        return raw
+    removals = len(raw) - expected_total
+    reconciled = list(pages[0]) if pages else []
+    for index in range(1, len(pages)):
+        overlap = min(_cursor_boundary_overlap(pages[index - 1], pages[index]), removals)
+        reconciled.extend(pages[index][overlap:])
+        removals -= overlap
+    if removals or len(reconciled) != expected_total:
+        raise ValueError("cursor usage pagination was inconsistent")
+    return reconciled
 
 
 def _normalize_cursor_quota(summary, *, request_usage=None, sand_usage=None, user_info=None,
@@ -4538,7 +4782,7 @@ def fetch_cursor_quota(session=None):
     session = session or _cursor_session()
     if not session:
         return {}
-    marker = session["marker"]
+    marker = _provider_credential_marker("cursor-usage-v1", session["marker"])
     cached = _cached_provider_quota("cursor", marker, _PROVIDER_QUOTA_TTL)
     if cached:
         return cached
@@ -4569,9 +4813,15 @@ def fetch_cursor_quota(session=None):
                 headers={**headers, "Origin": base}, method="POST", body={})
         except Exception:
             pass
+        usage = _provider_usage_from_days({})
+        try:
+            usage = _normalize_cursor_usage_events(_fetch_cursor_usage_events(session))
+        except Exception:
+            pass
         quota = _normalize_cursor_quota(
             summary, request_usage=request_usage, sand_usage=sand_usage,
             user_info=user_info, identity=session)
+        quota["usage"] = usage
         _save_provider_quota_cache("cursor", marker, quota)
         return quota
     except Exception:
@@ -4876,6 +5126,63 @@ def _zai_quota_url(url, scope="personal"):
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment))
 
 
+def _zai_model_usage_url(base, scope="personal", now=None):
+    from urllib.parse import urlencode
+    now = now or datetime.now().astimezone()
+    start = (now - timedelta(days=30)).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = now.replace(minute=59, second=59, microsecond=0)
+    query = {
+        "startTime": start.strftime("%Y-%m-%d %H:%M:%S"),
+        "endTime": end.strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    if scope == "team":
+        query["type"] = "3"
+    return base.rstrip("/") + "/api/monitor/usage/model-usage?" + urlencode(query)
+
+
+def _normalize_zai_model_usage(payload, *, bounds=None):
+    if not isinstance(payload, dict) or payload.get("success") is not True \
+            or _provider_number(payload.get("code")) != 200:
+        return _provider_usage_from_days({}, bounds=bounds, limited_coverage="近30天")
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    labels = data.get("x_time") if isinstance(data.get("x_time"), list) else []
+    models = data.get("modelDataList") \
+        if isinstance(data.get("modelDataList"), list) else []
+    parsed_labels = []
+    for label in labels:
+        if not isinstance(label, str):
+            parsed_labels.append(None)
+            continue
+        try:
+            parsed_labels.append(datetime.fromisoformat(label).astimezone())
+        except ValueError:
+            parsed_labels.append(None)
+    days = {}
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        name = model.get("modelName")
+        name = name.strip() if isinstance(name, str) and name.strip() else "unknown"
+        values = model.get("tokensUsage") if isinstance(model.get("tokensUsage"), list) else []
+        for index, dt in enumerate(parsed_labels):
+            if dt is None or index >= len(values):
+                continue
+            tokens = _provider_usage_int(values[index])
+            if tokens <= 0:
+                continue
+            day_key = dt.date().isoformat()
+            day = days.setdefault(
+                day_key,
+                {"tokens": 0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+                 "reason": 0, "cost": 0.0, "requests": 0, "models": {},
+                 "hours": [0] * 24})
+            day["tokens"] += tokens
+            day["hours"][dt.hour] += tokens
+            usage = day["models"].setdefault(name, {"tokens": 0})
+            usage["tokens"] += tokens
+    return _provider_usage_from_days(days, bounds=bounds, limited_coverage="近30天")
+
+
 def _zai_limit(raw):
     if not isinstance(raw, dict) or raw.get("type") not in {
             "TOKENS_LIMIT", "CREDIT_LIMIT", "TIME_LIMIT"}:
@@ -5018,7 +5325,7 @@ def fetch_zai_quota():
     base = "https://open.bigmodel.cn" if region == "bigmodel-cn" else "https://api.z.ai"
     quota_url = _zai_quota_url(base + "/api/monitor/usage/quota/limit", scope)
     marker = _provider_credential_marker(
-        "zai", api_key, region, scope, organization, project, quota_url)
+        "zai-usage-v1", api_key, region, scope, organization, project, quota_url)
     cached = _cached_provider_quota("zai", marker, _PROVIDER_QUOTA_TTL)
     if cached:
         return cached
@@ -5037,6 +5344,15 @@ def fetch_zai_quota():
             except Exception:
                 pass
         quota = _normalize_zai_quota(payload, region=region, balance=balance)
+        usage = _provider_usage_from_days({}, limited_coverage="近30天")
+        try:
+            model_payload = _provider_json_request(
+                _zai_model_usage_url(base, scope), headers=headers, timeout=15,
+                max_bytes=8 * 1024 * 1024)
+            usage = _normalize_zai_model_usage(model_payload)
+        except Exception:
+            pass
+        quota["usage"] = usage
         _save_provider_quota_cache("zai", marker, quota)
         return quota
     except Exception:
@@ -8592,6 +8908,13 @@ def compute():
     qwenwork_quota = _safe_scan(
         "qwenwork_quota", scan_qwenwork_quota, lambda: {}, errors) or {}
     provider_quotas = scan_provider_quotas(errors)
+    _cache_dashboard_days(
+        cache, _CURSOR_PROVIDER_DAYS_CACHE_KEY,
+        ((provider_quotas.get("cursor") or {}).get("usage") or {}).get("days", {}))
+    _cache_dashboard_days(
+        cache, _ZAI_PROVIDER_DAYS_CACHE_KEY,
+        ((provider_quotas.get("zai") or {}).get("usage") or {}).get("days", {}))
+    _save_scan_cache(cache)
     codex_reset_cards = _safe_scan(
         "codex_reset_cards", fetch_codex_reset_cards, lambda: {}, errors) or {}
 
@@ -9657,7 +9980,45 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
                            "reason": v.get("reason", 0), "tokens": total_tok, "tool": v["tool"],
                            "cost_per_k": cost_per_k, "out_ratio": out_ratio})
 
-    return {"daily": daily, "models": model_list}
+    provider_models = {}
+    for cache_key, tool, suffix in (
+            (_CURSOR_PROVIDER_DAYS_CACHE_KEY, "cursor", "Cursor 账号"),
+            (_ZAI_PROVIDER_DAYS_CACHE_KEY, "zai", "z.ai 账号")):
+        for day_key, day in (cache.get(cache_key) or {}).items():
+            if cutoff and day_key < cutoff or not isinstance(day, dict):
+                continue
+            for raw_name, raw_usage in (day.get("models") or {}).items():
+                if not isinstance(raw_usage, dict):
+                    continue
+                name = f"{nice_model(raw_name)} ({suffix})"
+                model = provider_models.setdefault(
+                    name,
+                    {"name": name, "cost": 0.0, "in": 0, "out": 0,
+                     "cr": 0, "cw": 0, "reason": 0, "tokens": 0,
+                     "tool": tool})
+                components = {field: _provider_usage_int(raw_usage.get(field))
+                              for field in _PROVIDER_USAGE_FIELDS}
+                model["tokens"] += _provider_usage_int(raw_usage.get("tokens")) \
+                    or sum(components.values())
+                for field, value in components.items():
+                    model[field] += value
+                cost = _provider_number(raw_usage.get("cost")) or 0.0
+                if cost >= 0:
+                    model["cost"] += cost
+
+    provider_model_list = []
+    for model in sorted(
+            provider_models.values(), key=lambda item: (-item["tokens"], item["name"])):
+        out_k = model["out"] / 1000 if model["out"] else 0
+        provider_model_list.append({
+            **model,
+            "cost": round(model["cost"], 2),
+            "cost_per_k": round(model["cost"] / out_k, 3) if out_k > 0 else 0,
+            "out_ratio": round(model["out"] / model["tokens"] * 100, 1)
+            if model["tokens"] > 0 else 0,
+        })
+
+    return {"daily": daily, "models": model_list, "provider_models": provider_model_list}
 
 
 def daily_costs():


### PR DESCRIPTION
## 背景

参考 CodexBar 的 Provider 额度逻辑，为 Tokei 补充 Cursor、Zed、Sub2API、z.ai / GLM 与 Gemini / Antigravity 的额度和账号级 Token 用量展示。

## 主要改动

- Cursor
  - 复用 Cursor.app 本地登录态，无需在 Tokei 保存 Cookie
  - 展示套餐额度、Cursor/第三方模型额度及 Grok Bot
  - 聚合账号级 Token、请求、输入/输出/缓存、API 价与按模型统计
- Zed
  - 复用 Zed Keychain 登录凭据，无弹窗查询 Edit Predictions 等额度
- Sub2API
  - 支持自定义 Base URL 与 Group API Key
  - 展示余额、今日/累计请求与 Token、成本
- z.ai / GLM
  - 支持 Global 与 BigModel CN
  - 展示会话、周期、MCP 额度
  - 聚合近 30 天 Token 和按模型统计
- Gemini / Antigravity
  - 兼容新版 Antigravity SQLite/protobuf 时间戳结构
  - 显示本地 Token 与按模型统计；所选范围无数据时明确展示最近非空范围
  - 从已运行的本机 loopback 服务读取额度，不会自动启动客户端
- Dashboard
  - 新增账号 Provider 额度与模型区
  - 账号级统计不并入本地工具总量，避免重复计算
- 凭据与打包
  - Provider API Key 存入 macOS Keychain
  - 避免旧 ad-hoc Keychain ACL 阻塞，打包时优先使用稳定代码签名
  - 兼容 Command Line Tools 缺失 SwiftUIMacros 的环境
  - 加固新版 hdiutil/diskutil 的 DMG 打包流程
- 隐私
  - 远程 Provider 查询均由卡片开关显式启用
  - Provider 账号标签、额度和密钥不写入多设备同步快照

## 验证

- `pytest -q tests --ignore=tests/test_usage_summary.py`：232 passed
- `bash package.sh`：通过
- `codesign --verify --deep --strict Tokei.app`：通过
- `hdiutil verify Tokei.dmg`：通过
- `Tokei --shot`：通过
