### PR TITLE
fix(openclaw): 兼容 2026.8.1+ 的会话 SQLite

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -15,7 +15,7 @@ Tokei 主要读取本地 AI 工具日志，统计 token 用量与成本。额度
 | QoderWork | `~/Library/Application Support/QoderWork/data/agents.db` | SQLite, `messages.metadata` |
 | Qoder CLI | `~/.qoder/projects/**/*.jsonl` | JSONL, 会话/调用/工具/时长；文本量估算 Token |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` | SQLite, `session_model_usage*` 用量表，回退 `sessions` 表 |
-| OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` | JSONL 用量 + SQLite 任务 |
+| OpenClaw | `~/.openclaw/state/openclaw.sqlite` + agent SQLite；兼容旧 JSONL | SQLite/JSONL 用量 + SQLite 任务 |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` | JSONL, `message.usage` |
 | Prime Agent | `~/.prime/agent/sessions/*.jsonl` + `session-artifacts/**/**/*.jsonl` | JSONL, assistant `message.usage` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` | JSONL, `message.usage` / `providerData.usage` |
@@ -151,9 +151,16 @@ Dashboard、Wrapped 或项目 token 总量。
 
 **Qoder** — `inputTokens` / `outputTokens` 目前全为 0,仅 `durationMs` 和 `contextUsageRatio` 有值。
 
-**OpenClaw** — Session JSONL 的 `message.usage` 提供输入、输出、缓存读写和成本；
-`state/openclaw.sqlite` 的 `task_runs` 提供任务状态。旧版
-`~/.openclaw/tasks/runs.sqlite` 仍作为兼容回退。
+**OpenClaw** — 新版从 `state/openclaw.sqlite` 的 `agent_databases` 动态发现每个 agent 的
+`openclaw-agent.sqlite`，只读取 `transcript_events.event_json` 中 role 为 assistant 且带
+`message.usage` 的原始事件。输入、输出、缓存读写、推理和成本分别使用
+`input` / `output` / `cacheRead` / `cacheWrite` / `reasoningTokens` / `cost`；日期以事件时间为准，
+模型依次使用 `message.responseModel`、`message.model` 和 `session_windows.model`。未知模型保留原名且
+不套用其他模型价格。
+
+旧版 `agents/*/sessions/*.jsonl` 继续兼容；SQLite 与 JSONL 中相同 session 只保留记录更完整的一份，
+`.trajectory.jsonl`、全文索引和非 usage 事件不参与统计。`state/openclaw.sqlite` 的 `task_runs`
+仍提供任务状态，旧版 `~/.openclaw/tasks/runs.sqlite` 作为任务统计回退。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | z.ai / GLM | macOS Keychain API Key + Global/BigModel CN quota / model-usage API（卡片默认关闭） |
 | Grok Build | `${GROK_HOME:-~/.grok}/logs/unified.jsonl`（含真实 token + billing 额度）+ `sessions/*/*/{summary,signals}.json`；可选实时账单接口（设置里默认关闭） |
 | Hermes | `~/.hermes/state.db` + `~/.hermes/profiles/*/state.db` |
-| OpenClaw | `~/.openclaw/agents/*/sessions/*.jsonl` + `~/.openclaw/state/openclaw.sqlite` |
+| OpenClaw | `~/.openclaw/state/openclaw.sqlite` 动态发现 agent SQLite；兼容旧版 `agents/*/sessions/*.jsonl` |
 | Pi Coding Agent CLI | `~/.pi/agent/sessions/<project>/*.jsonl` |
 | Prime Agent | `~/.prime/agent/sessions/*.jsonl` + `session-artifacts/**/**/*.jsonl` |
 | WorkBuddy | `~/.workbuddy/projects/<project>/*.jsonl` |

--- a/Tokei/Sources/Tokei/DashboardView.swift
+++ b/Tokei/Sources/Tokei/DashboardView.swift
@@ -1274,7 +1274,7 @@ struct DashboardView: View {
     }
 
     static func openClawTotal(_ r: OpenClawRange) -> Int {
-        r.in + r.out + r.cr + r.cw
+        r.in + r.out + r.cr + r.cw + r.reason
     }
 
     static func tokenModelTotal(_ m: TokenModelStat) -> Int {

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -603,6 +603,7 @@ struct OpenClawRange: Codable {
     var out: Int
     var cr: Int
     var cw: Int
+    var reason: Int = 0
     var cost: Double
     var sessions: Int
     var models: [TokenModelStat]
@@ -617,6 +618,7 @@ struct OpenClawRange: Codable {
         out = try c.decodeIfPresent(Int.self, forKey: .out) ?? 0
         cr = try c.decodeIfPresent(Int.self, forKey: .cr) ?? 0
         cw = try c.decodeIfPresent(Int.self, forKey: .cw) ?? 0
+        reason = try c.decodeIfPresent(Int.self, forKey: .reason) ?? 0
         cost = try c.decodeIfPresent(Double.self, forKey: .cost) ?? 0
         sessions = try c.decodeIfPresent(Int.self, forKey: .sessions) ?? 0
         models = try c.decodeIfPresent([TokenModelStat].self, forKey: .models) ?? []

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -412,7 +412,7 @@ struct PanelView: View {
             ToolCardItem(id: "mimocode", name: "MiMoCode", visible: showMimoCode, active: mr.sessions > 0,
                          tint: Theme.mimocode, content: AnyView(tokenUsageBlock(title: "MiMoCode", mr, tint: Theme.mimocode, modelsOpen: $mimocodeModelsOpen, toolID: "mimocode"))),
             ToolCardItem(id: "openclaw", name: "OpenClaw", visible: showOpenClaw,
-                         active: lr.tasks > 0 || lr.in + lr.out + lr.cr + lr.cw > 0,
+                         active: lr.tasks > 0 || lr.in + lr.out + lr.cr + lr.cw + lr.reason > 0,
                          tint: Theme.openclaw, content: AnyView(openclawBlock(lr, modelsOpen: $openClawModelsOpen))),
             ToolCardItem(id: "pi", name: "Pi", visible: showPi, active: pr.sessions > 0,
                          tint: Theme.pi, content: AnyView(tokenUsageBlock(title: "Pi Coding Agent", pr, tint: Theme.pi, modelsOpen: $piModelsOpen, toolID: "pi"))),
@@ -1449,8 +1449,8 @@ struct PanelView: View {
     func openclawBlock(_ r: OpenClawRange, modelsOpen: Binding<Bool>) -> some View {
         VStack(alignment: .leading, spacing: 11) {
             cardHead("OpenClaw", tint: Theme.openclaw, sessions: r.sessions, toolID: "openclaw")
-            if r.in + r.out + r.cr + r.cw > 0 {
-                CostHeadline(value: Fmt.human(r.in + r.out + r.cr + r.cw), caption: "\(sel.label) 总量", tint: Theme.openclaw)
+            if r.in + r.out + r.cr + r.cw + r.reason > 0 {
+                CostHeadline(value: Fmt.human(r.in + r.out + r.cr + r.cw + r.reason), caption: "\(sel.label) 总量", tint: Theme.openclaw)
                 metricGrid([.init("dollarsign.circle", "≈成本", String(format: "$%.2f", r.cost))],
                     hit: r.hit, extra: {
                     var items: [Metric] = [
@@ -1458,6 +1458,7 @@ struct PanelView: View {
                         .init("arrow.up", "输出", Fmt.human(r.out)),
                         .init("bolt.fill", "缓存读", Fmt.human(r.cr)),
                     ]
+                    if r.reason > 0 { items.append(.init("brain", "推理", Fmt.human(r.reason))) }
                     if r.tasks > 0 { items.append(.init("checklist", "任务", "\(r.tasks)")) }
                     return items
                 }(), tint: Theme.openclaw)

--- a/Tokei/Sources/Tokei/SyncManager.swift
+++ b/Tokei/Sources/Tokei/SyncManager.swift
@@ -611,7 +611,7 @@ final class SyncManager {
             var d = dst.get(pair.dst), s = src.get(pair.src)
             d.tasks += s.tasks; d.completed += s.completed; d.failed += s.failed
             d.in += s.in; d.out += s.out; d.cr += s.cr; d.cw += s.cw
-            d.cost += s.cost; d.sessions += s.sessions
+            d.reason += s.reason; d.cost += s.cost; d.sessions += s.sessions
             d.hit = hitRate(cached: d.cr, input: d.in, cacheWrite: d.cw)
             mergeTokenModels(&d.models, s.models)
             dst.set(pair.dst, d)

--- a/Tokei/Sources/Tokei/UsageSummaryBuilder.swift
+++ b/Tokei/Sources/Tokei/UsageSummaryBuilder.swift
@@ -252,10 +252,11 @@ enum UsageSummaryBuilder {
             let r = usage.openclaw.ranges.get(range)
             let line = Line(
                 id: "openclaw", name: "OpenClaw", cost: r.cost,
-                tokens: r.in + r.out + r.cr + r.cw, sessions: r.sessions,
+                tokens: r.in + r.out + r.cr + r.cw + r.reason, sessions: r.sessions,
                 calls: r.tasks > 0 ? r.tasks : nil,
                 input: r.in, output: r.out, cacheRead: r.cr, cacheWrite: r.cw,
-                reason: nil, hit: r.hit > 0 ? r.hit : nil, extra: nil
+                reason: r.reason > 0 ? r.reason : nil,
+                hit: r.hit > 0 ? r.hit : nil, extra: nil
             )
             if !line.isEmpty { lines.append(line) }
         }

--- a/tests/swift/UsageSummaryBuilderCheck.swift
+++ b/tests/swift/UsageSummaryBuilderCheck.swift
@@ -87,6 +87,14 @@ struct UsageSummaryBuilderCheck {
         try expect(lines[1].cost == 0.50, "codex cost value")
         try expect(lines[1].tokens == 350, "codex tokens 100+50+200")
 
+        try expect(usage.openclaw.ranges.today.reason == 0,
+                   "older OpenClaw snapshots without reason must decode as zero")
+        let openClawYear = UsageSummaryBuilder.toolLines(
+            usage: usage, range: .year, visibility: allVisible
+        ).first(where: { $0.id == "openclaw" })
+        try expect(openClawYear?.tokens == 7 && openClawYear?.reason == 7,
+                   "OpenClaw reasoning tokens must survive decode and summary aggregation")
+
         let totals = UsageSummaryBuilder.totals(for: lines)
         try expect(totals.tools == 2, "totals tools")
         try expect(abs(totals.cost - 1.75) < 0.001, "totals cost")
@@ -211,7 +219,7 @@ struct UsageSummaryBuilderCheck {
           "week": {"tasks": 0, "completed": 0, "failed": 0, "models": []},
           "last_week": {"tasks": 0, "completed": 0, "failed": 0, "models": []},
           "month": {"tasks": 0, "completed": 0, "failed": 0, "models": []},
-          "year": {"tasks": 0, "completed": 0, "failed": 0, "models": []}
+          "year": {"tasks": 0, "completed": 0, "failed": 0, "reason": 7, "models": []}
         }
       },
       "opencode": {

--- a/tests/test_dashboard_cache.py
+++ b/tests/test_dashboard_cache.py
@@ -109,10 +109,10 @@ class DashboardCacheTests(unittest.TestCase):
                   "cost": 2.5, "hours": [0, 15] + [0] * 22,
                   "models": {"gpt-5.5": {
                       "in": 1, "out": 2, "cr": 3, "cw": 4, "reason": 5, "cost": 2.5}}}
-        openclaw = {"in": 6, "out": 7, "cr": 8, "cw": 9, "reason": 0,
-                    "cost": 3.5, "hours": [0, 0, 30] + [0] * 21,
+        openclaw = {"in": 6, "out": 7, "cr": 8, "cw": 9, "reason": 6,
+                    "cost": 3.5, "hours": [0, 0, 36] + [0] * 21,
                     "models": {"claude-sonnet-4.6": {
-                        "in": 6, "out": 7, "cr": 8, "cw": 9, "reason": 0, "cost": 3.5}}}
+                        "in": 6, "out": 7, "cr": 8, "cw": 9, "reason": 6, "cost": 3.5}}}
         qoderwork = {"in": 19, "out": 11, "hours": [0, 0, 0, 0, 30] + [0] * 19}
         cache = {
             "v": USAGE._SCAN_CACHE_VERSION,
@@ -126,7 +126,7 @@ class DashboardCacheTests(unittest.TestCase):
                     "reason": 10, "cost": 0}},
                 "sessions": ["session-1"]}},
             "hermes": {"db": {"days": {today: hermes}}},
-            "openclaw": {"session": {"days": {today: openclaw}}},
+            "openclaw": {"_selected_days": {today: openclaw}},
             "qoder": {"db": {"model": "performance", "days": {today: qoderwork}}},
         }
 
@@ -134,16 +134,16 @@ class DashboardCacheTests(unittest.TestCase):
         wrapped = USAGE.build_wrapped("1d", refresh=False, _cache=cache)
 
         self.assertEqual(len(daily["daily"]), 1)
-        self.assertEqual(daily["daily"][0]["tokens"], 255)
-        self.assertEqual(sum(model["tokens"] for model in daily["models"]), 255)
+        self.assertEqual(daily["daily"][0]["tokens"], 261)
+        self.assertEqual(sum(model["tokens"] for model in daily["models"]), 261)
         self.assertEqual(
             next(model["tokens"] for model in daily["models"] if model["tool"] == "qoderwork"),
             30,
         )
         self.assertEqual(daily["daily"][0]["total"], 7.25)
-        self.assertEqual(wrapped["total_tokens"], 255)
+        self.assertEqual(wrapped["total_tokens"], 261)
         self.assertEqual(wrapped["total_cost"], 7.25)
-        self.assertEqual(sum(wrapped["hours"]), 255)
+        self.assertEqual(sum(wrapped["hours"]), 261)
 
     def test_account_provider_models_are_reported_without_double_counting_local_totals(self):
         today = date.today().isoformat()

--- a/tests/test_openclaw_tasks.py
+++ b/tests/test_openclaw_tasks.py
@@ -1,7 +1,9 @@
+import json
+import os
 import sqlite3
 import tempfile
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
 
@@ -31,21 +33,132 @@ class OpenClawTaskTests(unittest.TestCase):
         connection.commit()
         connection.close()
 
-    def scan(self, state_db, legacy_db, agents_dir):
+    def add_agent_registry(self, state_db, paths):
+        state_db.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(state_db)
+        connection.execute("""
+            CREATE TABLE IF NOT EXISTS agent_databases (
+                agent_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                schema_version INTEGER NOT NULL,
+                last_seen_at INTEGER NOT NULL,
+                size_bytes INTEGER,
+                PRIMARY KEY (agent_id, path)
+            )
+        """)
+        connection.executemany(
+            "INSERT INTO agent_databases VALUES (?, ?, ?, ?, ?)",
+            [(f"agent-{index}", path, 19, 1_700_000_000_000, None)
+             for index, path in enumerate(paths)],
+        )
+        connection.commit()
+        connection.close()
+
+    def create_agent_database(self, path, events, session_models=None, fts_event=None):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(path)
+        connection.execute("""
+            CREATE TABLE transcript_events (
+                session_id TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                event_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY (session_id, seq)
+            )
+        """)
+        connection.execute("""
+            CREATE TABLE session_windows (
+                session_id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                previous_session_id TEXT,
+                reason TEXT,
+                session_scope TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                transcript_updated_at INTEGER,
+                transcript_observed_at INTEGER,
+                session_entry_provenance INTEGER NOT NULL,
+                acp_owned INTEGER NOT NULL,
+                plugin_owner_id TEXT,
+                hook_external_content_source TEXT,
+                started_at INTEGER,
+                ended_at INTEGER,
+                status TEXT,
+                chat_type TEXT,
+                channel TEXT,
+                account_id TEXT,
+                primary_conversation_id TEXT,
+                model_provider TEXT,
+                model TEXT,
+                agent_harness_id TEXT,
+                parent_session_key TEXT,
+                spawned_by TEXT,
+                display_name TEXT
+            )
+        """)
+        connection.execute("CREATE TABLE session_transcript_fts (event_json TEXT NOT NULL)")
+        connection.executemany(
+            "INSERT INTO transcript_events VALUES (?, ?, ?, ?)",
+            [(session_id, seq, json.dumps(event), created_ms)
+             for seq, (session_id, event, created_ms) in enumerate(events, 1)],
+        )
+        for session_id, model in (session_models or {}).items():
+            created_ms = next(
+                created for sid, _, created in events if sid == session_id)
+            connection.execute("""
+                INSERT INTO session_windows (
+                    session_id, session_key, session_scope, created_at, updated_at,
+                    session_entry_provenance, acp_owned, started_at, model
+                ) VALUES (?, ?, 'local', ?, ?, 1, 0, ?, ?)
+            """, (session_id, f"session:{session_id}", created_ms, created_ms,
+                  created_ms, model))
+        if fts_event is not None:
+            connection.execute(
+                "INSERT INTO session_transcript_fts VALUES (?)", (json.dumps(fts_event),))
+        connection.commit()
+        connection.close()
+
+    def usage_event(self, event_id, timestamp, usage, role="assistant",
+                    model=None, response_model=None):
+        message = {"role": role, "usage": usage}
+        if model is not None:
+            message["model"] = model
+        if response_model is not None:
+            message["responseModel"] = response_model
+        return {"type": "message", "id": event_id,
+                "timestamp": timestamp.isoformat(), "message": message}
+
+    def write_jsonl(self, path, session_id, events):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rows = [{"type": "session", "id": session_id,
+                 "timestamp": datetime.now().astimezone().isoformat()}] + events
+        path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+    def scan(self, state_db, legacy_db, agents_dir, cache=None, ledger=None):
         old_state = USAGE.OPENCLAW_STATE_DB
         old_legacy = USAGE.OPENCLAW_DB
         old_agents = USAGE.OPENCLAW_AGENTS
+        old_ledger_cache = USAGE._LEDGER_CACHE.copy()
         USAGE.OPENCLAW_STATE_DB = str(state_db)
         USAGE.OPENCLAW_DB = str(legacy_db)
         USAGE.OPENCLAW_AGENTS = str(agents_dir)
+        USAGE._LEDGER_CACHE.clear()
+        USAGE._LEDGER_CACHE.update({
+            "data": ledger or {"v": USAGE._LEDGER_VERSION,
+                                "tools": {"openclaw": {}}},
+            "dirty": False,
+        })
         try:
-            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            if cache is None:
+                cache = {"v": USAGE._SCAN_CACHE_VERSION}
             result = USAGE.scan_openclaw(USAGE.range_bounds(), cache)
             return result, cache
         finally:
             USAGE.OPENCLAW_STATE_DB = old_state
             USAGE.OPENCLAW_DB = old_legacy
             USAGE.OPENCLAW_AGENTS = old_agents
+            USAGE._LEDGER_CACHE.clear()
+            USAGE._LEDGER_CACHE.update(old_ledger_cache)
 
     def test_prefers_new_database_and_accepts_current_statuses(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -127,6 +240,246 @@ class OpenClawTaskTests(unittest.TestCase):
                 USAGE.OPENCLAW_AGENTS = old_agents
 
         self.assertEqual(result["ranges"]["today"]["tasks"], 0)
+
+    def test_discovers_relative_agent_database_and_reads_only_transcript_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "openclaw fixture"
+            state_db = root / "state" / "openclaw.sqlite"
+            legacy_db = root / "tasks" / "runs.sqlite"
+            agent_db = root / "agents" / "example-agent" / "agent" / "openclaw-agent.sqlite"
+            now = datetime.now().astimezone().replace(microsecond=0)
+            created_ms = int((now - timedelta(days=1)).timestamp() * 1000)
+            task_created_ms = int(now.timestamp() * 1000)
+            usage = {"input": 0, "output": 0, "cacheRead": 40, "cacheWrite": 3,
+                     "reasoningTokens": 7, "totalTokens": 50,
+                     "cost": {"total": 0.75}}
+            assistant = self.usage_event("event-usage", now, usage)
+            user_decoy = self.usage_event(
+                "event-user", now,
+                {"input": 9_999, "output": 9_999, "cost": {"total": 99}},
+                role="user",
+            )
+            no_usage = {"type": "message", "id": "event-no-usage",
+                        "timestamp": now.isoformat(),
+                        "message": {"role": "assistant"}}
+            fts_decoy = self.usage_event(
+                "fts-decoy", now,
+                {"input": 8_888, "output": 8_888, "cost": {"total": 88}},
+            )
+            self.create_database(state_db, task_created_ms, ["completed"])
+            relative = os.path.relpath(agent_db, root)
+            self.add_agent_registry(state_db, [relative, relative])
+            self.create_agent_database(
+                agent_db,
+                [("session-sqlite", assistant, created_ms),
+                 ("session-sqlite", user_decoy, created_ms),
+                 ("session-sqlite", no_usage, created_ms)],
+                {"session-sqlite": "vendor/example-session-model"},
+                fts_event=fts_decoy,
+            )
+            trajectory = (root / "agents" / "example-agent" / "sessions"
+                          / "ignored.trajectory.jsonl")
+            self.write_jsonl(trajectory, "trajectory-session", [fts_decoy])
+
+            result, cache = self.scan(state_db, legacy_db, root / "agents")
+
+        today = result["ranges"]["today"]
+        self.assertEqual(today["tasks"], 1)
+        self.assertEqual((today["in"], today["out"], today["cr"], today["cw"],
+                          today["reason"]), (0, 0, 40, 3, 7))
+        self.assertAlmostEqual(today["cost"], 0.75)
+        self.assertEqual(today["sessions"], {"session-sqlite"})
+        selected = cache["openclaw"]["_selected_days"][now.date().isoformat()]
+        self.assertIn("vendor/example-session-model", selected["models"])
+        sqlite_entries = [entry for entry in cache["openclaw"].values()
+                          if isinstance(entry, dict) and entry.get("source") == "sqlite"]
+        self.assertEqual(len(sqlite_entries), 1)
+
+    def test_response_model_precedes_message_model_and_unknown_stays_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_db = root / "state" / "openclaw.sqlite"
+            agent_db = root / "agents" / "example-agent" / "agent" / "openclaw-agent.sqlite"
+            now = datetime.now().astimezone().replace(microsecond=0)
+            created_ms = int(now.timestamp() * 1000)
+            self.create_database(state_db, created_ms, [], with_tasks=False)
+            self.add_agent_registry(state_db, [os.path.relpath(agent_db, root)])
+            base_usage = {"input": 5, "output": 2, "cacheRead": 0,
+                          "cacheWrite": 0, "reasoningTokens": 0,
+                          "totalTokens": 7, "cost": {"total": 0}}
+            response_event = self.usage_event(
+                "event-response", now, base_usage,
+                model="vendor/example-message-model",
+                response_model="vendor/example-response-model",
+            )
+            unknown_event = self.usage_event(
+                "event-unknown", now, base_usage,
+            )
+            self.create_agent_database(
+                agent_db,
+                [("session-response", response_event, created_ms),
+                 ("session-unknown", unknown_event, created_ms)],
+            )
+
+            _, cache = self.scan(state_db, root / "missing.sqlite", root / "agents")
+
+        models = cache["openclaw"]["_selected_days"][now.date().isoformat()]["models"]
+        self.assertIn("vendor/example-response-model", models)
+        self.assertNotIn("vendor/example-message-model", models)
+        self.assertIn("unknown", models)
+
+    def test_pricing_fallback_treats_reasoning_as_separate_output(self):
+        now = datetime.now().astimezone().replace(microsecond=0)
+        event = self.usage_event(
+            "event-priced", now,
+            {"input": 10, "output": 20, "cacheRead": 30, "cacheWrite": 40,
+             "reasoningTokens": 5, "totalTokens": 105, "cost": {"total": 0}},
+            model="vendor/example-priced",
+        )
+        with mock.patch.dict(USAGE._PRICING_DB, {
+            "vendor/example-priced": {
+                "in": 1.0, "out": 2.0, "cache_read": 3.0, "cache_write": 4.0,
+            },
+        }):
+            record = USAGE._openclaw_usage_record(event)
+
+        expected = (10 * 1.0 + (20 + 5) * 2.0 + 30 * 3.0 + 40 * 4.0) / 1_000_000
+        self.assertAlmostEqual(record["cost"], expected, places=12)
+
+    def test_sqlite_and_jsonl_choose_one_copy_per_session(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_db = root / "state" / "openclaw.sqlite"
+            agent_db = root / "agents" / "example-agent" / "agent" / "openclaw-agent.sqlite"
+            sessions_dir = root / "agents" / "example-agent" / "sessions"
+            now = datetime.now().astimezone().replace(microsecond=0)
+            created_ms = int(now.timestamp() * 1000)
+            self.create_database(state_db, created_ms, [], with_tasks=False)
+            self.add_agent_registry(state_db, [os.path.relpath(agent_db, root)])
+            shared = self.usage_event(
+                "event-shared", now,
+                {"input": 10, "output": 0, "cacheRead": 0, "cacheWrite": 0,
+                 "reasoningTokens": 0, "totalTokens": 10, "cost": {"total": 0}},
+                model="vendor/example-model",
+            )
+            unique = self.usage_event(
+                "event-unique", now,
+                {"input": 7, "output": 0, "cacheRead": 0, "cacheWrite": 0,
+                 "reasoningTokens": 0, "totalTokens": 7, "cost": {"total": 0}},
+                model="vendor/example-model",
+            )
+            trajectory = self.usage_event(
+                "event-trajectory", now,
+                {"input": 1_000, "output": 0, "cacheRead": 0, "cacheWrite": 0,
+                 "reasoningTokens": 0, "totalTokens": 1_000, "cost": {"total": 0}},
+            )
+            self.create_agent_database(
+                agent_db, [("session-shared", shared, created_ms)])
+            self.write_jsonl(sessions_dir / "session-shared.jsonl", "session-shared", [shared])
+            self.write_jsonl(sessions_dir / "archived-copy.jsonl", "session-shared", [shared])
+            self.write_jsonl(sessions_dir / "session-unique.jsonl", "session-unique", [unique])
+            self.write_jsonl(
+                sessions_dir / "session-unique.trajectory.jsonl",
+                "session-unique", [trajectory],
+            )
+
+            result, _ = self.scan(state_db, root / "missing.sqlite", root / "agents")
+
+        today = result["ranges"]["today"]
+        self.assertEqual(today["in"], 17)
+        self.assertEqual(today["sessions"], {"session-shared", "session-unique"})
+
+    def test_agent_wal_change_invalidates_cached_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_db = root / "state" / "openclaw.sqlite"
+            agent_db = root / "agents" / "example-agent" / "agent" / "openclaw-agent.sqlite"
+            now = datetime.now().astimezone().replace(microsecond=0)
+            created_ms = int(now.timestamp() * 1000)
+            self.create_database(state_db, created_ms, [], with_tasks=False)
+            self.add_agent_registry(state_db, [os.path.relpath(agent_db, root)])
+            first = self.usage_event(
+                "event-first", now,
+                {"input": 3, "output": 0, "totalTokens": 3, "cost": {"total": 0}},
+            )
+            second = self.usage_event(
+                "event-second", now,
+                {"input": 4, "output": 0, "totalTokens": 4, "cost": {"total": 0}},
+            )
+            self.create_agent_database(
+                agent_db, [("session-wal", first, created_ms)])
+            cache = {"v": USAGE._SCAN_CACHE_VERSION}
+            initial, cache = self.scan(
+                state_db, root / "missing.sqlite", root / "agents", cache=cache)
+            connection = sqlite3.connect(agent_db)
+            try:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute("PRAGMA wal_autocheckpoint=0")
+                connection.execute(
+                    "INSERT INTO transcript_events VALUES (?, ?, ?, ?)",
+                    ("session-wal", 2, json.dumps(second), created_ms),
+                )
+                connection.commit()
+                self.assertTrue(Path(str(agent_db) + "-wal").exists())
+                refreshed, cache = self.scan(
+                    state_db, root / "missing.sqlite", root / "agents", cache=cache)
+            finally:
+                connection.close()
+
+        self.assertEqual(initial["ranges"]["today"]["in"], 3)
+        self.assertEqual(refreshed["ranges"]["today"]["in"], 7)
+        sqlite_entry = next(
+            entry for entry in cache["openclaw"].values()
+            if isinstance(entry, dict) and entry.get("source") == "sqlite"
+        )
+        self.assertIn("-wal", sqlite_entry["sig"])
+
+    def test_legacy_jsonl_remains_supported_without_registry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime.now().astimezone().replace(microsecond=0)
+            event = self.usage_event(
+                "legacy-event", now,
+                {"input": 2, "output": 3, "cacheRead": 4, "cacheWrite": 5,
+                 "reasoningTokens": 6, "totalTokens": 20, "cost": {"total": 0.2}},
+                model="vendor/example-legacy-model",
+            )
+            self.write_jsonl(
+                root / "agents" / "example-agent" / "sessions" / "legacy.jsonl",
+                "legacy-session", [event],
+            )
+
+            result, _ = self.scan(
+                root / "missing-state.sqlite", root / "missing-legacy.sqlite",
+                root / "agents",
+            )
+
+        today = result["ranges"]["today"]
+        self.assertEqual((today["in"], today["out"], today["cr"], today["cw"],
+                          today["reason"]), (2, 3, 4, 5, 6))
+        self.assertEqual(today["sessions"], {"legacy-session"})
+        self.assertAlmostEqual(today["cost"], 0.2)
+
+    def test_new_openclaw_ledger_version_can_replace_old_duplicate_high_water(self):
+        day_key = datetime.now().astimezone().date().isoformat()
+        old = {"in": 100, "out": 20, "cr": 0, "cw": 0, "reason": 0,
+               "cost": 1.0, "models": {}, "hours": [0] * 24}
+        new = {"in": 10, "out": 2, "cr": 0, "cw": 0, "reason": 1,
+               "cost": 0.1, "models": {}, "hours": [0] * 24,
+               "_ledger_version": USAGE._OPENCLAW_LEDGER_VERSION}
+        ledger = {"v": USAGE._LEDGER_VERSION,
+                  "tools": {"openclaw": {day_key: old}}}
+        original = USAGE._LEDGER_CACHE.copy()
+        try:
+            USAGE._LEDGER_CACHE.clear()
+            USAGE._LEDGER_CACHE.update({"data": ledger, "dirty": False})
+            merged = USAGE.ledger_reconcile("openclaw", {day_key: new})
+        finally:
+            USAGE._LEDGER_CACHE.clear()
+            USAGE._LEDGER_CACHE.update(original)
+
+        self.assertEqual(merged[day_key]["in"], 10)
+        self.assertEqual(merged[day_key]["reason"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_openclaw_tasks.py
+++ b/tests/test_openclaw_tasks.py
@@ -328,6 +328,33 @@ class OpenClawTaskTests(unittest.TestCase):
         self.assertNotIn("vendor/example-message-model", models)
         self.assertIn("unknown", models)
 
+    def test_relative_agent_path_uses_openclaw_root_when_registry_is_overridden(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp)
+            openclaw_root = fixture / "custom-openclaw-root"
+            state_db = fixture / "registry-copy.sqlite"
+            agent_db = (openclaw_root / "agents" / "example-agent" / "agent"
+                        / "openclaw-agent.sqlite")
+            now = datetime.now().astimezone().replace(microsecond=0)
+            created_ms = int(now.timestamp() * 1000)
+            self.create_database(state_db, created_ms, [], with_tasks=False)
+            self.add_agent_registry(state_db, [
+                "agents/example-agent/agent/openclaw-agent.sqlite",
+            ])
+            event = self.usage_event(
+                "event-custom-root", now,
+                {"input": 9, "output": 0, "totalTokens": 9,
+                 "cost": {"total": 0}},
+            )
+            self.create_agent_database(
+                agent_db, [("session-custom-root", event, created_ms)])
+
+            result, _ = self.scan(
+                state_db, fixture / "missing.sqlite", openclaw_root / "agents",
+            )
+
+        self.assertEqual(result["ranges"]["today"]["in"], 9)
+
     def test_pricing_fallback_treats_reasoning_as_separate_output(self):
         now = datetime.now().astimezone().replace(microsecond=0)
         event = self.usage_event(

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -681,8 +681,8 @@ def ledger_flush():
             for dk, day in days.items():
                 kept = stored.get(dk)
                 if (kept is None
-                        or _ledger_cost_version(day) > _ledger_cost_version(kept)
-                        or (_ledger_cost_version(day) == _ledger_cost_version(kept)
+                        or _ledger_record_version(day) > _ledger_record_version(kept)
+                        or (_ledger_record_version(day) == _ledger_record_version(kept)
                             and _ledger_day_total(day) > _ledger_day_total(kept))):
                     stored[dk] = day
         _save_ledger(fresh)
@@ -723,8 +723,17 @@ def _ledger_day_total(day):
                and k != "cost" and not k.startswith("_"))
 
 
-def _ledger_cost_version(day):
-    value = day.get("_cost_version", 0) if isinstance(day, dict) else 0
+def _ledger_record_version(day):
+    """Return the schema version for a persisted daily record.
+
+    ``_cost_version`` is retained for existing collectors.  New parsers can use
+    the broader ``_ledger_version`` when a deduplication or token-accounting
+    change must replace an older high-water value, even when the new total is
+    lower.
+    """
+    if not isinstance(day, dict):
+        return 0
+    value = day.get("_ledger_version", day.get("_cost_version", 0))
     return int(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
 
 
@@ -761,8 +770,8 @@ def ledger_reconcile(tool, live_days):
     max_day = (date.today() + timedelta(days=1)).isoformat()
     for dk, live in live_days.items():
         kept = stored.get(dk)
-        kept_version = _ledger_cost_version(kept)
-        live_version = _ledger_cost_version(live)
+        kept_version = _ledger_record_version(kept)
+        live_version = _ledger_record_version(live)
         if (kept and kept_version > live_version
                 or (kept and kept_version == live_version
                     and _ledger_day_total(kept) > _ledger_day_total(live))):
@@ -877,7 +886,7 @@ def _empty_hermes():
 
 def _empty_openclaw():
     ranges = {k: {"tasks": 0, "completed": 0, "failed": 0,
-                  "in": 0, "out": 0, "cr": 0, "cw": 0,
+                  "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0,
                   "cost": 0.0, "sessions": set(), "models": {}} for k in RANGE_KEYS}
     return {"ranges": ranges}
 
@@ -6583,8 +6592,13 @@ def scan_hermes(bounds, cache):
 
 
 # ---------- OpenClaw ----------
-# SQLite: ~/.openclaw/state/openclaw.sqlite（新版）或 ~/.openclaw/tasks/runs.sqlite（旧版）
-# Session JSONL: ~/.openclaw/agents/*/sessions/*.jsonl — token 用量
+# 全局 SQLite: ~/.openclaw/state/openclaw.sqlite（任务 + agent DB 注册表）
+# Agent SQLite: agent_databases.path -> transcript_events.event_json（新版 token 用量）
+# Session JSONL: ~/.openclaw/agents/*/sessions/*.jsonl（旧版 token 用量）
+_OPENCLAW_PARSER_VERSION = 1
+_OPENCLAW_LEDGER_VERSION = 1
+
+
 def _openclaw_db_paths():
     return [path for path in _path_candidates(
         "TOKEI_OPENCLAW_DB", OPENCLAW_STATE_DB, OPENCLAW_DB) if os.path.isfile(path)]
@@ -6637,6 +6651,256 @@ def _scan_openclaw_db(db_path, sqlite_module):
         conn.close()
 
 
+def _openclaw_agent_db_paths(sqlite_module):
+    """Discover agent databases from the global registry.
+
+    OpenClaw stores registry paths relative to ``~/.openclaw`` on current
+    releases.  Absolute paths remain supported for compatible installations.
+    The boolean result distinguishes an authoritative empty registry from a
+    transient read failure so cached agent data is not discarded on lock/I/O
+    errors.
+    """
+    read_failed = False
+    for registry_path in _openclaw_db_paths():
+        conn = None
+        try:
+            conn = _openclaw_connect(registry_path, sqlite_module)
+            found = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='agent_databases'"
+            ).fetchone()
+            if not found:
+                continue
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(agent_databases)")}
+            if "path" not in columns:
+                continue
+            root = os.path.dirname(os.path.dirname(os.path.abspath(registry_path)))
+            paths = []
+            seen = set()
+            for (raw_path,) in conn.execute("SELECT path FROM agent_databases"):
+                if not isinstance(raw_path, str) or not raw_path.strip():
+                    continue
+                expanded = os.path.expandvars(os.path.expanduser(raw_path.strip()))
+                resolved = expanded if os.path.isabs(expanded) else os.path.join(root, expanded)
+                resolved = os.path.realpath(os.path.abspath(resolved))
+                key = os.path.normcase(resolved)
+                if key not in seen:
+                    seen.add(key)
+                    paths.append(resolved)
+            return True, paths
+        except Exception:
+            read_failed = True
+        finally:
+            if conn is not None:
+                conn.close()
+    return not read_failed, []
+
+
+def _openclaw_number(value):
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _openclaw_cost_number(value):
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        return max(float(value or 0), 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+
+
+def _openclaw_datetime(value):
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        seconds = float(value) / 1000 if value > 10_000_000_000 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds).astimezone()
+        except (OSError, OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        parsed = parse_ts(value)
+        return parsed.astimezone() if parsed else None
+    return None
+
+
+def _openclaw_usage_record(event, created_at=None, session_model=None):
+    if not isinstance(event, dict):
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    # The persisted event timestamp is authoritative. created_at mirrors it on
+    # current databases and is the stable fallback when optional JSON fields are
+    # absent; message.timestamp can precede persistence by several seconds.
+    occurred_at = (_openclaw_datetime(event.get("timestamp"))
+                   or _openclaw_datetime(created_at)
+                   or _openclaw_datetime(message.get("timestamp")))
+    if occurred_at is None:
+        return None
+
+    inp = _openclaw_number(usage.get("input"))
+    out = _openclaw_number(usage.get("output"))
+    cr = _openclaw_number(usage.get("cacheRead"))
+    cw = _openclaw_number(usage.get("cacheWrite"))
+    reason = _openclaw_number(usage.get("reasoningTokens"))
+
+    raw_model = next((candidate.strip() for candidate in (
+        message.get("responseModel"), message.get("model"), session_model
+    ) if isinstance(candidate, str) and candidate.strip()), "")
+    model = _model_identity_id(raw_model) or raw_model or "unknown"
+
+    cost_obj = usage.get("cost")
+    if isinstance(cost_obj, dict):
+        cost = _openclaw_cost_number(cost_obj.get("total"))
+        if cost <= 0:
+            cost = sum(_openclaw_cost_number(cost_obj.get(field)) for field in (
+                "input", "output", "cacheRead", "cacheWrite"))
+    else:
+        cost = _openclaw_cost_number(cost_obj)
+    pricing_id = _exact_pricing_id(model)
+    if cost <= 0 and pricing_id:
+        price = _raw_price(pricing_id)
+        cost = (inp / 1e6 * price["in"] + (out + reason) / 1e6 * price["out"]
+                + cr / 1e6 * price["cache_read"] + cw / 1e6 * price["cache_write"])
+
+    return {"date": occurred_at.date().isoformat(), "hour": occurred_at.hour,
+            "in": inp, "out": out, "cr": cr, "cw": cw, "reason": reason,
+            "cost": cost, "model": model}
+
+
+def _openclaw_add_record(days, record):
+    day = days.setdefault(record["date"], _empty_token_day())
+    _add_token_usage(day, record["in"], record["out"], record["cr"], record["cw"],
+                     record["reason"], record["cost"], record["model"])
+    day["hours"][record["hour"]] += token_total(record)
+
+
+def _openclaw_event_key(event, raw_event):
+    event_id = event.get("id") if isinstance(event, dict) else None
+    if isinstance(event_id, str) and event_id:
+        return "id:" + event_id
+    material = raw_event if isinstance(raw_event, str) else json.dumps(
+        event, sort_keys=True, separators=(",", ":"))
+    return "hash:" + hashlib.sha256(
+        material.encode("utf-8", errors="surrogatepass")
+    ).hexdigest()
+
+
+def _scan_openclaw_agent_db(db_path, sqlite_module):
+    conn = _openclaw_connect(db_path, sqlite_module)
+    try:
+        tables = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        if "transcript_events" not in tables:
+            raise sqlite_module.OperationalError("missing transcript_events")
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(transcript_events)")}
+        if not {"session_id", "seq", "event_json", "created_at"}.issubset(columns):
+            raise sqlite_module.OperationalError("incompatible transcript_events")
+
+        session_models = {}
+        if "session_windows" in tables:
+            window_columns = {row[1] for row in conn.execute(
+                "PRAGMA table_info(session_windows)"
+            )}
+            if {"session_id", "model"}.issubset(window_columns):
+                session_models = {str(session_id): model for session_id, model in conn.execute(
+                    "SELECT session_id, model FROM session_windows"
+                )}
+
+        sessions = {}
+        seen_events = {}
+        for session_id, seq, raw_event, created_at in conn.execute(
+                "SELECT session_id, seq, event_json, created_at "
+                "FROM transcript_events ORDER BY session_id, seq"):
+            try:
+                event = json.loads(raw_event)
+            except (TypeError, ValueError):
+                continue
+            session_key = str(session_id)
+            event_key = _openclaw_event_key(event, raw_event)
+            session_seen = seen_events.setdefault(session_key, set())
+            if event_key in session_seen:
+                continue
+            session_seen.add(event_key)
+            record = _openclaw_usage_record(
+                event, created_at, session_models.get(session_key))
+            if record is None:
+                continue
+            session = sessions.setdefault(session_key, {"days": {}, "events": 0})
+            _openclaw_add_record(session["days"], record)
+            session["events"] += 1
+        return sessions
+    finally:
+        conn.close()
+
+
+def _scan_openclaw_jsonl(path):
+    session_id = os.path.basename(path)[:-6]
+    days = {}
+    events = 0
+    seen = set()
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            if '"usage"' not in line and '"type"' not in line:
+                continue
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if (event.get("type") == "session" and isinstance(event.get("id"), str)
+                    and event["id"]):
+                session_id = event["id"]
+            event_key = _openclaw_event_key(event, line)
+            if event_key in seen:
+                continue
+            seen.add(event_key)
+            record = _openclaw_usage_record(event)
+            if record is None:
+                continue
+            _openclaw_add_record(days, record)
+            events += 1
+    return session_id, {"days": days, "events": events}
+
+
+def _openclaw_session_score(copy, source):
+    token_count = sum(_ledger_token_sum(day) for day in copy.get("days", {}).values())
+    return token_count, int(copy.get("events", 0)), 1 if source == "sqlite" else 0
+
+
+def _openclaw_selected_sessions(tool_cache):
+    selected = {}
+    for entry_key, entry in tool_cache.items():
+        if entry_key.startswith("_") or not isinstance(entry, dict):
+            continue
+        if entry.get("parser_version") != _OPENCLAW_PARSER_VERSION:
+            continue
+        source = entry.get("source")
+        if source == "sqlite":
+            copies = (entry.get("sessions") or {}).items()
+        elif source == "jsonl":
+            copies = [(entry.get("session_id") or entry_key, {
+                "days": entry.get("days", {}), "events": entry.get("events", 0)})]
+        else:
+            continue
+        for session_id, copy in copies:
+            if not isinstance(copy, dict):
+                continue
+            session_key = str(session_id)
+            score = _openclaw_session_score(copy, source)
+            previous = selected.get(session_key)
+            if previous is None or score > previous[0]:
+                selected[session_key] = (score, copy)
+    return {session_id: copy for session_id, (_, copy) in selected.items()}
+
+
 def scan_openclaw(bounds, cache):
     import sqlite3 as _sq
     ledger_touch("openclaw")
@@ -6662,7 +6926,7 @@ def scan_openclaw(bounds, cache):
         return ks
 
     B = {k: {"tasks": 0, "completed": 0, "failed": 0,
-             "in": 0, "out": 0, "cr": 0, "cw": 0,
+             "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0,
              "cost": 0.0, "sessions": set(), "models": {}} for k in RANGE_KEYS}
 
     # --- Part 1: SQLite task counts ---
@@ -6694,110 +6958,93 @@ def scan_openclaw(bounds, cache):
         fc.pop("_db", None)
         changed = True
 
-    # --- Part 2: Session JSONL token usage ---
-    live_days = {}
-    if os.path.isdir(OPENCLAW_AGENTS):
-        stale = {k for k in fc if not k.startswith("_")}
-        for f in glob.glob(os.path.join(OPENCLAW_AGENTS, "*", "sessions", "*.jsonl")):
-            if f.endswith(".trajectory.jsonl"):
-                continue
-            stale.discard(f)
+    # --- Part 2: dynamically discovered agent SQLite usage ---
+    registry_ok, agent_db_paths = _openclaw_agent_db_paths(_sq)
+    active_sqlite_keys = set()
+    for agent_db_path in agent_db_paths:
+        entry_key = "sqlite:" + os.path.realpath(agent_db_path)
+        active_sqlite_keys.add(entry_key)
+        sig = _sqlite_signature(agent_db_path)
+        entry = fc.get(entry_key)
+        needs_scan = (not entry or entry.get("parser_version") != _OPENCLAW_PARSER_VERSION
+                      or entry.get("path") != agent_db_path or entry.get("sig") != sig)
+        if sig and needs_scan:
             try:
-                st = os.stat(f)
-            except OSError:
+                sessions = _scan_openclaw_agent_db(agent_db_path, _sq)
+            except Exception:
                 continue
-            sig = f"{st.st_mtime}:{st.st_size}"
-            entry = fc.get(f)
-            if not entry or entry.get("sig") != sig:
-                days = {}
-                try:
-                    with open(f, "r", encoding="utf-8", errors="ignore") as fh:
-                        for line in fh:
-                            if '"usage"' not in line:
-                                continue
-                            try:
-                                o = json.loads(line)
-                            except Exception:
-                                continue
-                            msg = o.get("message", {})
-                            if msg.get("role") != "assistant":
-                                continue
-                            u = msg.get("usage")
-                            if not u:
-                                continue
-                            dt = parse_ts(o.get("timestamp", ""))
-                            if dt is None:
-                                continue
-                            dt = dt.astimezone()
-                            inp = u.get("input", 0) or 0
-                            out = u.get("output", 0) or 0
-                            cr = u.get("cacheRead", 0) or 0
-                            cw = u.get("cacheWrite", 0) or 0
-                            if inp == 0 and out == 0:
-                                continue
-                            model = msg.get("model", "")
-                            model_id = _model_identity_id(model)
-                            pricing_id = _exact_pricing_id(model_id)
-                            cost_obj = u.get("cost")
-                            raw_cost = float((cost_obj or {}).get("total", 0) or 0)
-                            if raw_cost > 0:
-                                cost = raw_cost
-                            elif pricing_id:
-                                p = _raw_price(pricing_id)
-                                cost = inp / 1e6 * p["in"] + out / 1e6 * p["out"] + cr / 1e6 * p["cache_read"] + cw / 1e6 * p["cache_write"]
-                            else:
-                                cost = 0.0
-                            dk = dt.date().isoformat()
-                            day = days.setdefault(dk, {"in": 0, "out": 0, "cr": 0, "cw": 0,
-                                                       "cost": 0.0, "models": {},
-                                                       "hours": [0] * 24})
-                            day["in"] += inp; day["out"] += out
-                            day["cr"] += cr; day["cw"] += cw; day["cost"] += cost
-                            day["hours"][dt.hour] += inp + out + cr + cw
-                            mn = model_id or model or "unknown"
-                            mm = day["models"].setdefault(
-                                mn, {"in": 0, "out": 0, "cr": 0, "cw": 0,
-                                     "reason": 0, "cost": 0.0})
-                            mm["in"] += inp; mm["out"] += out
-                            mm["cr"] += cr; mm["cw"] += cw; mm["cost"] += cost
-                except OSError:
-                    continue
-                fc[f] = {"sig": sig, "days": days}
+            fc[entry_key] = {"source": "sqlite", "path": agent_db_path, "sig": sig,
+                             "parser_version": _OPENCLAW_PARSER_VERSION,
+                             "sessions": sessions}
+            changed = True
+    if registry_ok:
+        for entry_key, entry in list(fc.items()):
+            if (isinstance(entry, dict) and entry.get("source") == "sqlite"
+                    and entry_key not in active_sqlite_keys):
+                fc.pop(entry_key, None)
                 changed = True
 
-        for p in stale:
-            fc.pop(p, None)
+    # --- Part 3: legacy JSONL usage, excluding trajectory logs ---
+    jsonl_files = set()
+    if os.path.isdir(OPENCLAW_AGENTS):
+        jsonl_files = {
+            path for path in glob.glob(
+                os.path.join(OPENCLAW_AGENTS, "*", "sessions", "*.jsonl"))
+            if not path.endswith(".trajectory.jsonl")
+        }
+    for path in sorted(jsonl_files):
+        try:
+            stat = os.stat(path)
+        except OSError:
+            continue
+        sig = f"{stat.st_mtime_ns}:{stat.st_size}"
+        entry = fc.get(path)
+        if (entry and entry.get("source") == "jsonl"
+                and entry.get("parser_version") == _OPENCLAW_PARSER_VERSION
+                and entry.get("sig") == sig):
+            continue
+        try:
+            session_id, copy = _scan_openclaw_jsonl(path)
+        except OSError:
+            continue
+        fc[path] = {"source": "jsonl", "sig": sig,
+                    "parser_version": _OPENCLAW_PARSER_VERSION,
+                    "session_id": session_id, "days": copy["days"],
+                    "events": copy["events"]}
+        changed = True
+
+    for entry_key, entry in list(fc.items()):
+        if entry_key.startswith("_") or not isinstance(entry, dict):
+            continue
+        is_jsonl = entry.get("source") == "jsonl" or (
+            entry.get("source") is None and entry_key.endswith(".jsonl"))
+        if is_jsonl and entry_key not in jsonl_files:
+            fc.pop(entry_key, None)
             changed = True
 
-        for f, entry in fc.items():
-            if f.startswith("_"):
-                continue
-            for dk, day in entry.get("days", {}).items():
-                try:
-                    d = date.fromisoformat(dk)
-                except ValueError:
-                    continue
-                agg = live_days.setdefault(
-                    dk, {"in": 0, "out": 0, "cr": 0, "cw": 0,
-                         "cost": 0.0, "models": {}, "hours": [0] * 24})
-                agg["in"] += day["in"]; agg["out"] += day["out"]
-                agg["cr"] += day["cr"]; agg["cw"] += day["cw"]; agg["cost"] += day["cost"]
-                for mn, mv in day["models"].items():
-                    mm = agg["models"].setdefault(
-                        mn, {"in": 0, "out": 0, "cr": 0, "cw": 0,
-                             "reason": 0, "cost": 0.0})
-                    for key in TOKEN_FIELDS:
-                        mm[key] += mv.get(key, 0)
-                    mm["cost"] += mv.get("cost", 0)
-                for hour, amount in enumerate((day.get("hours") or [])[:24]):
-                    agg["hours"][hour] += amount
-                # 会话数只能来自现存日志(被清日志无从归属)
-                for k in _day_keys(d):
-                    B[k]["sessions"].add(f)
-    else:
-        for p in [key for key in fc if not key.startswith("_")]:
-            fc.pop(p, None)
-            changed = True
+    # Select one complete copy per logical session across SQLite/JSONL sources.
+    live_days = {}
+    live_sessions = {}
+    for session_id, copy in _openclaw_selected_sessions(fc).items():
+        for day_key, day in copy.get("days", {}).items():
+            agg = live_days.setdefault(day_key, _empty_token_day())
+            _merge_live_token_day(agg, day)
+            live_sessions.setdefault(day_key, set()).add(session_id)
+    for day in live_days.values():
+        day["_ledger_version"] = _OPENCLAW_LEDGER_VERSION
+
+    if fc.get("_selected_days") != live_days:
+        fc["_selected_days"] = live_days
+        changed = True
+
+    # 会话数只来自现存 session 副本；账本无法可靠恢复被清日志的归属。
+    for day_key, session_ids in live_sessions.items():
+        try:
+            day_date = date.fromisoformat(day_key)
+        except ValueError:
+            continue
+        for range_key in _day_keys(day_date):
+            B[range_key]["sessions"].update(session_ids)
 
     for dk, day in ledger_reconcile("openclaw", live_days).items():
         try:
@@ -6808,6 +7055,7 @@ def scan_openclaw(bounds, cache):
             b = B[k]
             b["in"] += day.get("in", 0); b["out"] += day.get("out", 0)
             b["cr"] += day.get("cr", 0); b["cw"] += day.get("cw", 0)
+            b["reason"] += day.get("reason", 0)
             b["cost"] += day.get("cost", 0)
             for mn, mv in (day.get("models") or {}).items():
                 mm = b["models"].setdefault(
@@ -8968,7 +9216,7 @@ def compute():
         hit = (b["cr"] / denom * 100) if denom else 0.0
         return {"tasks": b["tasks"], "completed": b["completed"], "failed": b["failed"],
                 "hit": hit, "in": b["in"], "out": b["out"], "cr": b["cr"], "cw": b["cw"],
-                "cost": b["cost"], "sessions": len(b["sessions"]),
+                "reason": b["reason"], "cost": b["cost"], "sessions": len(b["sessions"]),
                 "models": _format_token_models(b["models"])}
 
     hranges = {k: hermes_range(hm["ranges"][k]) for k in RANGE_KEYS}
@@ -9951,23 +10199,20 @@ def build_daily_costs(period="all", refresh=True, _cache=None):
                 for key in TOKEN_FIELDS:
                     model[key] += mv.get(key, 0)
 
-    for entry_key, entry in cache.get("openclaw", {}).items():
-        if entry_key.startswith("_") or not isinstance(entry, dict):
+    for dk, day in cache.get("openclaw", {}).get("_selected_days", {}).items():
+        if cutoff and dk < cutoff:
             continue
-        for dk, day in entry.get("days", {}).items():
-            if cutoff and dk < cutoff:
-                continue
-            d = days.setdefault(dk, _empty())
-            d["openclaw"] += day.get("cost", 0)
-            _add_day_tokens(d, dk, "openclaw", token_total(day))
-            for mn, mv in day.get("models", {}).items():
-                name = f"{nice_model(mn)} (OpenClaw)"
-                model = models.setdefault(
-                    name, {"cost": 0.0, "in": 0, "out": 0, "cr": 0, "cw": 0,
-                           "reason": 0, "tool": "openclaw"})
-                model["cost"] += mv.get("cost", 0)
-                for key in TOKEN_FIELDS:
-                    model[key] += mv.get(key, 0)
+        d = days.setdefault(dk, _empty())
+        d["openclaw"] += day.get("cost", 0)
+        _add_day_tokens(d, dk, "openclaw", token_total(day))
+        for mn, mv in day.get("models", {}).items():
+            name = f"{nice_model(mn)} (OpenClaw)"
+            model = models.setdefault(
+                name, {"cost": 0.0, "in": 0, "out": 0, "cr": 0, "cw": 0,
+                       "reason": 0, "tool": "openclaw"})
+            model["cost"] += mv.get("cost", 0)
+            for key in TOKEN_FIELDS:
+                model[key] += mv.get(key, 0)
 
     for fp, entry in cache.get("qoder", {}).items():
         model_name = entry.get("model") or "QoderWork"
@@ -10263,21 +10508,18 @@ def build_wrapped(period="all", refresh=True, _cache=None):
                 name = f"{nice_model(model)} (Hermes)"
                 model_tok[name] = model_tok.get(name, 0) + token_total(usage)
 
-    # --- OpenClaw (in + out + cr + cw) ---
-    for f, entry in cache.get("openclaw", {}).items():
-        if not isinstance(entry, dict):
+    # --- OpenClaw (in + out + cr + cw + reason) ---
+    for dk, day in cache.get("openclaw", {}).get("_selected_days", {}).items():
+        if cutoff and dk < cutoff:
             continue
-        for dk, day in entry.get("days", {}).items():
-            if cutoff and dk < cutoff:
-                continue
-            tok = token_total(day)
-            day_tokens[dk] = day_tokens.get(dk, 0) + tok
-            day_cost[dk] = day_cost.get(dk, 0.0) + day.get("cost", 0)
-            weekday[date.fromisoformat(dk).weekday()] += tok
-            add_hours(dk, day.get("hours"))
-            for model, usage in day.get("models", {}).items():
-                name = f"{nice_model(model)} (OpenClaw)"
-                model_tok[name] = model_tok.get(name, 0) + token_total(usage)
+        tok = token_total(day)
+        day_tokens[dk] = day_tokens.get(dk, 0) + tok
+        day_cost[dk] = day_cost.get(dk, 0.0) + day.get("cost", 0)
+        weekday[date.fromisoformat(dk).weekday()] += tok
+        add_hours(dk, day.get("hours"))
+        for model, usage in day.get("models", {}).items():
+            name = f"{nice_model(model)} (OpenClaw)"
+            model_tok[name] = model_tok.get(name, 0) + token_total(usage)
 
     # --- OpenCode (in + out + cr + cw + reason) ---
     for dk, day in _iter_cached_token_days(cache.get("opencode", {})):

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -6673,7 +6673,7 @@ def _openclaw_agent_db_paths(sqlite_module):
             columns = {row[1] for row in conn.execute("PRAGMA table_info(agent_databases)")}
             if "path" not in columns:
                 continue
-            root = os.path.dirname(os.path.dirname(os.path.abspath(registry_path)))
+            root = os.path.dirname(os.path.realpath(os.path.abspath(OPENCLAW_AGENTS)))
             paths = []
             seen = set()
             for (raw_path,) in conn.execute("SELECT path FROM agent_databases"):


### PR DESCRIPTION
## 问题

从 OpenClaw 2026.8.1 开始，会话存储从 `agents/*/sessions/*.jsonl` 搬到了每个 agent 的 `openclaw-agent.sqlite`。Tokei 仍在扫描旧 JSONL，所以升级后任务数看起来正常，token 却变成了 0。任务数来自全局库里的 `task_runs`，两套数据源刚好把问题藏住了。

## 修改

Tokei 现在从全局 `agent_databases` 找到 agent SQLite，不需要预先知道 agent 名称。相对路径以 OpenClaw 目录为准，registry DB 放到自定义位置时也能正常解析。

会话用量只读 `transcript_events.event_json`。条件很窄：`message.role == "assistant"`，并且存在 `message.usage`。日期取事件时间；模型按 `responseModel`、`message.model`、`session_windows.model` 依次回退。遇到价格表里没有的模型，就保留原名，成本记 0，不猜成某个公共模型。

迁移期可能同时留下 SQLite、旧 JSONL 和归档副本。扫描器会按 session 比较这些副本，选 token 和 usage 记录更完整的一份；两边相同时用 SQLite。`.trajectory.jsonl`、FTS 和没有 usage 的事件不会进统计。

原来的 `task_runs` 统计和旧任务数据库回退都保留。agent DB 的缓存签名加入 WAL；OpenClaw 的缓存和账本记录各自带版本，旧口径即使留下了更高的重复值，也能按新版本重算。Swift 端新增的 `reason` 按可选字段解码，旧设备快照缺这个字段时按 0 处理。

## 真机验证

验证是在一台真实运行 OpenClaw 2026.8.1 的主机上完成的。全局 registry 找到 1 个 schema v19 agent DB；库里有 40 条 transcript event，其中 11 条是带 usage 的 assistant 消息，分属 2 个 session。

直接解析这 11 条事件得到：

- input：387,068
- output：2,524
- cache read：2,304
- cache write：0
- reasoning：0
- 合计：391,896

11 条事件的 `totalTokens` 合计也是 391,896，逐条对比没有一处不一致。最终版 scanner 在同一台机器上得到 391,896 token、2 个 session 和 149 个 task，和直接查库的结果相同。

这台机器的 FTS 表有 8 行，trajectory 表有 14 行；两者都没有被计入。40 条事件的时间戳全部与 `transcript_events.created_at` 对上，坏 JSON 为 0。agent DB 的 WAL 已进入缓存签名，数据库没有变化时第二次扫描直接使用缓存。

验证过程只打开只读 SQLite，并在内存里运行 scanner。OpenClaw 数据、Tokei scan cache 和 ledger 的文件时间与大小都没有变化，也没有创建 probe 文件。随后已把最终脚本安装到远端 `~/.tokei/usage.30s.py`，SHA-256 为 `782e33ab576e50ed690c5fc467db0a8a4b44ab3abd1d6e37a5a89109c6d0f51f`；旧脚本保留了带时间戳的备份。没有手动运行 `sync.sh`，下一次计划任务会使用新脚本。

真实样本里 11 条 usage 都带 `cost` 对象，但 `cost.total` 均为 0，所以“日志自带正成本优先”这条分支没有真实正值可核对。价格回退和 reasoning 成本由合成测试覆盖。

## 兼容性与隐私

旧 JSONL 和旧任务数据库仍可用。SQLite 连接使用 `mode=ro` 和 `PRAGMA query_only=ON`，没有新增网络请求。测试中的事件、模型名和消息内容都是合成数据；PR 不包含真实模型、provider、endpoint、凭据或会话正文。

## 测试

- 隔离 `HOME`、`TMPDIR` 后运行完整 Python suite：248/248
- `swift build --package-path Tokei`
- `bash Tokei/Tests/run-sync-integration-checks.sh`：17/17
- `ocr` 完整审查基础提交 8/8 个文件；修复相对路径问题后复审 2/2 个文件，0 findings

本地没有跑 Release 配置构建。PR 目前没有 GitHub Actions 结果，仍保持 Draft。

## 检查

- [x] 完整测试和真机对账通过
- [x] 文档已更新
- [x] 没有带入真实会话或凭据
- [ ] GitHub Actions
