### PR TITLE
fix(zed): 修复登录态读取与额度查询

### DIFF
--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -407,7 +407,7 @@ struct PanelView: View {
                          tint: Theme.zed, presentation: .compactStatus,
                          content: AnyView(providerQuotaBlock(
                             "Zed", quota: u.zed, tint: Theme.zed,
-                            setupHint: "请先在 Zed 中登录 GitHub；Tokei 会无弹窗读取现有 Keychain 登录态。"))),
+                            setupHint: "请先在 Zed 中登录 GitHub，再到设置的「Provider 额度」中授权读取登录态。"))),
             ToolCardItem(id: "sub2api", name: "Sub2API", visible: showSub2API, active: showSub2API,
                          tint: Theme.sub2api, presentation: .compactStatus,
                          content: AnyView(providerQuotaBlock(
@@ -2364,6 +2364,8 @@ struct PanelView: View {
     @State private var providerSettingsResult = ""
     @State private var grokBotAuthorizing = false
     @State private var grokBotAuthorizationResult = ""
+    @State private var zedAuthorizing = false
+    @State private var zedAuthorizationResult = ""
     @AppStorage("syncDir") private var syncDir = ""
     @AppStorage("deviceName") private var deviceName = ""
     @State private var configuredDeviceID: String?
@@ -2631,10 +2633,29 @@ struct PanelView: View {
 
     var settingsProviderQuotaSection: some View {
         settingsSection("key.horizontal.fill", "Provider 额度") {
-            Text("Cursor 复用 Cursor.app 登录态，Zed 复用 Zed Keychain；两者无需在 Tokei 中保存密钥。显示对应卡片即允许查询。")
+            Text("Cursor 复用 Cursor.app 登录态；Zed 首次使用需允许 Tokei 读取其 Keychain 登录态。Tokei 不保存这些登录密钥。")
                 .font(.system(size: 8.5))
                 .foregroundStyle(Theme.tTertiary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            if showZed {
+                HStack(spacing: 8) {
+                    settingsActionButton(
+                        icon: "key.fill",
+                        title: zedAuthorizing ? "等待授权…" : "授权 Zed"
+                    ) {
+                        authorizeZedQuota()
+                    }
+                    .disabled(zedAuthorizing)
+                    if zedAuthorizing { ProgressView().controlSize(.mini) }
+                    if !zedAuthorizationResult.isEmpty {
+                        Text(zedAuthorizationResult)
+                            .font(.system(size: 8.5))
+                            .foregroundStyle(Theme.tTertiary)
+                            .lineLimit(2)
+                    }
+                }
+            }
 
             thinDivider
 
@@ -2779,6 +2800,42 @@ struct PanelView: View {
         loadProviderSettings()
         providerSettingsResult = "已清除"
         store.refresh()
+    }
+
+    private func authorizeZedQuota() {
+        guard !zedAuthorizing, let executable = Bundle.main.executableURL else { return }
+        zedAuthorizing = true
+        zedAuthorizationResult = ""
+        DispatchQueue.global(qos: .userInitiated).async {
+            func run(_ argument: String) -> Bool {
+                let process = Process()
+                process.executableURL = executable
+                process.arguments = [argument]
+                process.standardInput = FileHandle.nullDevice
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    return process.terminationStatus == 0
+                } catch {
+                    return false
+                }
+            }
+            let interactiveSucceeded = run("--zed-authorize")
+            let persistentSucceeded = interactiveSucceeded && run("--zed-verify")
+            DispatchQueue.main.async {
+                zedAuthorizing = false
+                if persistentSucceeded {
+                    zedAuthorizationResult = "授权成功，正在刷新 Zed 额度"
+                    store.refresh()
+                } else if interactiveSucceeded {
+                    zedAuthorizationResult = "仅允许了本次读取，请重新授权并选择“始终允许”"
+                } else {
+                    zedAuthorizationResult = "未授权，或 Zed 尚未登录"
+                }
+            }
+        }
     }
 
     private static func validSub2APIBaseURL(_ value: String) -> Bool {

--- a/Tokei/Sources/Tokei/ProviderCredentialStore.swift
+++ b/Tokei/Sources/Tokei/ProviderCredentialStore.swift
@@ -63,6 +63,20 @@ enum ProviderCredentialStore {
         case value(String)
     }
 
+    static func runIfRequested() -> Bool {
+        if CommandLine.arguments.contains("--zed-authorize") {
+            let ok = zedCredentials(allowInteraction: true) != nil
+            print(ok ? "ok" : "unavailable")
+            exit(ok ? 0 : 2)
+        }
+        if CommandLine.arguments.contains("--zed-verify") {
+            let ok = zedCredentials() != nil
+            print(ok ? "ok" : "unavailable")
+            exit(ok ? 0 : 2)
+        }
+        return false
+    }
+
     static func token(for provider: ProviderSecret) -> String? {
         switch tokenLookup(for: provider, service: service) {
         case .value(let value): return value
@@ -183,7 +197,9 @@ enum ProviderCredentialStore {
         }
     }
 
-    private static func zedCredentials() -> (userID: String, accessToken: String)? {
+    private static func zedCredentials(
+        allowInteraction: Bool = false
+    ) -> (userID: String, accessToken: String)? {
         let url = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/zed/settings.json")
         let settings = (try? Data(contentsOf: url))
@@ -200,19 +216,26 @@ enum ProviderCredentialStore {
             .first ?? "https://zed.dev"
 
         if let credentials = queryZedCredentials(
-            itemClass: kSecClassInternetPassword, attribute: kSecAttrServer, value: serviceURL
+            itemClass: kSecClassInternetPassword,
+            attribute: kSecAttrServer,
+            value: serviceURL,
+            allowInteraction: allowInteraction
         ) {
             return credentials
         }
         return queryZedCredentials(
-            itemClass: kSecClassGenericPassword, attribute: kSecAttrService, value: serviceURL
+            itemClass: kSecClassGenericPassword,
+            attribute: kSecAttrService,
+            value: serviceURL,
+            allowInteraction: allowInteraction
         )
     }
 
     private static func queryZedCredentials(
         itemClass: CFTypeRef,
         attribute: CFString,
-        value: String
+        value: String,
+        allowInteraction: Bool
     ) -> (userID: String, accessToken: String)? {
         var query: [String: Any] = [
             kSecClass as String: itemClass,
@@ -221,10 +244,17 @@ enum ProviderCredentialStore {
             kSecReturnAttributes as String: true,
             kSecReturnData as String: true,
         ]
-        applyNoUI(to: &query)
+        if !allowInteraction {
+            applyNoUI(to: &query)
+        }
         var result: AnyObject?
-        let status = withoutKeychainUI {
-            SecItemCopyMatching(query as CFDictionary, &result)
+        let status: OSStatus
+        if allowInteraction {
+            status = SecItemCopyMatching(query as CFDictionary, &result)
+        } else {
+            status = withoutKeychainUI {
+                SecItemCopyMatching(query as CFDictionary, &result)
+            }
         }
         guard status == errSecSuccess,
               let item = result as? [String: Any],

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -529,6 +529,10 @@ if GrokBotQuotaBridge.runIfRequested() {
     exit(0)
 }
 
+if ProviderCredentialStore.runIfRequested() {
+    exit(0)
+}
+
 if LoginItemCommandLine.runIfRequested() {
     exit(0)
 }

--- a/tests/test_provider_quotas.py
+++ b/tests/test_provider_quotas.py
@@ -254,6 +254,38 @@ class ProviderQuotaTests(unittest.TestCase):
         self.assertEqual(unlimited["windows"][0]["used_pct"], 0.0)
         self.assertEqual(unlimited["windows"][0]["detail"], "Unlimited")
 
+    def test_zed_lists_plans_for_each_organization(self):
+        payload = {
+            "user": {"github_login": "octocat", "name": "Octo Cat"},
+            "default_organization_id": 10,
+            "organizations": [
+                {"id": 10, "name": "Octo's Organization", "is_personal": True},
+                {"id": 20, "name": "Zed VIP", "is_personal": False},
+            ],
+            "plans_by_organization": {
+                "10": "zed_student",
+                "20": "zed_vip",
+            },
+            "plan": {
+                "plan_v3": "zed_student",
+                "usage": {"edit_predictions": {"used": 2, "limit": {"limited": 10}}},
+            },
+        }
+
+        quota = USAGE._normalize_zed_quota(payload)
+
+        self.assertEqual(quota["plan"], "Zed Student + Zed VIP")
+        self.assertEqual(quota["details"], [
+            {"label": "账号", "value": "Octo Cat"},
+            {
+                "label": "Octo's Organization",
+                "value": "Zed Student",
+                "secondary": "当前组织",
+            },
+            {"label": "Zed VIP", "value": "Zed VIP"},
+        ])
+        self.assertEqual(quota["windows"][0]["used_pct"], 20.0)
+
     def test_zed_settings_reject_cross_origin_credentials(self):
         trusted = USAGE._zed_connection_settings({
             "credentials_url": "zed-preview-key",
@@ -283,6 +315,7 @@ class ProviderQuotaTests(unittest.TestCase):
         def request(url, **kwargs):
             self.assertEqual(url, "https://cloud.zed.dev/client/users/me")
             self.assertEqual(kwargs["headers"]["Authorization"], "42 zed-token")
+            self.assertEqual(kwargs["headers"]["User-Agent"], "Tokei/1.0")
             return payload
 
         with tempfile.TemporaryDirectory() as tmp:

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -5260,7 +5260,8 @@ def _zed_plan_name(raw):
     names = {
         "zed_free": "Zed Free", "zed_pro": "Zed Pro",
         "zed_pro_trial": "Zed Pro Trial", "zed_student": "Zed Student",
-        "zed_business": "Zed Business",
+        "zed_business": "Zed Business", "student": "Student",
+        "vip": "VIP", "zed_vip": "Zed VIP",
     }
     if not isinstance(raw, str) or not raw.strip():
         return None
@@ -5308,9 +5309,37 @@ def _normalize_zed_quota(payload, updated=None):
     details = []
     if isinstance(user.get("name"), str) and user["name"].strip():
         details.append({"label": "账号", "value": user["name"].strip()})
+    organization_plans = payload.get("plans_by_organization")
+    organization_plans = organization_plans if isinstance(organization_plans, dict) else {}
+    default_organization_id = payload.get("default_organization_id")
+    default_organization_id = str(default_organization_id) \
+        if isinstance(default_organization_id, (str, int)) \
+        and not isinstance(default_organization_id, bool) else None
+    plan_names = []
+    for organization in payload.get("organizations", []):
+        if not isinstance(organization, dict):
+            continue
+        organization_id = organization.get("id")
+        organization_id = str(organization_id) \
+            if isinstance(organization_id, (str, int)) \
+            and not isinstance(organization_id, bool) else None
+        name = organization.get("name")
+        name = name.strip() if isinstance(name, str) and name.strip() else None
+        if not organization_id or not name:
+            continue
+        plan_name = _zed_plan_name(organization_plans.get(organization_id))
+        if not plan_name:
+            continue
+        if plan_name not in plan_names:
+            plan_names.append(plan_name)
+        detail = {"label": name, "value": plan_name}
+        if organization_id == default_organization_id:
+            detail["secondary"] = "当前组织"
+        details.append(detail)
+    displayed_plan = " + ".join(plan_names) if plan_names else _zed_plan_name(plan.get("plan_v3"))
     return {
-        "available": bool(windows or plan),
-        "plan": _zed_plan_name(plan.get("plan_v3")),
+        "available": bool(windows or plan or plan_names),
+        "plan": displayed_plan,
         "account": user.get("github_login"),
         "windows": windows,
         "details": details,
@@ -5333,7 +5362,11 @@ def fetch_zed_quota():
         return cached
     try:
         payload = _provider_json_request(
-            connection["api_url"], headers={"Authorization": f"{user_id} {token}"})
+            connection["api_url"], headers={
+                "Authorization": f"{user_id} {token}",
+                # Zed Cloud rejects urllib's default Python-urllib/... user agent.
+                "User-Agent": "Tokei/1.0",
+            })
         quota = _normalize_zed_quota(payload)
         _save_provider_quota_cache("zed", marker, quota)
         return quota


### PR DESCRIPTION
Fixes #77

### 问题

Zed 已登录且 Keychain 中存在凭据时，Tokei 仍可能因缺少读取权限而提示先登录。原有流程只尝试静默读取，未提供主动授权入口。

### 改动

- 在 Provider 额度设置中增加 Zed 授权按钮，仅在用户主动点击后允许系统弹出 Keychain 授权提示。
- 授权后启动独立进程验证能否静默读取，并在成功后刷新额度；日常后台读取继续禁止授权弹窗。
- 为 Zed 额度请求设置明确的 `User-Agent: Tokei/1.0`，用于解决默认 Python User-Agent 被拒绝的问题。
- 同时补充多组织套餐展示、当前组织标记及 Student/VIP 套餐名称映射。

### 验证

- 新增多组织套餐展示测试，并在已有请求测试中补充 User-Agent 断言。
- 本次提交 PR 前已核对与上游的差异，仅包含这一项提交；未重新运行测试或编译 Swift 应用。
- Keychain 的拒绝、单次允许、始终允许及重启后静默读取流程仍需实机验证。
