### PR TITLE
feat(kimi): Kimi Code 官方额度(5h 滚动窗口 + 订阅周期)

### DIFF
--- a/CALCULATION.md
+++ b/CALCULATION.md
@@ -26,6 +26,7 @@ Tokei 主要读取本地 AI 工具日志，统计 token 用量与成本。额度
 | Qwen Code | `${QWEN_RUNTIME_DIR:-~/.qwen}/usage/token-usage-*.jsonl` + `~/.qwen/usage_record.jsonl` | JSONL,逐请求记录 + 会话汇总 |
 | 千问办公（QwenWork） | `~/.qwenworkcn/mcp-adaptor.config` + `.status.json` 文件元数据 + 官方桌面端 `127.0.0.1` MCP | JSON-RPC，`qw_query` / `qwenwork.usage`（默认关闭） |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/*/wire.jsonl`；兼容旧版 `${KIMI_SHARE_DIR:-~/.kimi}/sessions/*/*/wire.jsonl` | JSONL, protocol 1.5 `usage.record` / protocol 1 `StatusUpdate.token_usage` |
+| Kimi Code(额度) | `${KIMI_CODE_HOME:-~/.kimi-code}/credentials/kimi-code.json` → `api.kimi.com/coding/v1/usages` | 本机登录态只读查询，见 §5 |
 | ZCode | `~/.zcode/cli/db/db.sqlite` | SQLite, `model_usage` Token 明细 |
 | MiMoCode | `$XDG_DATA_HOME/mimocode/mimocode*.db`，macOS 使用 `~/Library/Application Support/mimocode/` | SQLite, OpenCode-compatible `message` 数据 |
 
@@ -300,6 +301,36 @@ Pi 优先使用会话 JSONL 中的 `usage.cost.total`；OpenCode 优先读取 SQ
 ID、邀请信息或个人资料；每天最多自动查询一次，最近一张卡到期后立即更新，失败后
 6 小时再试。未登录或仅使用 API Key 时不请求；401/403 静默隐藏或沿用未过期缓存，
 Codex 刷新登录 Token 后立即重试。
+
+### Kimi Code(usages)
+
+使用 Kimi Code CLI 已有的本机登录态只读查询 `https://api.kimi.com/coding/v1/usages`:
+- `p5` — 5 小时滚动窗口已用百分比,取 `limits[]` 中 `window` 折算为 300 分钟的那条
+  (`TIME_UNIT_MINUTE`/`TIME_UNIT_HOUR` 均按同一口径折算,不假设接口固定用哪种单位)
+- `pw` — 订阅周期额度已用百分比,取顶层 `usage`
+- `r5` / `rw` — 各自的 `resetTime`
+- `plan` — `user.membership.level`
+
+接口把额度数字写成字符串(`"limit": "100"`),解析时统一转数值;`used` 缺失时按
+`limit - remaining` 推算。顶层 `usage` 不带 `window` 字段,接口没有说明该额度是周还是月,
+因此界面只显示"订阅额度剩余"和它给出的重置时刻,不替接口命名周期。
+
+**凭据只读、绝不代刷。** access_token 由 CLI 写在
+`${KIMI_CODE_HOME:-~/.kimi-code}/credentials/kimi-code.json`,有效期很短(实测约 30 分钟)。
+Tokei 只读 `access_token`,从不使用同一文件中的 `refresh_token`:OAuth 刷新令牌通常带
+rotation,由 Tokei 抢先刷新会顶掉 Kimi Code 自己的登录态。因此凭据过期时直接跳过这次
+请求(发出去也必然 401),转为使用缓存并标记读数已过期。
+
+额度过期的判定有两条,命中任一即标 `p5_stale` / `pw_stale`,卡片改为显示"额度读数已过期"
+并附上读数时间:
+- 窗口的 `resetTime` 已经过去 —— 这份读数不再代表当前窗口
+- 读数本身超过 30 分钟未更新 —— 通常是 CLI 长时间未使用,登录态已过期
+
+Codex 在窗口翻篇后若本机零消耗会判定"确实回满",Kimi 不套用这条:Kimi 额度按调用次数
+计量,本机 token 日志无法反推它的真实消耗,谎报满额比承认不知道危险得多。
+
+成功查询缓存 5 分钟;网络失败后 5 分钟内不再重试,避免每轮 30 秒刷新都白等超时。
+可用 `TOKEI_KIMI_LIVE_QUOTA=0` 完全关闭该查询,关闭后 token 用量统计不受影响。
 
 ### Grok Build(credits)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪 20+ 款 AI 编程工具
 | **千问办公（QwenWork）** | 套餐与加购积分余额、团队共享资源包 |
 | **Qoder** | Token、调用次数、配额 |
 | **QoderWork** | Token、调用次数、配额 |
-| **Kimi Code** | Token（输入/输出/缓存）、会话、模型、项目 |
+| **Kimi Code** | Token（输入/输出/缓存）、会话、模型、项目、配额（5h / 订阅周期） |
 
 ## 功能一览
 
@@ -97,6 +97,7 @@ Tokei 是一款 **macOS 菜单栏应用**，实时追踪 20+ 款 AI 编程工具
 ### 隐私优先
 - 核心 Token、成本和项目统计均在本机完成，不向 Tokei 服务上传使用数据；Cursor 与 z.ai 还可读取对应 Provider 返回的账号级 Token/模型摘要
 - Codex 额度使用本机 Codex 登录态读取官方接口；重置卡每天最多自动查询一次
+- Kimi Code 额度使用 Kimi Code CLI 已有的本机登录态读取官方接口。Tokei 只读 `access_token`，从不使用同目录的 `refresh_token` 代为刷新（避免顶掉 CLI 自己的登录态）；登录态过期时直接跳过查询，卡片改为标注读数已过期而不是继续显示旧百分比。可用 `TOKEI_KIMI_LIVE_QUOTA=0` 关闭
 - Grok 实时额度默认关闭，可选择只读本地日志
 - Grok Bot 本地活动直接读取会话快照，快照不含 Token、模型和成本，Tokei 不按文本量估算。官方用量查询默认关闭；用户明确授权后，Tokei 临时解密 Grok Bot 当前登录态，只查询 `sand` 客户端的官方 Token、模型、成本和额度。登录 Token 只在内存中使用
 - 千问办公额度默认关闭；开启后仅调用官方桌面端的 `127.0.0.1` MCP，由已运行并登录的千问办公查询官方额度
@@ -205,7 +206,7 @@ chmod +x ~/.tokei/tokei-sync.sh
 | 千问办公（QwenWork） | `~/.qwenworkcn/mcp-adaptor.config` + `.status.json` 文件元数据 + 官方桌面端 `127.0.0.1` MCP（默认关闭；需客户端运行且已登录） |
 | Qoder | `~/.qodo-ai/sessions/*.jsonl` |
 | QoderWork | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
-| Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/*/wire.jsonl`；兼容旧版 `${KIMI_SHARE_DIR:-~/.kimi}/sessions/*/*/wire.jsonl` |
+| Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/*/wire.jsonl`；兼容旧版 `${KIMI_SHARE_DIR:-~/.kimi}/sessions/*/*/wire.jsonl`；额度用本机登录态查 `api.kimi.com/coding/v1/usages` |
 | Qoder Desktop | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` |
 | QoderWork | `~/Library/Application Support/QoderWork/data/agents.db` |
 | Qoder CLI | `~/.qoder/projects/**/*.jsonl` |

--- a/Tokei/Sources/Tokei/MenuBarStyle.swift
+++ b/Tokei/Sources/Tokei/MenuBarStyle.swift
@@ -69,6 +69,8 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
     case claudeFable
     case codex5h
     case codexWeek
+    case kimi5h
+    case kimiSubscription
     case grok
 
     var id: String { rawValue }
@@ -80,6 +82,8 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
         case .claudeFable: return "Claude Fable"
         case .codex5h: return "Codex 5h"
         case .codexWeek: return "Codex 周"
+        case .kimi5h: return "Kimi 5h"
+        case .kimiSubscription: return "Kimi 订阅"
         case .grok: return "Grok"
         }
     }
@@ -92,6 +96,8 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
         case .claudeFable: return "menuBarQuotaClaudeFable"
         case .codex5h: return "menuBarQuotaCodex5h"
         case .codexWeek: return "menuBarQuotaCodex"
+        case .kimi5h: return "menuBarQuotaKimi5h"
+        case .kimiSubscription: return "menuBarQuotaKimiSubscription"
         case .grok: return "menuBarQuotaGrok"
         }
     }
@@ -100,7 +106,7 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
     var defaultEnabled: Bool {
         switch self {
         case .claude5h, .codexWeek: return true
-        case .claudeWeek, .claudeFable, .codex5h, .grok: return false
+        case .claudeWeek, .claudeFable, .codex5h, .kimi5h, .kimiSubscription, .grok: return false
         }
     }
 
@@ -113,9 +119,9 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
     /// Grok 的窗口随数据在周/月之间变，画不出确定的符号，所以不给它符号。
     var window: MenuBarQuotaWindow? {
         switch self {
-        case .claude5h, .codex5h: return .fiveHour
+        case .claude5h, .codex5h, .kimi5h: return .fiveHour
         case .claudeWeek, .claudeFable, .codexWeek: return .week
-        case .grok: return nil
+        case .kimiSubscription, .grok: return nil
         }
     }
 
@@ -125,6 +131,7 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
         case .claude5h, .claudeWeek: return AppDelegate.claudeColor
         case .claudeFable: return .systemOrange
         case .codex5h, .codexWeek: return AppDelegate.codexColor
+        case .kimi5h, .kimiSubscription: return AppDelegate.kimicodeColor
         case .grok: return AppDelegate.grokColor
         }
     }
@@ -134,6 +141,7 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
         case .claude5h, .claudeWeek: return Theme.claude
         case .claudeFable: return .orange
         case .codex5h, .codexWeek: return Theme.codex
+        case .kimi5h, .kimiSubscription: return Theme.kimicode
         case .grok: return Theme.grok
         }
     }
@@ -146,6 +154,8 @@ enum MenuBarQuotaSource: String, CaseIterable, Identifiable {
         case .claudeFable: return (usage.claude.qf, usage.claude.qf_stale)
         case .codex5h: return (usage.codex.p5, usage.codex.p5_stale)
         case .codexWeek: return (usage.codex.pw, usage.codex.pw_stale)
+        case .kimi5h: return (usage.kimicode.p5, usage.kimicode.p5_stale)
+        case .kimiSubscription: return (usage.kimicode.pw, usage.kimicode.pw_stale)
         case .grok: return (usage.grok.pct, usage.grok.stale)
         }
     }

--- a/Tokei/Sources/Tokei/Model.swift
+++ b/Tokei/Sources/Tokei/Model.swift
@@ -726,6 +726,23 @@ struct TokenUsageRanges: Codable {
 }
 struct TokenUsageStat: Codable { var ranges: TokenUsageRanges }
 
+/// Kimi Code 既有本地 token 统计,也有官方额度(5h 滚动窗口 + 订阅周期)。
+/// 订阅窗口的周期长度接口没有给,因此只透传它返回的重置时刻,不替它命名周期。
+struct KimiCodeStat: Codable {
+    var ranges: TokenUsageRanges
+    var p5: Double? = nil
+    var pw: Double? = nil
+    var r5: Int? = nil
+    var rw: Int? = nil
+    var q_updated: Int? = nil
+    var p5_stale: Bool? = nil
+    var pw_stale: Bool? = nil
+    var plan: String? = nil
+
+    var hasQuota: Bool { p5 != nil || pw != nil }
+    var hasStaleQuota: Bool { p5_stale == true || pw_stale == true }
+}
+
 /// A single quota bucket reported by the QwenWork desktop app.
 /// `total == 0` does not imply that the bucket is empty: some plans expose
 /// only an absolute remaining-credit balance.
@@ -911,7 +928,7 @@ struct Usage: Codable {
     var opencode: TokenUsageStat
     var qwencode: TokenUsageStat
     var qwenwork: QwenWorkQuota
-    var kimicode: TokenUsageStat
+    var kimicode: KimiCodeStat
     var antigravity: ProviderQuotaStat
     var cursor: ProviderQuotaStat
     var zed: ProviderQuotaStat
@@ -952,7 +969,7 @@ struct Usage: Codable {
         opencode = try c.decode(TokenUsageStat.self, forKey: .opencode)
         qwencode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .qwencode) ?? TokenUsageStat(ranges: .empty)
         qwenwork = (try? c.decodeIfPresent(QwenWorkQuota.self, forKey: .qwenwork)) ?? QwenWorkQuota()
-        kimicode = try c.decodeIfPresent(TokenUsageStat.self, forKey: .kimicode) ?? TokenUsageStat(ranges: .empty)
+        kimicode = try c.decodeIfPresent(KimiCodeStat.self, forKey: .kimicode) ?? KimiCodeStat(ranges: .empty)
         antigravity = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .antigravity) ?? ProviderQuotaStat()
         cursor = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .cursor) ?? ProviderQuotaStat()
         zed = try c.decodeIfPresent(ProviderQuotaStat.self, forKey: .zed) ?? ProviderQuotaStat()

--- a/Tokei/Sources/Tokei/PanelView.swift
+++ b/Tokei/Sources/Tokei/PanelView.swift
@@ -83,6 +83,8 @@ struct PanelView: View {
     @AppStorage(MenuBarQuotaSource.claudeFable.defaultsKey) private var menuBarQuotaClaudeFable = false
     @AppStorage(MenuBarQuotaSource.codex5h.defaultsKey) private var menuBarQuotaCodex5h = false
     @AppStorage(MenuBarQuotaSource.codexWeek.defaultsKey) private var menuBarQuotaCodexWeek = true
+    @AppStorage(MenuBarQuotaSource.kimi5h.defaultsKey) private var menuBarQuotaKimi5h = false
+    @AppStorage(MenuBarQuotaSource.kimiSubscription.defaultsKey) private var menuBarQuotaKimiSubscription = false
     @AppStorage(MenuBarQuotaSource.grok.defaultsKey) private var menuBarQuotaGrok = false
     @State private var copyFeedback = false
     @State private var copiedToolID: String?
@@ -490,8 +492,9 @@ struct PanelView: View {
                              u.qwenwork.remaining != nil || !u.qwenwork.segments.isEmpty ||
                              u.qwenwork.shared != nil,
                          tint: Theme.qwenwork, content: AnyView(qwenWorkBlock(u.qwenwork))),
-            ToolCardItem(id: "kimicode", name: "Kimi Code", visible: showKimiCode, active: kcr.sessions > 0,
-                         tint: Theme.kimicode, content: AnyView(tokenUsageBlock(title: "Kimi Code", kcr, tint: Theme.kimicode, modelsOpen: $kimiCodeModelsOpen, showsCost: false, toolID: "kimicode"))),
+            ToolCardItem(id: "kimicode", name: "Kimi Code", visible: showKimiCode,
+                         active: kcr.sessions > 0 || u.kimicode.hasQuota || u.kimicode.hasStaleQuota,
+                         tint: Theme.kimicode, content: AnyView(kimiCodeBlock(u.kimicode, kcr))),
         ]
     }
 
@@ -673,6 +676,69 @@ struct PanelView: View {
                     source: "Codex 本地状态",
                     updated: nil,
                     tint: Theme.codex
+                )
+            }
+        }
+    }
+
+    // MARK: - Kimi Code 卡片
+    // 额度来自官方 usages 接口,登录态由 Kimi Code CLI 自己刷新(有效期很短),
+    // 因此这里必须能表达"读数已过期",而不是把上一次的百分比一直显示下去。
+    @ViewBuilder
+    func kimiCodeBlock(_ x: KimiCodeStat, _ r: TokenUsageRange) -> some View {
+        VStack(alignment: .leading, spacing: 11) {
+            cardHead("Kimi Code", tint: Theme.kimicode, sessions: r.sessions, toolID: "kimicode")
+            if r.sessions > 0 {
+                CostHeadline(value: Fmt.human(r.in + r.out + r.cr + r.cw + r.reason),
+                             caption: "\(sel.label) 总量", tint: Theme.kimicode)
+                metricGrid([], hit: r.hit, extra: tokenUsageMetrics(r), tint: Theme.kimicode)
+                if !r.models.isEmpty {
+                    tokenModelDisclosure(r.models, open: $kimiCodeModelsOpen, tint: Theme.kimicode)
+                }
+            } else if x.hasQuota {
+                usageEmptyHint
+            } else {
+                emptyHint
+            }
+            if x.hasQuota || x.hasStaleQuota {
+                thinDivider
+            }
+            if let p5 = x.p5, x.p5_stale != true {
+                quotaRow(title: "5h 剩余", pct: 100 - p5, reset: x.r5, tint: Theme.kimicode)
+            }
+            if let pw = x.pw, x.pw_stale != true {
+                // 接口只给了这一档的重置时刻,没有说周期是周还是月,所以标题不写周期名。
+                quotaRow(title: "订阅额度剩余", pct: 100 - pw, reset: x.rw, tint: Theme.kimicode)
+            }
+            if x.hasStaleQuota {
+                quotaStateNotice(
+                    title: "额度读数已过期",
+                    detail: "Kimi Code 的登录态很快到期,过期后 Tokei 不再查询官方额度,也不会代它刷新。在 Kimi Code 里发一条消息即可让它自行刷新,额度随后恢复更新。",
+                    source: "api.kimi.com",
+                    updated: x.q_updated,
+                    tint: Theme.kimicode,
+                    warning: true
+                )
+            }
+            if let plan = x.plan, !plan.isEmpty {
+                HStack {
+                    Text("plan").font(.system(size: 11)).foregroundStyle(Theme.tTertiary)
+                    Spacer()
+                    Text(plan.replacingOccurrences(of: "LEVEL_", with: ""))
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Theme.tSecondary)
+                        .padding(.horizontal, 7).padding(.vertical, 2)
+                        .background(Capsule().fill(Theme.kimicode.opacity(0.16)))
+                }
+            }
+            if r.sessions > 0 && !x.hasQuota && !x.hasStaleQuota {
+                thinDivider
+                quotaStateNotice(
+                    title: "暂未获取到额度数据",
+                    detail: "用量统计不受影响；登录 Kimi Code 后会自动展示官方额度。",
+                    source: "Kimi Code 本地登录态",
+                    updated: nil,
+                    tint: Theme.kimicode
                 )
             }
         }
@@ -2448,6 +2514,8 @@ struct PanelView: View {
         case .claudeFable: return $menuBarQuotaClaudeFable
         case .codex5h: return $menuBarQuotaCodex5h
         case .codexWeek: return $menuBarQuotaCodexWeek
+        case .kimi5h: return $menuBarQuotaKimi5h
+        case .kimiSubscription: return $menuBarQuotaKimiSubscription
         case .grok: return $menuBarQuotaGrok
         }
     }

--- a/Tokei/Sources/Tokei/main.swift
+++ b/Tokei/Sources/Tokei/main.swift
@@ -238,6 +238,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     static let claudeColor = NSColor(red: 0.92, green: 0.52, blue: 0.40, alpha: 1)
     static let codexColor  = NSColor(red: 0.42, green: 0.68, blue: 0.98, alpha: 1)
     static let grokColor   = NSColor(red: 0.65, green: 0.68, blue: 0.75, alpha: 1)
+    static let kimicodeColor = NSColor(red: 0.20, green: 0.78, blue: 0.66, alpha: 1)
 
     func applicationDidFinishLaunching(_ note: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)

--- a/site/index.html
+++ b/site/index.html
@@ -988,7 +988,7 @@ body::after{
       <div class="tool-card rv rv-d3" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,#32C7A8,#208D7C)">Ki</div>
         <h3>Kimi Code</h3>
-        <p><span class="en">Tokens, cache, models, subagents</span><span class="zh">Token · 缓存 · 模型 · 子 Agent</span></p>
+        <p><span class="en">Tokens, cache, models, quota</span><span class="zh">Token · 缓存 · 模型 · 额度</span></p>
       </div>
       <div class="tool-card rv rv-d4" data-tilt>
         <div class="tool-icon" style="background:linear-gradient(135deg,#D4A94E,#A97825)">QW</div>

--- a/tests/swift/MenuBarQuotaSourceCheck.swift
+++ b/tests/swift/MenuBarQuotaSourceCheck.swift
@@ -14,6 +14,7 @@ final class AppDelegate {
     static let claudeColor = NSColor(red: 0.92, green: 0.52, blue: 0.40, alpha: 1)
     static let codexColor  = NSColor(red: 0.42, green: 0.68, blue: 0.98, alpha: 1)
     static let grokColor   = NSColor(red: 0.65, green: 0.68, blue: 0.75, alpha: 1)
+    static let kimicodeColor = NSColor(red: 0.20, green: 0.78, blue: 0.66, alpha: 1)
 }
 
 @main
@@ -36,7 +37,7 @@ struct MenuBarQuotaSourceCheck {
     private static func checkSourceIdentity() throws {
         let order = MenuBarQuotaSource.allCases.map(\.rawValue)
         try expect(order == ["claude5h", "claudeWeek", "claudeFable",
-                             "codex5h", "codexWeek", "grok"],
+                             "codex5h", "codexWeek", "kimi5h", "kimiSubscription", "grok"],
                    "quota source order changed: \(order)")
 
         // 这两个 key 已经发布过，存的本来就是这两个窗口的开关。
@@ -54,7 +55,7 @@ struct MenuBarQuotaSourceCheck {
         // 标签必须写清是哪个窗口，这是用户能分辨谁是谁的前提。
         let labels = MenuBarQuotaSource.allCases.map(\.label)
         try expect(labels == ["Claude 5h", "Claude 周", "Claude Fable",
-                              "Codex 5h", "Codex 周", "Grok"],
+                              "Codex 5h", "Codex 周", "Kimi 5h", "Kimi 订阅", "Grok"],
                    "window labels changed: \(labels)")
 
         let defaultOn = MenuBarQuotaSource.allCases.filter(\.defaultEnabled).map(\.rawValue)
@@ -62,7 +63,7 @@ struct MenuBarQuotaSourceCheck {
                    "only the two historically-on windows may default on: \(defaultOn)")
 
         let windows = MenuBarQuotaSource.allCases.map(\.window)
-        try expect(windows == [.fiveHour, .week, .week, .fiveHour, .week, nil],
+        try expect(windows == [.fiveHour, .week, .week, .fiveHour, .week, .fiveHour, nil, nil],
                    "window kinds changed")
     }
 
@@ -116,18 +117,19 @@ struct MenuBarQuotaSourceCheck {
 
         let usage = try decodeFixture(fixtureJSON)
         let used = MenuBarQuotaSource.allCases.map { $0.reading(in: usage).value }
-        try expect(used == [20, 40, 10, 88, 35, 25], "reading mapped to the wrong field: \(used)")
+        try expect(used == [20, 40, 10, 88, 35, 15, 55, 25], "reading mapped to the wrong field: \(used)")
 
         // 模型里存已用百分比，状态栏显示剩余，别把 100-x 丢了。
         let metrics = MenuBarQuotaSource.metrics(in: usage)
-        try expect(metrics.map(\.value) == ["80", "60", "90", "12", "65", "75"],
+        try expect(metrics.map(\.value) == ["80", "60", "90", "12", "65", "85", "45", "75"],
                    "remaining conversion or order wrong: \(metrics.map(\.value))")
 
         // 账号没有这个窗口 → 整项不出现。
         var missingFable = usage
         missingFable.claude.qf = nil
         try expect(MenuBarQuotaSource.metrics(in: missingFable).map(\.kind.displayName)
-                    == ["Claude 5h", "Claude 周", "Codex 5h", "Codex 周", "Grok"],
+                    == ["Claude 5h", "Claude 周", "Codex 5h", "Codex 周",
+                        "Kimi 5h", "Kimi 订阅", "Grok"],
                    "a nil window must drop out entirely")
 
         // 数据过期 → 也不出现，别在状态栏上挂个陈旧数字。
@@ -337,6 +339,19 @@ struct MenuBarQuotaSourceCheck {
           "month": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
           "year": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []}
         }
+      },
+      "kimicode": {
+        "ranges": {
+          "today": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
+          "yesterday": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
+          "week": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
+          "last_week": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
+          "month": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []},
+          "year": {"hit": 0, "in": 0, "out": 0, "cr": 0, "cw": 0, "reason": 0, "cost": 0, "sessions": 0, "models": []}
+        },
+        "p5": 15,
+        "pw": 55,
+        "plan": "LEVEL_INTERMEDIATE"
       }
     }
     """

--- a/tests/test_kimi_quota.py
+++ b/tests/test_kimi_quota.py
@@ -1,0 +1,220 @@
+"""Kimi Code 官方额度:解析、缓存、以及"宁可说不知道也不谎报"的降级行为。"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from test_codex_limits import USAGE
+
+
+def iso(dt):
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+# 取自真实响应(api.kimi.com/coding/v1/usages):数字一律是字符串,
+# 5h 窗口在 limits[] 里按 TIME_UNIT_MINUTE/300 描述,顶层 usage 不带 window。
+def sample(now=None, five_used="2", sub_used="90"):
+    now = now or datetime.now(timezone.utc)
+    return {
+        "user": {"userId": "u-1", "membership": {"level": "LEVEL_INTERMEDIATE"}},
+        "usage": {
+            "limit": "100", "used": sub_used,
+            "remaining": str(100 - int(sub_used)),
+            "resetTime": iso(now + timedelta(days=1)),
+        },
+        "limits": [{
+            "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+            "detail": {
+                "limit": "100", "used": five_used,
+                "remaining": str(100 - int(five_used)),
+                "resetTime": iso(now + timedelta(hours=5)),
+            },
+        }],
+    }
+
+
+class KimiQuotaParseTests(unittest.TestCase):
+    def test_parses_string_numbers_from_real_payload(self):
+        limits = USAGE._kimi_live_to_limits(sample())
+        self.assertAlmostEqual(limits["five_hour"]["used_percent"], 2.0)
+        self.assertAlmostEqual(limits["subscription"]["used_percent"], 90.0)
+        self.assertEqual(limits["plan"], "LEVEL_INTERMEDIATE")
+        self.assertEqual(limits["user_id"], "u-1")
+
+    def test_five_hour_window_accepts_both_time_units(self):
+        self.assertEqual(USAGE._kimi_window_minutes(
+            {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"}), 300)
+        self.assertEqual(USAGE._kimi_window_minutes(
+            {"duration": 5, "timeUnit": "TIME_UNIT_HOUR"}), 300)
+        self.assertIsNone(USAGE._kimi_window_minutes(
+            {"duration": 5, "timeUnit": "TIME_UNIT_UNSPECIFIED"}))
+
+    def test_used_is_derived_when_only_remaining_is_given(self):
+        slot = USAGE._kimi_slot({"limit": "100", "remaining": "40"})
+        self.assertAlmostEqual(slot["used_percent"], 60.0)
+
+    def test_zero_limit_is_not_a_percentage(self):
+        self.assertIsNone(USAGE._kimi_slot({"limit": "0", "used": "0"}))
+
+    def test_payload_without_any_quota_returns_none(self):
+        self.assertIsNone(USAGE._kimi_live_to_limits({"user": {}, "limits": []}))
+
+    def test_non_five_hour_windows_are_ignored(self):
+        data = sample()
+        data["limits"][0]["window"] = {"duration": 1, "timeUnit": "TIME_UNIT_HOUR"}
+        limits = USAGE._kimi_live_to_limits(data)
+        self.assertIsNone(limits["five_hour"])
+        self.assertIsNotNone(limits["subscription"])
+
+
+class KimiQuotaStaleTests(unittest.TestCase):
+    def test_fresh_reading_is_not_stale(self):
+        now = int(datetime.now().timestamp())
+        limits = USAGE._kimi_live_to_limits(sample())
+        values = USAGE._kimi_quota_values(limits, now_epoch=now, updated_at=now)
+        self.assertFalse(values["p5_stale"])
+        self.assertFalse(values["pw_stale"])
+        self.assertAlmostEqual(values["p5"], 2.0)
+
+    def test_window_rollover_marks_stale_instead_of_reporting_full(self):
+        """窗口翻篇后不能显示"已回满" —— Kimi 额度按次计,本机无从反推真实消耗。"""
+        limits = {"five_hour": {"used_percent": 80.0, "resets_at": 1000},
+                  "subscription": {"used_percent": 90.0, "resets_at": 5000}}
+        values = USAGE._kimi_quota_values(limits, now_epoch=2000, updated_at=1900)
+        self.assertTrue(values["p5_stale"])
+        self.assertFalse(values["pw_stale"])
+        self.assertAlmostEqual(values["p5"], 80.0)
+
+    def test_old_reading_marks_stale_even_inside_window(self):
+        now = 100000
+        old = now - USAGE._KIMI_QUOTA_STALE_AFTER - 1
+        limits = {"five_hour": {"used_percent": 10.0, "resets_at": now + 3600},
+                  "subscription": {"used_percent": 20.0, "resets_at": now + 86400}}
+        values = USAGE._kimi_quota_values(limits, now_epoch=now, updated_at=old)
+        self.assertTrue(values["p5_stale"])
+        self.assertTrue(values["pw_stale"])
+
+    def test_missing_quota_is_not_stale(self):
+        values = USAGE._kimi_quota_values(None, now_epoch=1000, updated_at=1)
+        self.assertFalse(values["p5_stale"])
+        self.assertIsNone(values["p5"])
+
+
+class KimiQuotaFetchTests(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="kimi-quota-")
+        self.cache = os.path.join(self.home, "kimi_quota_cache.json")
+        self.creds_dir = os.path.join(self.home, "kimi", "credentials")
+        os.makedirs(self.creds_dir, exist_ok=True)
+        self.env = mock.patch.dict(
+            os.environ, {"TOKEI_KIMI_DIR": os.path.join(self.home, "kimi")}, clear=False)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.cache_patch = mock.patch.object(USAGE, "KIMI_QUOTA_CACHE", self.cache)
+        self.cache_patch.start()
+        self.addCleanup(self.cache_patch.stop)
+
+    def write_creds(self, expires_in_seconds):
+        path = os.path.join(self.creds_dir, "kimi-code.json")
+        with open(path, "w") as fh:
+            json.dump({
+                "access_token": "tok-" + str(expires_in_seconds),
+                "refresh_token": "refresh-should-never-be-used",
+                "expires_at": int(datetime.now().timestamp()) + expires_in_seconds,
+            }, fh)
+
+    def write_cache(self, age_seconds, used=42.0):
+        with open(self.cache, "w") as fh:
+            json.dump({
+                "fetched_at": datetime.now().timestamp() - age_seconds,
+                "limits": {
+                    "five_hour": {"used_percent": used,
+                                  "resets_at": int(datetime.now().timestamp()) + 3600},
+                    "subscription": {"used_percent": 90.0,
+                                     "resets_at": int(datetime.now().timestamp()) + 86400},
+                },
+                "plan": "LEVEL_INTERMEDIATE",
+                "user_id": "u-1",
+            }, fh)
+
+    def test_expired_token_never_hits_the_network(self):
+        """CLI 的登录态很短命。过期后发请求必然 401,更重要的是不能代刷 refresh_token。"""
+        self.write_creds(expires_in_seconds=-60)
+        self.write_cache(age_seconds=USAGE._KIMI_QUOTA_TTL + 10)
+        with mock.patch("urllib.request.urlopen") as opener:
+            result = USAGE.fetch_kimi_live_limits()
+        opener.assert_not_called()
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result[0]["five_hour"]["used_percent"], 42.0)
+
+    def test_refresh_token_is_never_read(self):
+        self.write_creds(expires_in_seconds=-60)
+        auth = USAGE._kimi_auth_context()
+        self.assertTrue(auth["expired"])
+        self.assertNotIn("refresh_token", auth)
+
+    def test_fresh_cache_short_circuits_before_reading_credentials(self):
+        self.write_cache(age_seconds=1)
+        with mock.patch("urllib.request.urlopen") as opener:
+            limits, plan, _ = USAGE.fetch_kimi_live_limits()
+        opener.assert_not_called()
+        self.assertEqual(plan, "LEVEL_INTERMEDIATE")
+        self.assertAlmostEqual(limits["five_hour"]["used_percent"], 42.0)
+
+    def test_live_fetch_writes_cache(self):
+        self.write_creds(expires_in_seconds=1800)
+        payload = json.dumps(sample()).encode()
+
+        class Res:
+            def __enter__(self_inner): return self_inner
+            def __exit__(self_inner, *a): return False
+            def geturl(self_inner): return USAGE._KIMI_USAGE_URL
+            def read(self_inner, *a): return payload
+
+        with mock.patch("urllib.request.urlopen", return_value=Res()):
+            limits, plan, fetched = USAGE.fetch_kimi_live_limits()
+        self.assertAlmostEqual(limits["subscription"]["used_percent"], 90.0)
+        self.assertEqual(plan, "LEVEL_INTERMEDIATE")
+        with open(self.cache) as fh:
+            saved = json.load(fh)
+        self.assertEqual(saved["user_id"], "u-1")
+        self.assertEqual(saved["source"], "live")
+
+    def test_redirect_off_host_is_rejected(self):
+        self.write_creds(expires_in_seconds=1800)
+
+        class Res:
+            def __enter__(self_inner): return self_inner
+            def __exit__(self_inner, *a): return False
+            def geturl(self_inner): return "https://evil.example.com/usages"
+            def read(self_inner, *a): return json.dumps(sample()).encode()
+
+        with mock.patch("urllib.request.urlopen", return_value=Res()):
+            self.assertIsNone(USAGE.fetch_kimi_live_limits())
+
+    def test_network_failure_falls_back_to_cache_and_backs_off(self):
+        self.write_creds(expires_in_seconds=1800)
+        self.write_cache(age_seconds=USAGE._KIMI_QUOTA_TTL + 10)
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            result = USAGE.fetch_kimi_live_limits()
+        self.assertIsNotNone(result)
+        with open(self.cache) as fh:
+            self.assertIn("last_failure_at", json.load(fh))
+
+    def test_disabled_by_env(self):
+        self.write_creds(expires_in_seconds=1800)
+        with mock.patch.dict(os.environ, {"TOKEI_KIMI_LIVE_QUOTA": "0"}):
+            with mock.patch("urllib.request.urlopen") as opener:
+                self.assertIsNone(USAGE.fetch_kimi_live_limits())
+            opener.assert_not_called()
+
+    def test_no_credentials_returns_none(self):
+        with mock.patch("urllib.request.urlopen") as opener:
+            self.assertIsNone(USAGE.fetch_kimi_live_limits())
+        opener.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -9260,6 +9260,266 @@ def _kimi_roots():
     return roots
 
 
+# ---------- Kimi Code 官方额度 ----------
+# 凭据由 Kimi Code CLI 自己写入并刷新;Tokei 只读、绝不代刷 —— refresh_token 通常带
+# rotation,抢刷会顶掉 CLI 自己的登录态。access_token 有效期很短(实测约 30 分钟),
+# 过期时直接走缓存并标 stale:显示一个过期读数比承认不知道危险得多(同 issue #63)。
+KIMI_QUOTA_CACHE = _writable_path("kimi_quota_cache.json")
+_KIMI_QUOTA_TTL = 300
+_KIMI_QUOTA_FALLBACK_TTL = 300
+_KIMI_QUOTA_STALE_AFTER = 1800
+_KIMI_USAGE_URL = "https://api.kimi.com/coding/v1/usages"
+_KIMI_USAGE_HOST = "api.kimi.com"
+_KIMI_USAGE_MAX_RESPONSE_BYTES = 256 * 1024
+_KIMI_FIVE_HOUR_MINUTES = 300
+_KIMI_TIME_UNITS = {
+    "TIME_UNIT_MINUTE": 1,
+    "TIME_UNIT_HOUR": 60,
+    "TIME_UNIT_DAY": 60 * 24,
+    "TIME_UNIT_WEEK": 60 * 24 * 7,
+}
+
+
+def _kimi_epoch_seconds(value):
+    """expires_at 可能按秒也可能按毫秒写。"""
+    if isinstance(value, bool):
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if num <= 0:
+        return None
+    return num / 1000.0 if num > 1e11 else num
+
+
+def _kimi_amount(value):
+    """接口把额度数字写成字符串("100"),直接参与运算会 TypeError。"""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _kimi_credential_files():
+    return [os.path.join(root, "credentials", "kimi-code.json")
+            for root in _kimi_roots()]
+
+
+def _kimi_auth_context(now_epoch=None):
+    """只读 CLI 写好的 access_token;过期时标记出来,由调用方决定不发请求。"""
+    now = now_epoch if now_epoch is not None else datetime.now().timestamp()
+    for path in _kimi_credential_files():
+        creds = _load_json(path, {})
+        if not isinstance(creds, dict):
+            continue
+        token = creds.get("access_token")
+        if not isinstance(token, str) or not token:
+            continue
+        expires_at = _kimi_epoch_seconds(creds.get("expires_at"))
+        return {
+            "access_token": token,
+            "expires_at": expires_at,
+            "expired": bool(expires_at is not None and now >= expires_at),
+            "auth_key": hashlib.sha256(token.encode("utf-8")).hexdigest(),
+        }
+    return {}
+
+
+def _kimi_window_minutes(window):
+    if not isinstance(window, dict):
+        return None
+    duration = _kimi_amount(window.get("duration"))
+    unit = _KIMI_TIME_UNITS.get(window.get("timeUnit"))
+    if duration is None or unit is None:
+        return None
+    return int(round(duration * unit))
+
+
+def _kimi_slot(detail):
+    """detail = {limit, used, remaining, resetTime} → 已用百分比 + 重置时刻。"""
+    if not isinstance(detail, dict):
+        return None
+    limit = _kimi_amount(detail.get("limit"))
+    used = _kimi_amount(detail.get("used"))
+    remaining = _kimi_amount(detail.get("remaining"))
+    if used is None and limit is not None and remaining is not None:
+        used = limit - remaining
+    if limit is None or limit <= 0 or used is None:
+        return None
+    slot = {"used_percent": max(0.0, min(100.0, 100.0 * used / limit))}
+    reset = _iso_to_epoch(detail.get("resetTime"))
+    if reset is not None:
+        slot["resets_at"] = reset
+    return slot
+
+
+def _kimi_live_to_limits(data):
+    """limits[] 里 300 分钟那条是 5h 滚动窗口;顶层 usage 是订阅周期额度。
+
+    顶层 usage 不带 window,接口没说周期是周还是月,所以只透传它给的 resetTime,
+    界面也只说"订阅额度",不替接口编一个周期名。
+    """
+    if not isinstance(data, dict):
+        return None
+    five_hour = None
+    for item in data.get("limits") or []:
+        if not isinstance(item, dict):
+            continue
+        if _kimi_window_minutes(item.get("window")) == _KIMI_FIVE_HOUR_MINUTES:
+            five_hour = _kimi_slot(item.get("detail"))
+            break
+    subscription = _kimi_slot(data.get("usage"))
+    if not five_hour and not subscription:
+        return None
+    user = data.get("user") if isinstance(data.get("user"), dict) else {}
+    membership = user.get("membership") if isinstance(user.get("membership"), dict) else {}
+    return {
+        "limit_id": "kimicode",
+        "five_hour": five_hour,
+        "subscription": subscription,
+        "plan": membership.get("level"),
+        "user_id": user.get("userId"),
+    }
+
+
+def _kimi_limits_have_active_window(limits, now_epoch=None):
+    now = float(now_epoch if now_epoch is not None else datetime.now().timestamp())
+    for key in ("five_hour", "subscription"):
+        slot = (limits or {}).get(key) or {}
+        reset = slot.get("resets_at")
+        try:
+            if reset is not None and float(reset) > now:
+                return True
+        except (TypeError, ValueError, OverflowError):
+            continue
+    return False
+
+
+def _cached_kimi_live_limits(max_age, allow_active_window=False):
+    cached = _load_json(KIMI_QUOTA_CACHE, {})
+    fetched_at = cached.get("fetched_at")
+    limits = cached.get("limits")
+    if not fetched_at or not limits:
+        return None
+    try:
+        fetched_at = float(fetched_at)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    age = datetime.now().timestamp() - fetched_at
+    if age > max_age and not (
+            allow_active_window and _kimi_limits_have_active_window(limits)):
+        return None
+    return limits, cached.get("plan"), fetched_at
+
+
+def fetch_kimi_live_limits():
+    if os.environ.get("TOKEI_KIMI_LIVE_QUOTA") == "0":
+        return None
+    cached = _cached_kimi_live_limits(_KIMI_QUOTA_TTL)
+    if cached:
+        return cached
+    auth = _kimi_auth_context()
+    token = auth.get("access_token")
+    if not token:
+        return None
+    auth_key = auth.get("auth_key")
+    if auth.get("expired"):
+        # CLI 还没来得及刷新。发出去必然 401,不如省掉这次请求,让 stale 说明读数已旧。
+        return _cached_kimi_live_limits(
+            _KIMI_QUOTA_FALLBACK_TTL, allow_active_window=True)
+    cache_state = _load_json(KIMI_QUOTA_CACHE, {})
+    last_failure = cache_state.get("last_failure_at", 0)
+    if cache_state.get("auth_key") not in (None, auth_key):
+        last_failure = 0
+    try:
+        failure_is_recent = (
+            bool(last_failure)
+            and datetime.now().timestamp() - float(last_failure) < 300)
+    except (TypeError, ValueError, OverflowError):
+        failure_is_recent = False
+    if failure_is_recent:
+        return _cached_kimi_live_limits(
+            _KIMI_QUOTA_FALLBACK_TTL, allow_active_window=True)
+    try:
+        import urllib.request
+        from urllib.parse import urlparse
+        req = urllib.request.Request(_KIMI_USAGE_URL)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", "Tokei")
+        req.add_unredirected_header("Authorization", "Bearer " + token)
+        with urllib.request.urlopen(req, timeout=3) as res:
+            final_url = urlparse(res.geturl())
+            if final_url.scheme != "https" or final_url.hostname != _KIMI_USAGE_HOST:
+                raise ValueError("unexpected Kimi usage redirect")
+            raw = res.read(_KIMI_USAGE_MAX_RESPONSE_BYTES + 1)
+        if len(raw) > _KIMI_USAGE_MAX_RESPONSE_BYTES:
+            raise ValueError("Kimi usage response is too large")
+        limits = _kimi_live_to_limits(json.loads(raw))
+        if not limits:
+            raise ValueError("invalid Kimi usage response")
+        plan = limits.get("plan")
+        fetched_at = datetime.now().timestamp()
+        _atomic_write_json(KIMI_QUOTA_CACHE, {
+            "fetched_at": fetched_at,
+            "limits": limits,
+            "plan": plan,
+            "user_id": limits.get("user_id"),
+            "auth_key": auth_key,
+            "source": "live",
+        })
+        return limits, plan, fetched_at
+    except Exception:
+        try:
+            state = _load_json(KIMI_QUOTA_CACHE, {})
+            if state.get("limits") and state.get("user_id") \
+                    and cache_state.get("user_id") \
+                    and state.get("user_id") != cache_state.get("user_id"):
+                state = {}
+            state["last_failure_at"] = datetime.now().timestamp()
+            state["auth_key"] = auth_key
+            _atomic_write_json(KIMI_QUOTA_CACHE, state)
+        except Exception:
+            pass
+    return _cached_kimi_live_limits(
+        _KIMI_QUOTA_FALLBACK_TTL, allow_active_window=True)
+
+
+def _kimi_quota_values(limits, now_epoch=None, updated_at=None):
+    """→ p5/pw + 重置时刻 + stale,字段语义与 Codex 卡片保持一致。
+
+    两种 stale:窗口已经翻篇(读数必然失真),或读数本身太旧(CLI 久未刷新 token)。
+    Kimi 的额度单位是调用次数而非 token,没法像 Codex 那样用本机消耗反推"确实回满了",
+    所以翻篇一律标 stale —— 宁可说不知道,也不谎报满额。
+    """
+    values = {"p5": None, "pw": None, "r5": None, "rw": None,
+              "p5_stale": False, "pw_stale": False}
+    mapping = (("five_hour", "p5", "r5"), ("subscription", "pw", "rw"))
+    for slot_key, pct_key, reset_key in mapping:
+        slot = (limits or {}).get(slot_key) or {}
+        if not slot:
+            continue
+        values[pct_key] = slot.get("used_percent")
+        values[reset_key] = slot.get("resets_at")
+
+    now = now_epoch if now_epoch is not None else int(datetime.now().timestamp())
+    try:
+        updated_age = (now - float(updated_at)) if updated_at else None
+    except (TypeError, ValueError, OverflowError):
+        updated_age = None
+    for _, pct_key, reset_key in mapping:
+        if values[pct_key] is None:
+            continue
+        reset = values[reset_key]
+        if reset and now > float(reset):
+            values[pct_key + "_stale"] = True
+        elif updated_age is not None and updated_age > _KIMI_QUOTA_STALE_AFTER:
+            values[pct_key + "_stale"] = True
+    return values
+
+
 def _kimi_wire_groups():
     """按会话产出 (agent_wires, root_wire);定深有界遍历,不碰 server/events 等镜像目录。
 
@@ -10049,6 +10309,9 @@ def compute():
     grok_quota = _safe_scan("grok_quota", scan_grok_quota, lambda: {}, errors) or {}
     qwenwork_quota = _safe_scan(
         "qwenwork_quota", scan_qwenwork_quota, lambda: {}, errors) or {}
+    kimi_live = _safe_scan("kimi_quota", fetch_kimi_live_limits, lambda: None, errors)
+    kimi_limits, kimi_plan, kimi_updated = kimi_live if kimi_live else (None, None, None)
+    kimi_quota = _kimi_quota_values(kimi_limits, updated_at=kimi_updated)
     provider_quotas = scan_provider_quotas(errors)
     _cache_dashboard_days(
         cache, _CURSOR_PROVIDER_DAYS_CACHE_KEY,
@@ -10165,6 +10428,11 @@ def compute():
         },
         "kimicode": {
             "ranges": kimiranges,
+            "p5": kimi_quota["p5"], "pw": kimi_quota["pw"],
+            "r5": kimi_quota["r5"], "rw": kimi_quota["rw"],
+            "q_updated": int(kimi_updated) if kimi_updated else None,
+            "p5_stale": kimi_quota["p5_stale"], "pw_stale": kimi_quota["pw_stale"],
+            "plan": kimi_plan,
         },
     }
     if errors:


### PR DESCRIPTION
## 背景

#44 提到希望支持 Kimi。目前 Kimi Code 只统计本地 wire 日志里的 token，没有额度。而 Kimi Code CLI 自己有官方额度接口、登录态也在本机，可以按 Tokei 现有的「复用本机登录态」模式接进来。

## 改动

用 Kimi Code CLI 已有的登录态只读查询 `https://api.kimi.com/coding/v1/usages`：

- `p5` — 5 小时滚动窗口，取 `limits[]` 中 `window` 折算为 300 分钟的那条
- `pw` — 订阅周期额度，取顶层 `usage`
- `r5` / `rw` — 各自的 `resetTime`
- `plan` — `user.membership.level`

额度进入 Kimi Code 卡片、菜单栏额度源（默认关）与设置项；token 用量统计口径不变。

## 几个设计决定

**只读 access_token，不代刷。** 凭据在 `${KIMI_CODE_HOME:-~/.kimi-code}/credentials/kimi-code.json`，同一文件里有 `refresh_token`，但没有使用它：OAuth 刷新令牌通常带 rotation，Tokei 抢先刷新会顶掉 Kimi Code 自己的登录态。实测 access_token 有效期只有约 30 分钟，因此过期时直接跳过这次请求（发出去必然 401），转用缓存并标记读数已过期。

**过期就标 stale，不谎报满额。** 两条判定：窗口 `resetTime` 已过，或读数超过 30 分钟未更新。没有套用 Codex 那条「窗口翻篇 + 本机零消耗即判定回满」—— Kimi 额度按调用次数计量，本机 token 日志无从反推它的真实消耗。这与 #63 的教训一致：显示一个过期读数比承认不知道更危险。

**不替接口命名周期。** 顶层 `usage` 不带 `window` 字段，接口没有说明该额度是周还是月，所以只透传它给的 `resetTime`，卡片写「订阅额度剩余」，菜单栏该项也不画窗口符号（与 Grok 同理）。

**额度数字是字符串。** 接口返回 `"limit": "100"` 这样的字符串，解析时统一转数值；`used` 缺失时按 `limit - remaining` 推算。

## 验证

- `tests/test_kimi_quota.py` 18 例：解析（真实响应结构、两种 `timeUnit`、零 limit 保护）、stale 判定、以及 fetch 行为 —— 凭据过期时断言 `urlopen` 未被调用、auth 上下文不含 `refresh_token`、跨域重定向拒绝、失败退避
- `tests/swift/MenuBarQuotaSourceCheck.swift` 同步扩展（顺序、标签、字段映射、剩余换算）
- 全量 299 例通过
- 改动前后 `--json` 输出逐字段 diff：新增 8 个 `kimicode` 字段，无字段丢失，既有数值零变化

## 开关

`TOKEI_KIMI_LIVE_QUOTA=0` 可完全关闭该查询，关闭后 token 统计不受影响。

---

https://claude.ai/code/session_01CNwVdSa2Ds7xpjNUdCHbCc
