### PR TITLE
fix(pricing): 网关前缀的 Muse 模型按 Meta 价格计价

### DIFF
--- a/tests/test_model_names.py
+++ b/tests/test_model_names.py
@@ -51,6 +51,14 @@ class ModelNameTests(unittest.TestCase):
         finally:
             USAGE._PRICING_DB = old_pricing
 
+    def test_gateway_prefixed_muse_models_resolve_to_meta_pricing(self):
+        self.assertEqual(USAGE._normalize("muse-spark-1.3-contributor"),
+                         "meta/muse-spark-1.3-contributor")
+        self.assertEqual(USAGE._normalize("vercel/meta/muse-spark-1.3-contributor"),
+                         "meta/muse-spark-1.3-contributor")
+        self.assertEqual(USAGE._pricing_id("vercel/meta/muse-spark-1.3-contributor"),
+                         "meta/muse-spark-1.3-contributor")
+
     def test_unknown_model_identity_is_preserved(self):
         old_pricing = USAGE._PRICING_DB
         old_override_models = USAGE._OV_MODELS

--- a/usage.30s.py
+++ b/usage.30s.py
@@ -396,6 +396,9 @@ def _normalize(model: str):
         return None
     m = re.sub(r"\s+", "-", m)
     m = re.sub(r"[:\-]free$", "", m)                  # 免费档按基础价
+    seg = m.rsplit("/", 1)[-1]
+    if seg.startswith("muse-"):
+        return "meta/" + seg                         # 网关前缀(如 vercel/meta/)剥离
     if "/" in m:
         return m                                      # 已是 OpenRouter 格式
     if m.startswith("claude"):
@@ -713,7 +716,7 @@ _SCAN_CACHE_FILE = _DEFAULT_SCAN_CACHE_FILE
 _SCAN_CACHE_VERSION = 21
 _SCAN_CACHE_MIGRATABLE_VERSION = 19
 _CODEX_EVENT_CACHE_SUFFIX = ".codex-events"
-_CODEX_PARSER_VERSION = 3
+_CODEX_PARSER_VERSION = 4  # v4: 网关前缀模型(如 vercel/meta/muse-*)正确计价后强制重扫
 _CODEX_SCAN_CHECKPOINT_INTERVAL = 5.0
 _GEMINI_DAYS_CACHE_KEY = "_gemini_dashboard_days"
 _GROK_DAYS_CACHE_KEY = "_grok_dashboard_days"


### PR DESCRIPTION
## 背景

Codex 经 Vercel AI Gateway 调用 Muse 模型时，rollout 里的模型 id 是 `vercel/meta/muse-spark-1.3-contributor` 这种带网关前缀的形式。本机 9 月 5 日一个 session 因此显示成本 **$1014.95**，实际按 contributor 档只应约 $5。

## 根因

两层叠加：

1. **计价认不出模型**：`_normalize` 遇到带 `/` 的 id 直接原样返回，`_FAMILY` 又没有 muse 关键字，于是 `_codex_estimated_cost` 回退到 `openai/gpt-5.5`（$5/$30，高上下文再 2x/1.5x）估算；
2. **用量本身是对的**：该 session 共 2366 个 response，平均每次重读约 409K 缓存上下文，增量加总 910M 缓存读（与 `thread_token_usage` 累计值自洽，无重复计数）。错的是单价，不是 token。

即：910M × 错单价 ≈ $1015；910M × contributor 缓存价 $0.002 ≈ $1.8。

## 修复

- `usage.30s.py`：`_normalize` 以后缀匹配剥离网关前缀——最后一段以 `muse-` 开头即映射 `meta/<段>`，覆盖裸 `muse-*` 与任意网关前缀；
- `_CODEX_PARSER_VERSION` 3 → 4，下次刷新触发一次性全量重扫；账本按 token 总量取高水位（token 未变），会接受修正后的成本，无需手动清缓存；
- `tests/test_model_names.py` 加回归测试（裸 id、网关前缀 id、`_pricing_id` 解析）。

## 验证

```text
# 缓存副本上全量重扫 codex（不碰真实缓存）
month 总成本  $1072.95 → $62.51
vercel/meta/muse-spark-1.3-contributor（显示为 meta/muse-spark-1.3-contributor）$1014.95 → $4.87

python3 -m unittest discover → Ran 282 tests — OK
python3 -m py_compile usage.30s.py / git diff --check → OK
```

## 隐私与限制

- 只读本地 codex rollout 与现有缓存，不涉及对话正文；
- contributor 档价格以[官方定价页](https://dev.meta.ai/docs/pricing-rate-limits)为准，Vercel 网关若有额外加价不在估算内；
- 与 #82（Muse Code CLI 接入）无关，独立分支独立合。

## English Summary

A Codex session routed via the Vercel AI Gateway showed **$1014.95** for `vercel/meta/muse-spark-1.3-contributor`. The tokens were correct (2366 responses × ~409K cached context ≈ 910M cache reads, consistent with cumulative counters — no double counting). The bug was pricing only: `_normalize` didn't recognize gateway-prefixed ids, so `_codex_estimated_cost` fell back to gpt-5.5 rates ($5/$30, plus long-context multipliers).

- Fix: suffix matching in `_normalize` strips gateway prefixes (`vercel/meta/muse-*` → `meta/muse-*`); `_CODEX_PARSER_VERSION` bumped 3 → 4 for a one-time rescan (the ledger keeps token high-water marks, so corrected costs are adopted automatically).
- Result on a cache copy: month total $1072.95 → $62.51; the model now shows ≈$4.87 under contributor pricing.
- Verification: 282 Python tests OK. Independent of #82, either may merge first.
